### PR TITLE
[WIP] Filtre pour les statistiques et les trajets

### DIFF
--- a/dashboard/src/app/core/components/authenticated-layout/authenticated-layout-page.scss
+++ b/dashboard/src/app/core/components/authenticated-layout/authenticated-layout-page.scss
@@ -1,4 +1,4 @@
-@import '../../../../styles/variables';
+@import '~src/styles/variables';
 
 .page {
   &-header {

--- a/dashboard/src/app/core/components/authenticated-layout/authenticated-layout.component.scss
+++ b/dashboard/src/app/core/components/authenticated-layout/authenticated-layout.component.scss
@@ -13,7 +13,8 @@
   &-body {
     margin-top: 68.5px;
     height: calc(100% - 68.5px);
-    overflow-x: auto;
+    overflow-y: auto;
+    overflow-x: hidden;
     display: flex;
     flex-direction: column;
     justify-content: space-between;

--- a/dashboard/src/app/core/interceptor/http.interceptor.ts
+++ b/dashboard/src/app/core/interceptor/http.interceptor.ts
@@ -19,7 +19,8 @@ export class HttpApiInterceptor implements HttpInterceptor {
     }
     this.currentToken = this.authService.token;
     const update: any = {};
-    if (this.APIMETHODS.indexOf(req.method) !== -1) {
+
+    if (this.APIMETHODS.indexOf(req.method) !== -1 && !req.url.startsWith('https://')) {
       update.url = this.api + req.url;
       update.setHeaders = {
         Authorization: 'Bearer ' + this.currentToken,

--- a/dashboard/src/app/core/interfaces/filter/filterInterface.ts
+++ b/dashboard/src/app/core/interfaces/filter/filterInterface.ts
@@ -43,7 +43,7 @@ export interface FilterViewInterface {
   minDistance: number;
   maxDistance: number;
   classes: classEnum[];
-  status: statusEnum[];
+  status: statusEnum;
   operators: OperatorNameInterface[];
 }
 

--- a/dashboard/src/app/core/interfaces/filter/filterInterface.ts
+++ b/dashboard/src/app/core/interfaces/filter/filterInterface.ts
@@ -1,0 +1,62 @@
+import { CampaignNameInterface } from '~/modules/campaign/modules/campaign-ui/components/campaign-auto-complete/campaign-auto-complete.component';
+import { OperatorNameInterface } from '~/core/interfaces/operatorInterface';
+
+export interface FilterInterface {
+  filter?: {
+    'campaigns._id'?: string;
+    'people.start.date'?: {
+      $gte: Date;
+    };
+    'people.end.date'?: {
+      $lt: Date;
+    };
+    status?: statusEnum;
+    'people.town'?: {
+      $in: string[];
+    };
+    'people.distance'?: {
+      $gte?: number;
+      $lt?: number;
+    };
+    'people.class'?: {
+      $in: classEnum[];
+    };
+    'people.operator._id'?: {
+      $in: string[];
+    };
+  };
+  hours?: {
+    start?: string;
+    end?: string;
+  };
+  days?: daysType[];
+}
+
+export interface FilterViewInterface {
+  campaign: CampaignNameInterface;
+  startDate: Date;
+  endDate: Date;
+  startTime: string;
+  endTime: string;
+  days: daysType[];
+  towns: string[];
+  minDistance: number;
+  maxDistance: number;
+  classes: classEnum[];
+  status: statusEnum[];
+  operators: OperatorNameInterface[];
+}
+
+type daysType = 0 | 1 | 2 | 3 | 4 | 5 | 6;
+
+enum classEnum {
+  A = 'A',
+  B = 'B',
+  C = 'C',
+}
+
+enum statusEnum {
+  pending = 'pending',
+  active = 'active',
+  deleted = 'deleted',
+}

--- a/dashboard/src/app/core/interfaces/geography/townInterface.ts
+++ b/dashboard/src/app/core/interfaces/geography/townInterface.ts
@@ -1,0 +1,3 @@
+export interface TownInterface {
+  name: string;
+}

--- a/dashboard/src/app/core/services/api/api.service.ts
+++ b/dashboard/src/app/core/services/api/api.service.ts
@@ -11,10 +11,7 @@ export class ApiService<T extends IModel> {
   protected _loading$ = new BehaviorSubject<boolean>(false);
   protected _loaded$ = new BehaviorSubject<boolean>(false);
 
-  constructor(private _httpClient: HttpClient,
-              private _jsonRPCService: JsonRPCService,
-              protected _method: string) {
-  }
+  constructor(private _httpClient: HttpClient, private _jsonRPCService: JsonRPCService, protected _method: string) {}
 
   // ===== Get ======
   get entities$(): Observable<T[]> {
@@ -41,9 +38,9 @@ export class ApiService<T extends IModel> {
   }
 
   // ==== CRUD ======
-  public load(): Observable<T[]> {
+  public load(parameters: object = {}): Observable<T[]> {
     this._loading$.next(true);
-    const jsonRPCParam = new JsonRPCParam(`${this._method}.list`);
+    const jsonRPCParam = new JsonRPCParam(`${this._method}.list`, parameters);
     return this._jsonRPCService.call(jsonRPCParam).pipe(
       tap((data) => {
         this._entities$.next(data);
@@ -63,7 +60,8 @@ export class ApiService<T extends IModel> {
         auxArray.push(entity);
         this._entities$.next(auxArray);
         console.log(`created ${this._method} id=${entity._id}`);
-      }));
+      }),
+    );
   }
 
   public patch(item: T): Observable<T> {
@@ -73,7 +71,8 @@ export class ApiService<T extends IModel> {
       tap((entity) => {
         console.log(`updated ${this._method} id=${entity.id}`);
         this.updateEntityArray(entity);
-      }));
+      }),
+    );
   }
 
   public delete(item: T): Observable<T> {
@@ -89,6 +88,7 @@ export class ApiService<T extends IModel> {
         }
         this._entities$.next(auxArray);
         console.log(`deleted ${this._method} id=${item._id}`);
-      }));
+      }),
+    );
   }
 }

