### PR TITLE
Changement d'unité des statistiques pour l'essence

### DIFF
--- a/dashboard/src/app/modules/statistics/config/stat_main.ts
+++ b/dashboard/src/app/modules/statistics/config/stat_main.ts
@@ -34,6 +34,8 @@ export const STAT_MAIN = {
   },
   number_aom : 3,
   average_co2_per_m : 0.000195,    // 0.000195 kg CO2 / m (chiffres de 2016, ademe)
-  average_petrol_per_m : 0.00005,    // 0.05 kg Pétrole / m (chiffres de 2015, ademe)
+  average_petrol_per_m : 0.00005,    // 0.05 kg Pétrole / km (chiffres de 2015, ademe)
+  average_petrol_liter_per_m: 0.0000636,
+  // = 0.00005 ( kg Petrole / m ) / 1000 ( kg -> T ) / 1,048 ( TEP) / 0.750 ( T/m3 ) * 1000 ( m3 -> litre )
   min_date: new Date(2019, 1, 0),
 };

--- a/dashboard/src/app/modules/statistics/config/stat_style.ts
+++ b/dashboard/src/app/modules/statistics/config/stat_style.ts
@@ -31,10 +31,10 @@ export const STAT_STYLE = {
       name: 'energyTotal',
       map: 'distance.total',
       type: 'number',
-      title: 'Pétrole économisé',
-      unitTransformation: `*${STAT_MAIN.average_petrol_per_m}`,
+      title: 'Essence économisé',
+      unitTransformation: `*${STAT_MAIN.average_petrol_liter_per_m}`,
       img: 'petrol.svg',
-      unit: 'kg',
+      unit: 'litre',
     }),
     new StatConfig({
       name: 'co2Total',
@@ -232,8 +232,8 @@ export const STAT_STYLE = {
       map: 'distance.day',
       type: 'line',
       cumul: true,
-      title: 'Pétrole économisé',
-      unitTransformation: `*${STAT_MAIN.average_petrol_per_m}`,
+      title: 'Essence économisé',
+      unitTransformation: `*${STAT_MAIN.average_petrol_liter_per_m}`,
       style: {
         backgroundColor: '#42A5F5',
         borderColor: '#1E88E5',
@@ -246,7 +246,7 @@ export const STAT_STYLE = {
             },
             scaleLabel: {
               display: true,
-              labelString: 'kg équivalent pétrole',
+              labelString: 'Litre d\'essence',
             },
           }],
           xAxes: [{


### PR DESCRIPTION
Calcul effectué :  
Essence consommé en litre par mètre : 0.0000636 = 0.00005 ( kg Petrole / m ) / 1000 ( kg -> T ) / 1,048 ( TEP) / 0.750 ( T/m3 ) * 1000 ( m3 -> litre )