--- a/dashboard/src/app/core/services/filter.service.ts
+++ b/dashboard/src/app/core/services/filter.service.ts
@@ -12,6 +12,9 @@ export class FilterService {
 
   constructor() {}
 
+  /**
+   * Change filter format from form compatible to object for JsonApi
+   */
   public formatDataForApi(data: FilterViewInterface): FilterInterface {
     const filter: FilterInterface = {};
     if (data.campaign) {

--- a/dashboard/src/app/core/services/filter.service.ts
+++ b/dashboard/src/app/core/services/filter.service.ts
@@ -1,0 +1,59 @@
+import * as _ from 'lodash';
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+
+import { FilterInterface, FilterViewInterface } from '~/core/interfaces/filter/filterInterface';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class FilterService {
+  public _filter$: BehaviorSubject<FilterInterface> = new BehaviorSubject<FilterInterface>({});
+
+  constructor() {}
+
+  public formatDataForApi(data: FilterViewInterface): FilterInterface {
+    const filter: FilterInterface = {};
+    if (data.campaign) {
+      _.set(filter, 'filter["campaigns._id"]', data.campaign._id);
+    }
+    if (data.startDate) {
+      _.set(filter, "filter['people.start.date'].$gte", data.startDate);
+    }
+    if (data.endDate) {
+      _.set(filter, "filter['people.end.date'].$lt", data.endDate);
+    }
+    if (data.startTime) {
+      _.set(filter, 'hours.start', data.startTime);
+    }
+    if (data.endTime) {
+      _.set(filter, 'hours.end', data.endTime);
+    }
+    if (data.days) {
+      _.set(filter, 'filter.days', data.days);
+    }
+    if (data.towns) {
+      _.set(filter, 'filter["people.town"].$in', data.towns);
+    }
+    if (data.minDistance) {
+      _.set(filter, 'filter["people.distance"].$gte', data.minDistance);
+    }
+    if (data.maxDistance) {
+      _.set(filter, 'filter["people.distance"].$lt', data.maxDistance);
+    }
+    if (data.classes) {
+      _.set(filter, 'filter["people.class"].$in', data.classes);
+    }
+    if (data.status) {
+      _.set(filter, 'filter.status', data.status);
+    }
+    if (data.operators) {
+      _.set(filter, 'filter["people.operator._id"].$in', data.operators);
+    }
+    return filter;
+  }
+
+  public setFilter(filter: FilterViewInterface): void {
+    this._filter$.next(this.formatDataForApi(filter));
+  }
+}

--- a/dashboard/src/app/modules/campaign/campaign.module.ts
+++ b/dashboard/src/app/modules/campaign/campaign.module.ts
@@ -5,12 +5,12 @@ import { CampaignRoutingModule } from '~/modules/campaign/campaign-routing.modul
 import { MaterialModule } from '~/shared/material/material.module';
 import { SharedModule } from '~/shared/shared.module';
 import { UiTripModule } from '~/modules/trip/ui-trip/ui-trip.module';
+import { StatUIModule } from '~/modules/stat/modules/stat-ui/stat-ui.module';
 
 import { CampaignDashboardComponent } from './pages/campaign-dashboard/campaign-dashboard.component';
 import { CampaignMenuComponent } from './components/campaign-menu/campaign-menu.component';
 import { CampaignsListComponent } from './components/campaigns-list/campaigns-list.component';
 import { CampaignCreateEditComponent } from './pages/campaign-create-edit/campaign-create-edit.component';
-
 
 @NgModule({
   declarations: [
@@ -19,13 +19,6 @@ import { CampaignCreateEditComponent } from './pages/campaign-create-edit/campai
     CampaignsListComponent,
     CampaignCreateEditComponent,
   ],
-  imports: [
-    CampaignRoutingModule,
-    CommonModule,
-    MaterialModule,
-    SharedModule,
-    UiTripModule,
-  ],
+  imports: [CampaignRoutingModule, CommonModule, MaterialModule, SharedModule, UiTripModule, StatUIModule],
 })
-export class CampaignModule {
-}
+export class CampaignModule {}

--- a/dashboard/src/app/modules/campaign/modules/campaign-ui/campaign-ui.module.ts
+++ b/dashboard/src/app/modules/campaign/modules/campaign-ui/campaign-ui.module.ts
@@ -1,0 +1,14 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+
+import { MaterialModule } from '~/shared/material/material.module';
+
+import { CampaignAutoCompleteComponent } from './components/campaign-auto-complete/campaign-auto-complete.component';
+
+@NgModule({
+  declarations: [CampaignAutoCompleteComponent],
+  imports: [CommonModule, MaterialModule, FormsModule, ReactiveFormsModule],
+  exports: [CampaignAutoCompleteComponent],
+})
+export class CampaignUiModule {}

--- a/dashboard/src/app/modules/campaign/modules/campaign-ui/components/campaign-auto-complete/campaign-auto-complete.component.html
+++ b/dashboard/src/app/modules/campaign/modules/campaign-ui/components/campaign-auto-complete/campaign-auto-complete.component.html
@@ -1,9 +1,6 @@
 <mat-form-field [formGroup]="parentForm" class="campaign" appearance="outline">
   <mat-label>Campagne</mat-label>
   <mat-select formControlName="campaign">
-    <mat-option value="21313435">Campagne n°1</mat-option>
-    <mat-option value="546465">Campagne n°2</mat-option>
-    <mat-option value="Campagne3">Campagne n°3</mat-option>
-    <mat-option value="Campagne4">Campagne n°4</mat-option>
+    <mat-option *ngFor="let campaign of campaigns" value="{{ campaign._id }}">{{ campaign.name }}</mat-option>
   </mat-select>
 </mat-form-field>

--- a/dashboard/src/app/modules/campaign/modules/campaign-ui/components/campaign-auto-complete/campaign-auto-complete.component.html
+++ b/dashboard/src/app/modules/campaign/modules/campaign-ui/components/campaign-auto-complete/campaign-auto-complete.component.html
@@ -1,0 +1,9 @@
+<mat-form-field [formGroup]="parentForm" class="campaign" appearance="outline">
+  <mat-label>Campagne</mat-label>
+  <mat-select formControlName="campaign">
+    <mat-option value="21313435">Campagne n°1</mat-option>
+    <mat-option value="546465">Campagne n°2</mat-option>
+    <mat-option value="Campagne3">Campagne n°3</mat-option>
+    <mat-option value="Campagne4">Campagne n°4</mat-option>
+  </mat-select>
+</mat-form-field>

--- a/dashboard/src/app/modules/campaign/modules/campaign-ui/components/campaign-auto-complete/campaign-auto-complete.component.ts
+++ b/dashboard/src/app/modules/campaign/modules/campaign-ui/components/campaign-auto-complete/campaign-auto-complete.component.ts
@@ -1,0 +1,15 @@
+import { Component, Input, OnInit } from '@angular/core';
+import { FormControl, FormGroup } from '@angular/forms';
+
+@Component({
+  selector: 'app-campaign-auto-complete',
+  templateUrl: './campaign-auto-complete.component.html',
+  styleUrls: ['./campaign-auto-complete.component.scss'],
+})
+export class CampaignAutoCompleteComponent implements OnInit {
+  @Input() parentForm: FormGroup;
+
+  constructor() {}
+
+  ngOnInit() {}
+}

--- a/dashboard/src/app/modules/campaign/modules/campaign-ui/components/campaign-auto-complete/campaign-auto-complete.component.ts
+++ b/dashboard/src/app/modules/campaign/modules/campaign-ui/components/campaign-auto-complete/campaign-auto-complete.component.ts
@@ -1,5 +1,10 @@
 import { Component, Input, OnInit } from '@angular/core';
-import { FormControl, FormGroup } from '@angular/forms';
+import { FormGroup } from '@angular/forms';
+
+export interface CampaignNameInterface {
+  _id: string;
+  name: string;
+}
 
 @Component({
   selector: 'app-campaign-auto-complete',
@@ -8,6 +13,18 @@ import { FormControl, FormGroup } from '@angular/forms';
 })
 export class CampaignAutoCompleteComponent implements OnInit {
   @Input() parentForm: FormGroup;
+
+  // todo: tmp remove
+  public campaigns: CampaignNameInterface[] = [
+    {
+      _id: 'id1',
+      name: 'campagne 1',
+    },
+    {
+      _id: 'id2',
+      name: 'campagne 2',
+    },
+  ];
 
   constructor() {}
 

--- a/dashboard/src/app/modules/campaign/pages/campaign-dashboard/campaign-dashboard.component.html
+++ b/dashboard/src/app/modules/campaign/pages/campaign-dashboard/campaign-dashboard.component.html
@@ -6,7 +6,7 @@
         Créer une nouvelle campagne
       </button>
     </div>
-    <!--    <app-trip-chart></app-trip-chart>-->
+    <app-stat-graph-view [graphName]="'trips'"></app-stat-graph-view>
     <div>
       <a class="link" [routerLink]="'/trip'">Voir toutes les statistiques</a>
     </div>

--- a/dashboard/src/app/modules/campaign/pages/campaign-dashboard/campaign-dashboard.component.scss
+++ b/dashboard/src/app/modules/campaign/pages/campaign-dashboard/campaign-dashboard.component.scss
@@ -30,3 +30,9 @@
     }
   }
 }
+
+:host {
+  .graph {
+    background-color: grey;
+  }
+}

--- a/dashboard/src/app/modules/filter/components/filter/filter.component.html
+++ b/dashboard/src/app/modules/filter/components/filter/filter.component.html
@@ -1,0 +1,111 @@
+<form [formGroup]="filterForm">
+  <div class="filter-wrapper" *ngIf="_showFilter">
+    <div class="filter-wrapper-close">
+      <button mat-mini-fab color="primary" type="button" (click)="onCloseClick()">
+        <mat-icon>close_rounded</mat-icon>
+      </button>
+    </div>
+    <div class="filter">
+      <div class="filter-content">
+        <div class="filter-content-column">
+          <div class="filter-content-column-title">
+            <p>Campagne</p>
+          </div>
+          <app-campaign-auto-complete [parentForm]="filterForm"></app-campaign-auto-complete>
+        </div>
+        <div class="filter-content-column">
+          <div class="filter-content-column-title">
+            <p>Dates & horaires</p>
+          </div>
+          <div class="filter-dates">
+            <mat-form-field appearance="outline">
+              <mat-label>Début</mat-label>
+              <input
+                matInput
+                formControlName="startDate"
+                [matDatepicker]="startDatePicker"
+                placeholder="Choisir une date"
+              />
+              <mat-datepicker-toggle matSuffix [for]="startDatePicker"></mat-datepicker-toggle>
+              <mat-datepicker #startDatePicker></mat-datepicker>
+            </mat-form-field>
+            <mat-form-field appearance="outline">
+              <mat-label>Fin</mat-label>
+              <input
+                matInput
+                formControlName="endDate"
+                [matDatepicker]="endDatePicker"
+                placeholder="Choisir une date"
+              />
+              <mat-datepicker-toggle matSuffix [for]="endDatePicker"></mat-datepicker-toggle>
+              <mat-datepicker #endDatePicker></mat-datepicker>
+            </mat-form-field>
+          </div>
+          <div class="filter-timeAndDays">
+            <mat-form-field class="start-time" appearance="outline">
+              <mat-label>De</mat-label>
+              <input matInput formControlName="startTime" type="time" />
+            </mat-form-field>
+            <mat-form-field class="end-time" appearance="outline">
+              <mat-label>A</mat-label>
+              <input matInput formControlName="endTime" type="time" />
+            </mat-form-field>
+            <mat-form-field class="days" appearance="outline">
+              <mat-label>Jours de la semaine</mat-label>
+              <mat-select formControlName="days" multiple>
+                <mat-option value="0">lundi</mat-option>
+                <mat-option value="1">mardi</mat-option>
+                <mat-option value="2">mercredi</mat-option>
+                <mat-option value="3">jeudi</mat-option>
+              </mat-select>
+            </mat-form-field>
+          </div>
+        </div>
+        <div class="filter-content-column">
+          <div class="filter-content-column-title">
+            <p>Géographie</p>
+          </div>
+          <div class="filter-distances">
+            <mat-form-field class="min-distance" appearance="outline">
+              <mat-label>Km min</mat-label>
+              <input matInput formControlName="minDistance" type="number" step="5" />
+            </mat-form-field>
+            <mat-form-field class="max-distance" appearance="outline">
+              <mat-label>Km max</mat-label>
+              <input matInput formControlName="maxDistance" type="number" step="5" />
+            </mat-form-field>
+          </div>
+          <div class="filter-geography">
+            <app-towns-autocomplete [parentForm]="filterForm"></app-towns-autocomplete>
+          </div>
+        </div>
+        <div class="filter-content-column">
+          <div class="filter-content-column-title">
+            <p>Types de trajets</p>
+          </div>
+          <mat-form-field class="class" appearance="outline">
+            <mat-label>Classe</mat-label>
+            <mat-select formControlName="classes" multiple>
+              <mat-option value="A">A</mat-option>
+              <mat-option value="B">B</mat-option>
+              <mat-option value="C">C</mat-option>
+            </mat-select>
+          </mat-form-field>
+          <mat-form-field class="class" appearance="outline">
+            <mat-label>Statut</mat-label>
+            <mat-select formControlName="classes" multiple>
+              <mat-option value="pending">En cours</mat-option>
+            </mat-select>
+          </mat-form-field>
+          <app-operators-autocomplete [parentForm]="filterForm"></app-operators-autocomplete>
+        </div>
+      </div>
+      <div class="filter-footer">
+        <button mat-flat-button color="primary" (click)="filterClick()">Affiner les résultats</button>
+        <button class="filter-footer-reinitialize" mat-button (click)="reinitializeClick()">
+          Réinitialiser les filtres
+        </button>
+      </div>
+    </div>
+  </div>
+</form>

--- a/dashboard/src/app/modules/filter/components/filter/filter.component.html
+++ b/dashboard/src/app/modules/filter/components/filter/filter.component.html
@@ -1,5 +1,5 @@
-<form [formGroup]="filterForm">
-  <div class="filter-wrapper" *ngIf="_showFilter">
+<form [formGroup]="filterForm" [@collapse]="_showFilter ? 'open' : 'closed'">
+  <div class="filter-wrapper">
     <div class="filter-wrapper-close">
       <button mat-mini-fab color="primary" type="button" (click)="onCloseClick()">
         <mat-icon>close_rounded</mat-icon>
@@ -53,10 +53,7 @@
             <mat-form-field class="days" appearance="outline">
               <mat-label>Jours de la semaine</mat-label>
               <mat-select formControlName="days" multiple>
-                <mat-option value="0">lundi</mat-option>
-                <mat-option value="1">mardi</mat-option>
-                <mat-option value="2">mercredi</mat-option>
-                <mat-option value="3">jeudi</mat-option>
+                <mat-option *ngFor="let day of days" value="{{ day.id }}">{{ day.french }}</mat-option>
               </mat-select>
             </mat-form-field>
           </div>
@@ -68,11 +65,11 @@
           <div class="filter-distances">
             <mat-form-field class="min-distance" appearance="outline">
               <mat-label>Km min</mat-label>
-              <input matInput formControlName="minDistance" type="number" step="5" />
+              <input matInput formControlName="minDistance" type="number" step="1" min="0" />
             </mat-form-field>
             <mat-form-field class="max-distance" appearance="outline">
               <mat-label>Km max</mat-label>
-              <input matInput formControlName="maxDistance" type="number" step="5" />
+              <input matInput formControlName="maxDistance" type="number" step="1" min="0" />
             </mat-form-field>
           </div>
           <div class="filter-geography">
@@ -86,23 +83,21 @@
           <mat-form-field class="class" appearance="outline">
             <mat-label>Classe</mat-label>
             <mat-select formControlName="classes" multiple>
-              <mat-option value="A">A</mat-option>
-              <mat-option value="B">B</mat-option>
-              <mat-option value="C">C</mat-option>
+              <mat-option *ngFor="let name of classes" value="{{ name }}">{{ name }}</mat-option>
             </mat-select>
           </mat-form-field>
           <mat-form-field class="class" appearance="outline">
             <mat-label>Statut</mat-label>
-            <mat-select formControlName="classes" multiple>
-              <mat-option value="pending">En cours</mat-option>
+            <mat-select formControlName="status">
+              <mat-option *ngFor="let status of tripStatusList" value="{{ status.id }}">{{ status.french }}</mat-option>
             </mat-select>
           </mat-form-field>
           <app-operators-autocomplete [parentForm]="filterForm"></app-operators-autocomplete>
         </div>
       </div>
       <div class="filter-footer">
-        <button mat-flat-button color="primary" (click)="filterClick()">Affiner les résultats</button>
-        <button class="filter-footer-reinitialize" mat-button (click)="reinitializeClick()">
+        <button mat-flat-button type="button" color="primary" (click)="filterClick()">Affiner les résultats</button>
+        <button mat-button class="filter-footer-reinitialize" type="button" (click)="reinitializeClick()">
           Réinitialiser les filtres
         </button>
       </div>

--- a/dashboard/src/app/modules/filter/components/filter/filter.component.scss
+++ b/dashboard/src/app/modules/filter/components/filter/filter.component.scss
@@ -1,0 +1,76 @@
+@import '~src/styles/variables';
+
+.filter {
+  &-wrapper {
+    background-color: $background-white;
+    border-radius: 6px;
+    margin-top: 20px;
+    margin-bottom: 30px;
+    padding: 10px 15px 15px 15px;
+    &-close {
+      height: 0;
+      button {
+        box-shadow: none;
+        position: relative;
+        top: -32px;
+        left: calc(100% - 6px);
+      }
+    }
+  }
+
+  &-content {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    margin-bottom: 15px;
+    &-column {
+      width: 240px;
+      &-title {
+        text-align: left;
+        font-weight: 600;
+      }
+    }
+  }
+
+  &-dates mat-form-field,
+  .days,
+  ::ng-deep .campaign,
+  ::ng-deep .towns {
+    width: 240px;
+  }
+
+  &-timeAndDays,
+  &-dates,
+  &-distances {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+  }
+
+  &-dates {
+    margin-bottom: 32px;
+  }
+
+  &-footer {
+    button {
+      font-weight: 600;
+    }
+    &-reinitialize {
+      margin-left: 30px;
+      text-decoration: underline;
+    }
+  }
+}
+
+.start-time,
+.end-time,
+.min-distance,
+.max-distance {
+  width: 116px;
+}
+
+:host ::ng-deep {
+  .mat-form-field-wrapper {
+    padding-bottom: 0;
+  }
+}

--- a/dashboard/src/app/modules/filter/components/filter/filter.component.ts
+++ b/dashboard/src/app/modules/filter/components/filter/filter.component.ts
@@ -1,0 +1,57 @@
+import { Component, ElementRef, EventEmitter, Input, OnInit, Output, ViewChild } from '@angular/core';
+import { Form, FormBuilder, FormControl, FormGroup } from '@angular/forms';
+import { COMMA, ENTER } from '@angular/cdk/keycodes';
+import { MatAutocompleteSelectedEvent, MatChipInputEvent } from '@angular/material';
+import { tap } from 'rxjs/operators';
+import * as _ from 'lodash';
+
+@Component({
+  selector: 'app-filter',
+  templateUrl: './filter.component.html',
+  styleUrls: ['./filter.component.scss'],
+})
+export class FilterComponent implements OnInit {
+  public filterForm: FormGroup;
+  public _showFilter = false;
+
+  @Input() set showFilter(showFilter: boolean) {
+    this._showFilter = showFilter;
+  }
+
+  @Output() filterNumber = new EventEmitter();
+  @Output() hideFilter = new EventEmitter();
+  @Output() filter = new EventEmitter();
+
+  @ViewChild('townInput', { static: false }) townInput: ElementRef;
+
+  constructor(private fb: FormBuilder) {}
+
+  ngOnInit() {
+    this.filterForm = this.fb.group({
+      campaign: [null],
+      startDate: [null],
+      endDate: [null],
+      startTime: [null],
+      endTime: [null],
+      days: [null],
+      towns: [null],
+      minDistance: [null],
+      maxDistance: [null],
+      classes: [null],
+      status: [null],
+      operators: [null],
+    });
+  }
+
+  public onCloseClick() {
+    this.hideFilter.emit();
+  }
+
+  public filterClick() {
+    console.log(this.filterForm.value);
+  }
+
+  public reinitializeClick() {
+    this.filterForm.reset();
+  }
+}

--- a/dashboard/src/app/modules/filter/components/filter/filter.component.ts
+++ b/dashboard/src/app/modules/filter/components/filter/filter.component.ts
@@ -1,9 +1,7 @@
 import { Component, ElementRef, EventEmitter, Input, OnInit, Output, ViewChild } from '@angular/core';
-import { Form, FormBuilder, FormControl, FormGroup } from '@angular/forms';
-import { COMMA, ENTER } from '@angular/cdk/keycodes';
-import { MatAutocompleteSelectedEvent, MatChipInputEvent } from '@angular/material';
-import { tap } from 'rxjs/operators';
-import * as _ from 'lodash';
+import { FormBuilder, FormGroup } from '@angular/forms';
+
+import { FilterService } from '~/core/services/filter.service';
 
 @Component({
   selector: 'app-filter',
@@ -20,11 +18,10 @@ export class FilterComponent implements OnInit {
 
   @Output() filterNumber = new EventEmitter();
   @Output() hideFilter = new EventEmitter();
-  @Output() filter = new EventEmitter();
 
   @ViewChild('townInput', { static: false }) townInput: ElementRef;
 
-  constructor(private fb: FormBuilder) {}
+  constructor(private fb: FormBuilder, private filterService: FilterService) {}
 
   ngOnInit() {
     this.filterForm = this.fb.group({
@@ -43,15 +40,22 @@ export class FilterComponent implements OnInit {
     });
   }
 
-  public onCloseClick() {
+  public onCloseClick(): void {
     this.hideFilter.emit();
   }
 
-  public filterClick() {
-    console.log(this.filterForm.value);
+  public filterClick(): void {
+    this.filterService.setFilter(this.filterForm.value);
+    this.filterNumber.emit(this.countFilters);
+    this.hideFilter.emit();
   }
 
-  public reinitializeClick() {
+  public reinitializeClick(): void {
     this.filterForm.reset();
+    this.filterNumber.emit(0);
+  }
+
+  public get countFilters(): number {
+    return Object.values(this.filterForm.value).filter((val) => !!val).length;
   }
 }

--- a/dashboard/src/app/modules/filter/components/filter/filter.component.ts
+++ b/dashboard/src/app/modules/filter/components/filter/filter.component.ts
@@ -1,5 +1,6 @@
 import { Component, ElementRef, EventEmitter, Input, OnInit, Output, ViewChild } from '@angular/core';
 import { FormBuilder, FormGroup } from '@angular/forms';
+import { animate, state, style, transition, trigger } from '@angular/animations';
 
 import { FilterService } from '~/core/services/filter.service';
 
@@ -7,10 +8,75 @@ import { FilterService } from '~/core/services/filter.service';
   selector: 'app-filter',
   templateUrl: './filter.component.html',
   styleUrls: ['./filter.component.scss'],
+  animations: [
+    trigger('collapse', [
+      state(
+        'open',
+        style({
+          'max-height': '1800px',
+        }),
+      ),
+      state(
+        'closed',
+        style({
+          'max-height': '0',
+          display: 'none',
+        }),
+      ),
+      transition('open => closed', [style({ 'margin-top': '30px' }), animate('0.3s')]),
+      transition('closed => open', [animate('0s')]),
+    ]),
+  ],
 })
 export class FilterComponent implements OnInit {
   public filterForm: FormGroup;
   public _showFilter = false;
+  public classes = ['A', 'B', 'C'];
+  public tripStatusList = [
+    {
+      id: 'pending',
+      french: 'En cours',
+    },
+    {
+      id: 'active',
+      french: 'Actif',
+    },
+    {
+      id: 'error',
+      french: 'Anomalie',
+    },
+  ];
+
+  public days = [
+    {
+      id: 0,
+      french: 'Lundi',
+    },
+    {
+      id: 1,
+      french: 'Mardi',
+    },
+    {
+      id: 2,
+      french: 'Mercredi',
+    },
+    {
+      id: 3,
+      french: 'Jeudi',
+    },
+    {
+      id: 4,
+      french: 'Vendredi',
+    },
+    {
+      id: 5,
+      french: 'Samedi',
+    },
+    {
+      id: 6,
+      french: 'Dimanche',
+    },
+  ];
 
   @Input() set showFilter(showFilter: boolean) {
     this._showFilter = showFilter;

--- a/dashboard/src/app/modules/filter/components/towns-autocomplete/towns-autocomplete.component.html
+++ b/dashboard/src/app/modules/filter/components/towns-autocomplete/towns-autocomplete.component.html
@@ -1,0 +1,24 @@
+<mat-form-field [formGroup]="parentForm" class="towns" appearance="outline">
+  <mat-label>Communes</mat-label>
+  <mat-chip-list #chipList>
+    <mat-chip *ngFor="let town of this.townForm.value" [selectable]="true" [removable]="true" (removed)="remove(town)">
+      {{ town.name }}
+      <mat-icon matChipRemove>remove</mat-icon>
+    </mat-chip>
+    <input
+      matInput
+      placeholder="+ ajouter"
+      aria-label="Ajouter une ville"
+      #townInput
+      [formControl]="townCtrl"
+      [matAutocomplete]="auto"
+      [matChipInputFor]="chipList"
+      [matChipInputAddOnBlur]="false"
+    />
+  </mat-chip-list>
+  <mat-autocomplete #auto="matAutocomplete" (optionSelected)="onTownSelect($event)">
+    <mat-option *ngFor="let town of filteredTowns" [value]="town.name">
+      {{ town.name }}
+    </mat-option>
+  </mat-autocomplete>
+</mat-form-field>

--- a/dashboard/src/app/modules/filter/components/towns-autocomplete/towns-autocomplete.component.ts
+++ b/dashboard/src/app/modules/filter/components/towns-autocomplete/towns-autocomplete.component.ts
@@ -1,10 +1,11 @@
 import { Component, ElementRef, Input, OnInit, ViewChild } from '@angular/core';
 import { FormControl, FormGroup } from '@angular/forms';
-import { tap } from 'rxjs/operators';
+import { debounceTime, tap } from 'rxjs/operators';
 import { MatAutocompleteSelectedEvent } from '@angular/material';
 import * as _ from 'lodash';
 
 import { TownInterface } from '~/core/interfaces/geography/townInterface';
+import { TownService } from '~/modules/filter/services/town.service';
 
 @Component({
   selector: 'app-towns-autocomplete',
@@ -14,28 +15,29 @@ import { TownInterface } from '~/core/interfaces/geography/townInterface';
 export class TownsAutocompleteComponent implements OnInit {
   public townCtrl = new FormControl();
   public townForm;
-  public filteredTowns: TownInterface[];
-
-  // TODO TMP REMOVE WHEN FINISHED
-  public mockTowns: TownInterface[] = [
-    {
-      name: 'Lyon',
-    },
-    {
-      name: 'Paris',
-    },
-  ];
+  public filteredTowns: TownInterface[] = [];
 
   @Input() parentForm: FormGroup;
 
   @ViewChild('townInput', { static: false }) townInput: ElementRef;
 
-  constructor() {}
+  constructor(private townService: TownService) {}
 
   ngOnInit() {
-    this.filterTowns();
     this.townForm = this.parentForm.get('towns');
-    this.townForm.valueChanges.pipe(tap((towns: TownInterface[]) => this.filterTowns(towns))).subscribe();
+    this.townForm.valueChanges
+      .pipe(
+        tap((towns: TownInterface[]) => {
+          this.filteredTowns = _.differenceWith(this.filteredTowns, towns, (x, y) => x.name === y.name);
+        }),
+      )
+      .subscribe();
+    this.townCtrl.valueChanges
+      .pipe(
+        debounceTime(1000),
+        tap((literal: string) => this.findTowns(literal)),
+      )
+      .subscribe();
   }
 
   public remove(town: TownInterface): void {
@@ -47,6 +49,15 @@ export class TownsAutocompleteComponent implements OnInit {
     }
   }
 
+  public findTowns(literal: string = ''): void {
+    if (!literal) {
+      return;
+    }
+    this.townService.findTowns(literal).subscribe((towns: TownInterface[]) => {
+      this.filteredTowns = _.differenceWith(towns, this.townForm.value, (x, y) => x.name === y.name);
+    });
+  }
+
   public onTownSelect(event: MatAutocompleteSelectedEvent): void {
     const towns: TownInterface[] = this.townForm.value || [];
     towns.push({ name: event.option.viewValue });
@@ -55,7 +66,7 @@ export class TownsAutocompleteComponent implements OnInit {
     this.townCtrl.setValue(null);
   }
 
-  private filterTowns(towns: TownInterface[] = []): void {
-    this.filteredTowns = _.differenceWith(this.mockTowns, towns, (x, y) => x.name === y.name);
+  private filterTowns(): void {
+    const selectedTowns = this.townForm.value;
   }
 }

--- a/dashboard/src/app/modules/filter/components/towns-autocomplete/towns-autocomplete.component.ts
+++ b/dashboard/src/app/modules/filter/components/towns-autocomplete/towns-autocomplete.component.ts
@@ -1,0 +1,61 @@
+import { Component, ElementRef, Input, OnInit, ViewChild } from '@angular/core';
+import { FormControl, FormGroup } from '@angular/forms';
+import { tap } from 'rxjs/operators';
+import { MatAutocompleteSelectedEvent } from '@angular/material';
+import * as _ from 'lodash';
+
+import { TownInterface } from '~/core/interfaces/geography/townInterface';
+
+@Component({
+  selector: 'app-towns-autocomplete',
+  templateUrl: './towns-autocomplete.component.html',
+  styleUrls: ['./towns-autocomplete.component.scss'],
+})
+export class TownsAutocompleteComponent implements OnInit {
+  public townCtrl = new FormControl();
+  public townForm;
+  public filteredTowns: TownInterface[];
+
+  // TODO TMP REMOVE WHEN FINISHED
+  public mockTowns: TownInterface[] = [
+    {
+      name: 'Lyon',
+    },
+    {
+      name: 'Paris',
+    },
+  ];
+
+  @Input() parentForm: FormGroup;
+
+  @ViewChild('townInput', { static: false }) townInput: ElementRef;
+
+  constructor() {}
+
+  ngOnInit() {
+    this.filterTowns();
+    this.townForm = this.parentForm.get('towns');
+    this.townForm.valueChanges.pipe(tap((towns: TownInterface[]) => this.filterTowns(towns))).subscribe();
+  }
+
+  public remove(town: TownInterface): void {
+    const index = this.townForm.value.indexOf(town);
+    if (index >= 0) {
+      const towns = [...this.townForm.value];
+      towns.splice(index, 1);
+      this.townForm.setValue(towns);
+    }
+  }
+
+  public onTownSelect(event: MatAutocompleteSelectedEvent): void {
+    const towns: TownInterface[] = this.townForm.value || [];
+    towns.push({ name: event.option.viewValue });
+    this.townForm.setValue(towns);
+    this.townInput.nativeElement.value = null;
+    this.townCtrl.setValue(null);
+  }
+
+  private filterTowns(towns: TownInterface[] = []): void {
+    this.filteredTowns = _.differenceWith(this.mockTowns, towns, (x, y) => x.name === y.name);
+  }
+}

--- a/dashboard/src/app/modules/filter/filter.module.ts
+++ b/dashboard/src/app/modules/filter/filter.module.ts
@@ -1,0 +1,17 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+
+import { MaterialModule } from '~/shared/material/material.module';
+import { CampaignUiModule } from '~/modules/campaign/modules/campaign-ui/campaign-ui.module';
+
+import { FilterComponent } from './components/filter/filter.component';
+import { OperatorUiModule } from '~/modules/operator/modules/operator-ui/operator-ui.module';
+import { TownsAutocompleteComponent } from './components/towns-autocomplete/towns-autocomplete.component';
+
+@NgModule({
+  declarations: [FilterComponent, TownsAutocompleteComponent],
+  imports: [CommonModule, MaterialModule, FormsModule, ReactiveFormsModule, CampaignUiModule, OperatorUiModule],
+  exports: [FilterComponent],
+})
+export class FilterModule {}

--- a/dashboard/src/app/modules/filter/filter.module.ts
+++ b/dashboard/src/app/modules/filter/filter.module.ts
@@ -4,9 +4,9 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 
 import { MaterialModule } from '~/shared/material/material.module';
 import { CampaignUiModule } from '~/modules/campaign/modules/campaign-ui/campaign-ui.module';
+import { OperatorUiModule } from '~/modules/operator/modules/operator-ui/operator-ui.module';
 
 import { FilterComponent } from './components/filter/filter.component';
-import { OperatorUiModule } from '~/modules/operator/modules/operator-ui/operator-ui.module';
 import { TownsAutocompleteComponent } from './components/towns-autocomplete/towns-autocomplete.component';
 
 @NgModule({

--- a/dashboard/src/app/modules/filter/services/town.service.ts
+++ b/dashboard/src/app/modules/filter/services/town.service.ts
@@ -1,0 +1,28 @@
+import * as _ from 'lodash';
+
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+import { TownInterface } from '~/core/interfaces/geography/townInterface';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class TownService {
+  private addressApiDomain = 'https://geo.api.gouv.fr';
+
+  constructor(public http: HttpClient) {}
+
+  public findTowns(literal: string = ''): Observable<TownInterface[]> {
+    const params = `/communes?nom=${encodeURIComponent(literal)}&fields=nom`;
+    return this.http
+      .get(`${this.addressApiDomain}${params}`)
+      .pipe(
+        map((response: object[]) =>
+          response.filter((el) => _.get(el, 'nom', null)).map((el) => <TownInterface>{ name: _.get(el, 'nom') }),
+        ),
+      );
+  }
+}

--- a/dashboard/src/app/modules/operator/modules/operator-ui/components/operators-autocomplete/operators-autocomplete.component.html
+++ b/dashboard/src/app/modules/operator/modules/operator-ui/components/operators-autocomplete/operators-autocomplete.component.html
@@ -1,0 +1,29 @@
+<mat-form-field [formGroup]="parentForm" class="operators" appearance="outline">
+  <mat-label>Opérateurs</mat-label>
+  <mat-chip-list #chipList>
+    <mat-chip
+      *ngFor="let operator of this.operatorForm.value"
+      [selectable]="true"
+      [removable]="true"
+      (removed)="remove(operator)"
+    >
+      {{ operator.name }}
+      <mat-icon matChipRemove>remove</mat-icon>
+    </mat-chip>
+    <input
+      matInput
+      placeholder="+ ajouter"
+      aria-label="Ajouter une ville"
+      #operatorInput
+      [formControl]="operatorCtrl"
+      [matAutocomplete]="auto"
+      [matChipInputFor]="chipList"
+      [matChipInputAddOnBlur]="false"
+    />
+  </mat-chip-list>
+  <mat-autocomplete #auto="matAutocomplete" (optionSelected)="onOperatorSelect($event)">
+    <mat-option *ngFor="let operator of filteredOperators" [value]="operator._id">
+      {{ operator.nom_commercial }}
+    </mat-option>
+  </mat-autocomplete>
+</mat-form-field>

--- a/dashboard/src/app/modules/operator/modules/operator-ui/components/operators-autocomplete/operators-autocomplete.component.html
+++ b/dashboard/src/app/modules/operator/modules/operator-ui/components/operators-autocomplete/operators-autocomplete.component.html
@@ -7,7 +7,7 @@
       [removable]="true"
       (removed)="remove(operator)"
     >
-      {{ operator.name }}
+      {{ operator.nom_commercial }}
       <mat-icon matChipRemove>remove</mat-icon>
     </mat-chip>
     <input

--- a/dashboard/src/app/modules/operator/modules/operator-ui/components/operators-autocomplete/operators-autocomplete.component.ts
+++ b/dashboard/src/app/modules/operator/modules/operator-ui/components/operators-autocomplete/operators-autocomplete.component.ts
@@ -1,0 +1,71 @@
+import { Component, ElementRef, Input, OnInit, ViewChild } from '@angular/core';
+import { tap } from 'rxjs/operators';
+import { FormControl, FormGroup } from '@angular/forms';
+import { MatAutocompleteSelectedEvent } from '@angular/material';
+import * as _ from 'lodash';
+
+import { OperatorNameInterface } from '~/core/interfaces/operatorInterface';
+
+@Component({
+  selector: 'app-operators-autocomplete',
+  templateUrl: './operators-autocomplete.component.html',
+  styleUrls: ['./operators-autocomplete.component.scss'],
+})
+export class OperatorsAutocompleteComponent implements OnInit {
+  public operatorCtrl = new FormControl();
+  public operatorForm;
+
+  public filteredOperators: OperatorNameInterface[];
+
+  @Input() parentForm: FormGroup;
+
+  @ViewChild('operatorInput', { static: false }) operatorInput: ElementRef;
+
+  // TODO TMP REMOVE WHEN FINISHED
+  public mockOperators: OperatorNameInterface[] = [
+    {
+      _id: 'eZEFZEF45455',
+      nom_commercial: 'Operateur 1',
+    },
+    {
+      _id: 'eZEFZEEEF45455',
+      nom_commercial: 'Operateur 2',
+    },
+  ];
+
+  constructor() {}
+
+  ngOnInit() {
+    this.filterOperators();
+    this.operatorForm = this.parentForm.get('operators');
+    this.operatorForm.valueChanges
+      .pipe(tap((operators: OperatorNameInterface[]) => this.filterOperators(operators)))
+      .subscribe();
+  }
+
+  public remove(operator: OperatorNameInterface): void {
+    const index = this.operatorForm.value.indexOf(operator);
+    console.log(index, this.operatorForm.value);
+    if (index >= 0) {
+      const operators = [...this.operatorForm.value];
+      operators.splice(index, 1);
+      this.operatorForm.setValue(operators);
+    }
+  }
+
+  public onOperatorSelect(event: MatAutocompleteSelectedEvent): void {
+    const operators: OperatorNameInterface[] = this.operatorForm.value || [];
+    operators.push({ _id: event.option.value, nom_commercial: event.option.viewValue });
+    this.operatorForm.setValue(operators);
+    this.operatorInput.nativeElement.value = null;
+    this.operatorCtrl.setValue(null);
+  }
+
+  private filterOperators(operators: OperatorNameInterface[] = []): void {
+    this.filteredOperators = _.differenceWith(
+      this.mockOperators,
+      operators,
+      (x: OperatorNameInterface, y: OperatorNameInterface) => x._id === y._id,
+    );
+  }
+}

--- a/dashboard/src/app/modules/operator/modules/operator-ui/operator-ui.module.ts
+++ b/dashboard/src/app/modules/operator/modules/operator-ui/operator-ui.module.ts
@@ -1,0 +1,14 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ReactiveFormsModule } from '@angular/forms';
+
+import { MaterialModule } from '~/shared/material/material.module';
+
+import { OperatorsAutocompleteComponent } from './components/operators-autocomplete/operators-autocomplete.component';
+
+@NgModule({
+  declarations: [OperatorsAutocompleteComponent],
+  exports: [OperatorsAutocompleteComponent],
+  imports: [CommonModule, MaterialModule, ReactiveFormsModule],
+})
+export class OperatorUiModule {}

--- a/dashboard/src/app/modules/operator/operator.module.ts
+++ b/dashboard/src/app/modules/operator/operator.module.ts
@@ -1,0 +1,8 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@NgModule({
+  declarations: [],
+  imports: [CommonModule],
+})
+export class OperatorModule {}

--- a/dashboard/src/app/modules/stat/modules/stat-ui/components/stat-graph-view/stat-graph-view.component.html
+++ b/dashboard/src/app/modules/stat/modules/stat-ui/components/stat-graph-view/stat-graph-view.component.html
@@ -1,0 +1,1 @@
+<app-stat-graph *ngIf="statService._loaded$.value" [graphName]="graphName"></app-stat-graph>

--- a/dashboard/src/app/modules/stat/modules/stat-ui/components/stat-graph-view/stat-graph-view.component.html
+++ b/dashboard/src/app/modules/stat/modules/stat-ui/components/stat-graph-view/stat-graph-view.component.html
@@ -1,1 +1,4 @@
-<app-stat-graph *ngIf="statService._loaded$.value" [graphName]="graphName"></app-stat-graph>
+<div class="stats--loading" *ngIf="statService.loading && !statService.stat">
+  <mat-spinner></mat-spinner>
+</div>
+<app-stat-graph *ngIf="statService.stat" [graphName]="graphName"></app-stat-graph>

--- a/dashboard/src/app/modules/stat/modules/stat-ui/components/stat-graph-view/stat-graph-view.component.scss
+++ b/dashboard/src/app/modules/stat/modules/stat-ui/components/stat-graph-view/stat-graph-view.component.scss
@@ -1,0 +1,6 @@
+.stats {
+  &--loading {
+    display: flex;
+    justify-content: space-around;
+  }
+}

--- a/dashboard/src/app/modules/stat/modules/stat-ui/components/stat-graph-view/stat-graph-view.component.ts
+++ b/dashboard/src/app/modules/stat/modules/stat-ui/components/stat-graph-view/stat-graph-view.component.ts
@@ -1,0 +1,31 @@
+import { Component, Input, OnInit } from '@angular/core';
+
+import { statDataNameType } from '~/core/types/stat/statDataNameType';
+import { Stat } from '~/core/entities/stat/stat';
+
+import { mockStats } from '../../../../mocks/stats';
+import { StatService } from '../../../../services/stat.service';
+
+@Component({
+  selector: 'app-stat-graph-view',
+  templateUrl: './stat-graph-view.component.html',
+  styleUrls: ['./stat-graph-view.component.scss'],
+})
+export class StatGraphViewComponent implements OnInit {
+  @Input() graphName: statDataNameType;
+
+  constructor(public statService: StatService) {}
+
+  ngOnInit() {
+    if (!this.statService._loaded$.value) {
+      this.statService.load().subscribe(
+        () => {},
+        (err) => {
+          // TODO TMP DELETE WHEN BACK IS LINKED
+          const stat = new Stat(mockStats);
+          this.statService.formatData(stat);
+        },
+      );
+    }
+  }
+}

--- a/dashboard/src/app/modules/stat/modules/stat-ui/components/stat-graph-view/stat-graph-view.component.ts
+++ b/dashboard/src/app/modules/stat/modules/stat-ui/components/stat-graph-view/stat-graph-view.component.ts
@@ -17,15 +17,20 @@ export class StatGraphViewComponent implements OnInit {
   constructor(public statService: StatService) {}
 
   ngOnInit() {
-    if (!this.statService._loaded$.value) {
-      this.statService.load().subscribe(
-        () => {},
-        (err) => {
-          // TODO TMP DELETE WHEN BACK IS LINKED
-          const stat = new Stat(mockStats);
-          this.statService.formatData(stat);
-        },
-      );
+    this.loadStat();
+  }
+
+  private loadStat(): void {
+    if (this.statService.loading) {
+      return;
     }
+    this.statService.load().subscribe(
+      () => {},
+      (err) => {
+        // TODO TMP DELETE WHEN BACK IS LINKED
+        const stat = new Stat(mockStats);
+        this.statService.formatData(stat);
+      },
+    );
   }
 }

--- a/dashboard/src/app/modules/stat/modules/stat-ui/components/stat-graph/stat-graph.component.ts
+++ b/dashboard/src/app/modules/stat/modules/stat-ui/components/stat-graph/stat-graph.component.ts
@@ -52,6 +52,7 @@ export class StatGraphComponent implements OnInit {
       co2: this.loadGraph('co2'),
       carpoolersPerVehicule: this.loadGraph('carpoolersPerVehicule'),
     };
+    console.log(data);
     this.graphTitle = data.trips.monthly.graphTitle;
     this.data = data;
   }

--- a/dashboard/src/app/modules/stat/modules/stat-ui/components/stat-graph/stat-graph.component.ts
+++ b/dashboard/src/app/modules/stat/modules/stat-ui/components/stat-graph/stat-graph.component.ts
@@ -52,7 +52,6 @@ export class StatGraphComponent implements OnInit {
       co2: this.loadGraph('co2'),
       carpoolersPerVehicule: this.loadGraph('carpoolersPerVehicule'),
     };
-    console.log(data);
     this.graphTitle = data.trips.monthly.graphTitle;
     this.data = data;
   }

--- a/dashboard/src/app/modules/stat/modules/stat-ui/components/stat-view/stat-view.component.html
+++ b/dashboard/src/app/modules/stat/modules/stat-ui/components/stat-view/stat-view.component.html
@@ -1,5 +1,5 @@
 <div class="stats" *ngIf="statService._loaded$.value">
-  <div class="stats-graph">
+  <div class="stats-graph" id="graph">
     <app-stat-graph [graphName]="graphName"></app-stat-graph>
   </div>
   <div class="stats-numbers">

--- a/dashboard/src/app/modules/stat/modules/stat-ui/components/stat-view/stat-view.component.html
+++ b/dashboard/src/app/modules/stat/modules/stat-ui/components/stat-view/stat-view.component.html
@@ -1,8 +1,11 @@
-<div class="stats" *ngIf="statService._loaded$.value">
-  <div class="stats-graph" id="graph">
+<div class="stats">
+  <div class="stats--loading" *ngIf="statService.loading && !statService.stat">
+    <mat-spinner></mat-spinner>
+  </div>
+  <div *ngIf="statService.stat" class="stats-graph" id="graph">
     <app-stat-graph [graphName]="graphName"></app-stat-graph>
   </div>
-  <div class="stats-numbers">
+  <div *ngIf="statService.stat" class="stats-numbers">
     <app-stat-number
       *ngFor="let statNumberName of statViewConfig.names"
       [statNumberName]="statNumberName"

--- a/dashboard/src/app/modules/stat/modules/stat-ui/components/stat-view/stat-view.component.scss
+++ b/dashboard/src/app/modules/stat/modules/stat-ui/components/stat-view/stat-view.component.scss
@@ -6,6 +6,10 @@
   @media (min-width: 1400px) {
     width: 1272px;
   }
+  &--loading {
+    display: flex;
+    justify-content: space-around;
+  }
   .stats-numbers {
     display: flex;
     flex-wrap: wrap;

--- a/dashboard/src/app/modules/stat/modules/stat-ui/components/stat-view/stat-view.component.scss
+++ b/dashboard/src/app/modules/stat/modules/stat-ui/components/stat-view/stat-view.component.scss
@@ -1,5 +1,4 @@
 .stats {
-  width: 849px;
   max-width: 100%;
   margin: auto;
   margin-top: 30px;
@@ -11,5 +10,8 @@
     display: flex;
     flex-wrap: wrap;
     margin: auto;
+    @media (max-width: 1400px) {
+      justify-content: space-evenly;
+    }
   }
 }

--- a/dashboard/src/app/modules/stat/modules/stat-ui/components/stat-view/stat-view.component.ts
+++ b/dashboard/src/app/modules/stat/modules/stat-ui/components/stat-view/stat-view.component.ts
@@ -27,8 +27,9 @@ export class StatViewComponent implements OnInit {
     operators: true,
   };
 
-  constructor(public statService: StatService, public filterService: FilterService) {}
   @Input() statViewConfig: { names: statDataNameType[]; defaultGraphName: statDataNameType };
+
+  constructor(public statService: StatService, public filterService: FilterService) {}
 
   ngOnInit() {
     this.resetSelected();
@@ -40,6 +41,9 @@ export class StatViewComponent implements OnInit {
   }
 
   private loadStat(filter: FilterInterface = {}): void {
+    if (this.statService.loading) {
+      return;
+    }
     this.statService.load(filter).subscribe(
       () => {},
       (err) => {

--- a/dashboard/src/app/modules/stat/modules/stat-ui/components/stat-view/stat-view.component.ts
+++ b/dashboard/src/app/modules/stat/modules/stat-ui/components/stat-view/stat-view.component.ts
@@ -71,6 +71,7 @@ export class StatViewComponent implements OnInit {
    * scroll to top of div.AuthenticatedLayout-body
    */
   public scrollToTop(): void {
-    document.getElementsByClassName('AuthenticatedLayout-body')[0].scrollTop = 0;
+    const offsetTop = document.getElementById('graph').offsetTop;
+    document.getElementsByClassName('AuthenticatedLayout-body')[0].scrollTop = offsetTop;
   }
 }

--- a/dashboard/src/app/modules/stat/modules/stat-ui/components/stat-view/stat-view.component.ts
+++ b/dashboard/src/app/modules/stat/modules/stat-ui/components/stat-view/stat-view.component.ts
@@ -3,6 +3,8 @@ import { Component, Input, OnInit } from '@angular/core';
 import { Stat } from '~/core/entities/stat/stat';
 import { statDataNameType } from '~/core/types/stat/statDataNameType';
 import { GraphNamesInterface } from '~/core/interfaces/stat/graphNamesInterface';
+import { FilterService } from '~/core/services/filter.service';
+import { FilterInterface } from '~/core/interfaces/filter/filterInterface';
 
 import { StatService } from '../../../../services/stat.service';
 import { mockStats } from '../../../../mocks/stats';
@@ -25,18 +27,20 @@ export class StatViewComponent implements OnInit {
     operators: true,
   };
 
-  constructor(public statService: StatService) {}
+  constructor(public statService: StatService, public filterService: FilterService) {}
   @Input() statViewConfig: { names: statDataNameType[]; defaultGraphName: statDataNameType };
 
   ngOnInit() {
     this.resetSelected();
-    this.initStat();
     this.graphName = this.statViewConfig.defaultGraphName;
     this.selected.trips = true;
+    this.filterService._filter$.subscribe((filter: FilterInterface) => {
+      this.loadStat(filter);
+    });
   }
 
-  private initStat(): void {
-    this.statService.load().subscribe(
+  private loadStat(filter: FilterInterface = {}): void {
+    this.statService.load(filter).subscribe(
       () => {},
       (err) => {
         // TODO TMP DELETE WHEN BACK IS LINKED

--- a/dashboard/src/app/modules/stat/modules/stat-ui/stat-ui.module.ts
+++ b/dashboard/src/app/modules/stat/modules/stat-ui/stat-ui.module.ts
@@ -9,10 +9,11 @@ import { MaterialModule } from '~/shared/material/material.module';
 import { StatNumberComponent } from './components/stat-number/stat-number.component';
 import { StatGraphComponent } from './components/stat-graph/stat-graph.component';
 import { StatViewComponent } from './components/stat-view/stat-view.component';
+import { StatGraphViewComponent } from './components/stat-graph-view/stat-graph-view.component';
 
 @NgModule({
-  declarations: [StatNumberComponent, StatGraphComponent, StatViewComponent],
+  declarations: [StatNumberComponent, StatGraphComponent, StatViewComponent, StatGraphViewComponent],
   imports: [CommonModule, ChartjsModule, FormsModule, MaterialModule, SharedModule],
-  exports: [StatGraphComponent, StatViewComponent],
+  exports: [StatGraphComponent, StatViewComponent, StatGraphViewComponent],
 })
 export class StatUIModule {}

--- a/dashboard/src/app/modules/stat/services/stat.service.ts
+++ b/dashboard/src/app/modules/stat/services/stat.service.ts
@@ -9,6 +9,7 @@ import { JsonRPCService } from '~/core/services/api/json-rpc.service';
 import { Stat } from '~/core/entities/stat/stat';
 import { JsonRPCParam } from '~/core/entities/api/jsonRPCParam';
 import { FormatedStatInterface } from '~/core/interfaces/stat/formatedStatInterface';
+import { FilterInterface } from '~/core/interfaces/filter/filterInterface';
 
 import { co2Factor, petrolFactor } from '../config/stat';
 
@@ -21,8 +22,8 @@ export class StatService {
 
   constructor(private _http: HttpClient, private _jsonRPC: JsonRPCService) {}
 
-  public load(): Observable<Stat[]> {
-    const jsonRPCParam = new JsonRPCParam(`stat.list`);
+  public load(filter: FilterInterface): Observable<Stat[]> {
+    const jsonRPCParam = new JsonRPCParam(`stat.list`, filter);
     return this._jsonRPC.call(jsonRPCParam).pipe(
       tap((data) => {
         this.formatData(data);
@@ -100,6 +101,7 @@ export class StatService {
           // tslint:disable-next-line:no-bitwise
           y: get(d, 'distance.days', [])
             .filter(this.filterLastWeek)
+            // tslint:disable-next-line:no-bitwise
             .map((i) => (i.total / 1000) | 0),
         },
         distancePerDayCumulated: {
@@ -137,6 +139,7 @@ export class StatService {
           // tslint:disable-next-line:no-bitwise
           y: get(d, 'distance.days', [])
             .filter(this.filterLastWeek)
+            // tslint:disable-next-line:no-bitwise
             .map((i) => (i.total * petrolFactor) | 0),
         },
         petrolPerDayCumulated: {
@@ -158,6 +161,7 @@ export class StatService {
           // tslint:disable-next-line:no-bitwise
           y: get(d, 'distance.days', [])
             .filter(this.filterLastWeek)
+            // tslint:disable-next-line:no-bitwise
             .map((i) => (i.total * co2Factor) | 0),
         },
         co2PerDayCumulated: {

--- a/dashboard/src/app/modules/stat/services/stat.service.ts
+++ b/dashboard/src/app/modules/stat/services/stat.service.ts
@@ -17,18 +17,24 @@ import { co2Factor, petrolFactor } from '../config/stat';
   providedIn: 'root',
 })
 export class StatService {
-  _formatedStat$ = new BehaviorSubject<FormatedStatInterface>(null);
-  _loaded$ = new BehaviorSubject<boolean>(false);
+  public _formatedStat$ = new BehaviorSubject<FormatedStatInterface>(null);
+  protected _loaded$ = new BehaviorSubject<boolean>(false);
+  protected _loading$ = new BehaviorSubject<boolean>(false);
 
   constructor(private _http: HttpClient, private _jsonRPC: JsonRPCService) {}
 
-  public load(filter: FilterInterface): Observable<Stat[]> {
+  public load(filter: FilterInterface = {}): Observable<Stat[]> {
+    this._loading$.next(true);
     const jsonRPCParam = new JsonRPCParam(`stat.list`, filter);
     return this._jsonRPC.call(jsonRPCParam).pipe(
       tap((data) => {
         this.formatData(data);
       }),
     );
+  }
+
+  get loading(): boolean {
+    return this._loading$.value;
   }
 
   get stat(): FormatedStatInterface {
@@ -188,6 +194,7 @@ export class StatService {
 
     this._formatedStat$.next(formatedStat);
     this._loaded$.next(true);
+    this._loading$.next(false);
   }
 
   private reduceCumulativeData(p, c, i): any[] {

--- a/dashboard/src/app/modules/trip/pages/trip-list/trip-list.component.ts
+++ b/dashboard/src/app/modules/trip/pages/trip-list/trip-list.component.ts
@@ -9,6 +9,8 @@ import { Trip } from '~/core/entities/trip/trip';
 import { TripClass } from '~/core/entities/trip/trip-class';
 import { TripStatus } from '~/core/entities/trip/trip-status';
 import { TripInterface } from '~/core/interfaces/tripInterface';
+import { FilterService } from '~/core/services/filter.service';
+import { FilterInterface } from '~/core/interfaces/filter/filterInterface';
 
 @Component({
   selector: 'app-trip-list',
@@ -19,10 +21,17 @@ export class TripListComponent implements OnInit {
   isExporting: boolean;
   trips: Trip[] = [];
 
-  constructor(public tripService: TripService, private toastr: ToastrService, private cd: ChangeDetectorRef) {}
+  constructor(
+    public filterService: FilterService,
+    public tripService: TripService,
+    private toastr: ToastrService,
+    private cd: ChangeDetectorRef,
+  ) {}
 
   ngOnInit() {
-    this.loadTrips();
+    this.filterService._filter$.subscribe((filter: FilterInterface) => {
+      this.loadTrips(filter);
+    });
   }
 
   onScroll() {
@@ -42,11 +51,11 @@ export class TripListComponent implements OnInit {
     );
   }
 
-  private loadTrips(): void {
+  private loadTrips(filter: FilterInterface = {}): void {
     if (this.tripService.loading) {
       return;
     }
-    this.tripService.load().subscribe(
+    this.tripService.load(filter).subscribe(
       (trips) => {
         this.trips = trips;
       },

--- a/dashboard/src/app/modules/trip/trip-layout/trip-layout.component.html
+++ b/dashboard/src/app/modules/trip/trip-layout/trip-layout.component.html
@@ -5,18 +5,36 @@
     </h1>
     <div class="page-menu">
       <nav mat-tab-nav-bar>
-        <a mat-tab-link
-           *ngFor="let link of menu"
-           [routerLink]="link.path"
-           routerLinkActive
-           #rla="routerLinkActive"
-           [active]="rla.isActive">
+        <a
+          mat-tab-link
+          *ngFor="let link of menu"
+          [routerLink]="link.path"
+          routerLinkActive
+          #rla="routerLinkActive"
+          [active]="rla.isActive"
+        >
           {{ link.label }}
         </a>
       </nav>
+      <button
+        class="page-menu-filter-button"
+        mat-flat-button
+        color="primary"
+        [matBadge]="filterNumber"
+        matBadgeColor="accent"
+        (click)="toggleFilterDisplay()"
+      >
+        <mat-icon>filter_list_rounded</mat-icon>
+        Affiner les résultats
+      </button>
     </div>
   </div>
-  <div class="page-content">
+  <div class="page-content" [class.filter-triangle]="showFilter">
+    <app-filter
+      (filterNumber)="setFilterNumber($event)"
+      [showFilter]="showFilter"
+      (hideFilter)="toggleFilterDisplay()"
+    ></app-filter>
     <router-outlet></router-outlet>
   </div>
 </div>

--- a/dashboard/src/app/modules/trip/trip-layout/trip-layout.component.scss
+++ b/dashboard/src/app/modules/trip/trip-layout/trip-layout.component.scss
@@ -1,1 +1,25 @@
-@import '../../../core/components/authenticated-layout/authenticated-layout-page';
+@import '~src/app/core/components/authenticated-layout/authenticated-layout-page';
+
+.page-menu {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  &-filter-button {
+    font-weight: 600;
+    height: 40px;
+  }
+}
+
+.filter-triangle:before {
+  content: '';
+  position: relative;
+  top: 4px;
+  left: calc(100% - 110px);
+  z-index: 0;
+  width: 0;
+  height: 0;
+  border-left: 15px solid transparent;
+  border-right: 15px solid transparent;
+  border-bottom: 20px solid $background-white;
+  clear: both;
+}

--- a/dashboard/src/app/modules/trip/trip-layout/trip-layout.component.scss
+++ b/dashboard/src/app/modules/trip/trip-layout/trip-layout.component.scss
@@ -1,25 +1,31 @@
 @import '~src/app/core/components/authenticated-layout/authenticated-layout-page';
 
-.page-menu {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  &-filter-button {
-    font-weight: 600;
-    height: 40px;
+.page {
+  &-content {
+    &.filter-triangle:before {
+      content: '';
+      position: relative;
+      top: 4px;
+      left: calc(100% - 110px);
+      z-index: 0;
+      width: 0;
+      height: 0;
+      border-left: 15px solid transparent;
+      border-right: 15px solid transparent;
+      border-bottom: 20px solid $background-white;
+      clear: both;
+      @media (min-width: 1400px) {
+        left: calc(100% - 110px);
+      }
+    }
   }
-}
-
-.filter-triangle:before {
-  content: '';
-  position: relative;
-  top: 4px;
-  left: calc(100% - 110px);
-  z-index: 0;
-  width: 0;
-  height: 0;
-  border-left: 15px solid transparent;
-  border-right: 15px solid transparent;
-  border-bottom: 20px solid $background-white;
-  clear: both;
+  &-menu {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    &-filter-button {
+      font-weight: 600;
+      height: 40px;
+    }
+  }
 }

--- a/dashboard/src/app/modules/trip/trip-layout/trip-layout.component.ts
+++ b/dashboard/src/app/modules/trip/trip-layout/trip-layout.component.ts
@@ -6,6 +6,9 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./trip-layout.component.scss'],
 })
 export class TripLayoutComponent implements OnInit {
+  public filterNumber = '';
+  public showFilter = false;
+
   public menu = [
     {
       path: '/trip/stats',
@@ -24,4 +27,12 @@ export class TripLayoutComponent implements OnInit {
   constructor() {}
 
   ngOnInit() {}
+
+  public setFilterNumber(filterNumber: number) {
+    this.filterNumber = filterNumber.toString();
+  }
+
+  public toggleFilterDisplay(): void {
+    this.showFilter = !this.showFilter;
+  }
 }

--- a/dashboard/src/app/modules/trip/trip-layout/trip-layout.component.ts
+++ b/dashboard/src/app/modules/trip/trip-layout/trip-layout.component.ts
@@ -29,7 +29,7 @@ export class TripLayoutComponent implements OnInit {
   ngOnInit() {}
 
   public setFilterNumber(filterNumber: number) {
-    this.filterNumber = filterNumber.toString();
+    this.filterNumber = filterNumber === 0 ? '' : filterNumber.toString();
   }
 
   public toggleFilterDisplay(): void {

--- a/dashboard/src/app/modules/trip/trip.module.ts
+++ b/dashboard/src/app/modules/trip/trip.module.ts
@@ -1,6 +1,5 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-
 import { InfiniteScrollModule } from 'ngx-infinite-scroll';
 
 import { TripRoutingModule } from '~/modules/trip/trip-routing.module';
@@ -8,7 +7,7 @@ import { MaterialModule } from '~/shared/material/material.module';
 import { SharedModule } from '~/shared/shared.module';
 import { UiTripModule } from '~/modules/trip/ui-trip/ui-trip.module';
 import { StatUIModule } from '~/modules/stat/modules/stat-ui/stat-ui.module';
-
+import { FilterModule } from '~/modules/filter/filter.module';
 
 import { TripLayoutComponent } from './trip-layout/trip-layout.component';
 import { TripStatsComponent } from './pages/trip-stats/trip-stats.component';
@@ -17,7 +16,15 @@ import { TripListComponent } from './pages/trip-list/trip-list.component';
 
 @NgModule({
   declarations: [TripLayoutComponent, TripStatsComponent, TripMapsComponent, TripListComponent],
-  imports: [TripRoutingModule, CommonModule, MaterialModule, SharedModule, UiTripModule, InfiniteScrollModule, StatUIModule],
+  imports: [
+    TripRoutingModule,
+    CommonModule,
+    FilterModule,
+    MaterialModule,
+    SharedModule,
+    UiTripModule,
+    InfiniteScrollModule,
+    StatUIModule,
+  ],
 })
-
 export class TripModule {}

--- a/dashboard/src/app/shared/material/material.module.ts
+++ b/dashboard/src/app/shared/material/material.module.ts
@@ -1,7 +1,10 @@
 import { NgModule } from '@angular/core';
 import {
+  MatBadgeModule,
   MatButtonModule,
+  MatButtonToggleModule,
   MatCheckboxModule,
+  MatDatepickerModule,
   MatIconModule,
   MatInputModule,
   MatMenuModule,
@@ -13,18 +16,25 @@ import {
   MatSortModule,
   MatProgressBarModule,
   MatTooltipModule,
+  MatNativeDateModule,
+  MatAutocompleteModule,
+  MatChipsModule,
 } from '@angular/material';
-import { MatButtonToggleModule } from '@angular/material/button-toggle';
 
 @NgModule({
   declarations: [],
   imports: [
+    MatAutocompleteModule,
+    MatBadgeModule,
     MatButtonModule,
     MatButtonToggleModule,
+    MatChipsModule,
+    MatDatepickerModule,
     MatInputModule,
     MatSelectModule,
     MatCheckboxModule,
     MatMenuModule,
+    MatNativeDateModule,
     MatIconModule,
     MatTabsModule,
     MatStepperModule,
@@ -35,12 +45,17 @@ import { MatButtonToggleModule } from '@angular/material/button-toggle';
     MatTooltipModule,
   ],
   exports: [
+    MatAutocompleteModule,
+    MatBadgeModule,
     MatButtonModule,
     MatButtonToggleModule,
+    MatChipsModule,
+    MatDatepickerModule,
     MatInputModule,
     MatSelectModule,
     MatCheckboxModule,
     MatMenuModule,
+    MatNativeDateModule,
     MatIconModule,
     MatTabsModule,
     MatStepperModule,
@@ -50,5 +65,6 @@ import { MatButtonToggleModule } from '@angular/material/button-toggle';
     MatProgressBarModule,
     MatTooltipModule,
   ],
+  providers: [MatDatepickerModule],
 })
 export class MaterialModule {}


### PR DESCRIPTION
**Actions principales** 
* formulaire de filtre sur les pages stats, carte et liste des trajets
* bouton pour actionner l'ouverture/fermeture du filtre dans le menu
* mis au format [api-query-params](https://www.npmjs.com/package/api-query-params) des filtres avant requête à l'api

**Détails**
* animation à la fermeture
* loader sur la page statistique
* "autocomplete" pour les villes utilisant l'api [geo](https://api.gouv.fr/api/api-geo.html)
* affichage du graphique dans la page campagne
