### PR TITLE
Fix/duplicated journeys

### DIFF
--- a/api/services/acquisition/queue.js
+++ b/api/services/acquisition/queue.js
@@ -7,11 +7,11 @@ const Sentry = require('@pdc/shared/providers/sentry/sentry');
  */
 const journeysQueue = Queue('journeys');
 journeysQueue.client.on('connect', () => {
-  console.log('🐮/journeys: Redis connection OK');
+  // console.log('🐮/journeys: Redis connection OK');
 });
 
 journeysQueue.client.on('close', () => {
-  console.log('🐮/journeys: Redis connection closed');
+  // console.log('🐮/journeys: Redis connection closed');
 });
 
 journeysQueue.on('error', (err) => {
@@ -38,6 +38,5 @@ journeysQueue.on('failed', (job, err) => {
   console.log(`🐮/journeys: failed ${job.id} ${job.data.type}`, err.message);
   Sentry.captureException(err);
 });
-
 
 module.exports = journeysQueue;

--- a/api/services/acquisition/service.js
+++ b/api/services/acquisition/service.js
@@ -49,6 +49,15 @@ const journeyService = serviceFactory(Journey, {
       throw new InternalServerError('Cannot duplicate null journey');
     }
 
+    // return an already existing duplicate if found
+    const existing = await Journey.findOne({ journey_id: doc.journey_id }).exec();
+
+    // track for debug
+    console.log(`>> journey (${doc.journey_id}) exists:`, !!existing);
+    if (existing) {
+      return existing;
+    }
+
     const journey = doc.toObject();
 
     if (!operatorId) {

--- a/api/services/stats/queue.js
+++ b/api/services/stats/queue.js
@@ -7,11 +7,11 @@ const Sentry = require('@pdc/shared/providers/sentry/sentry');
  */
 const statsQueue = Queue('stats');
 statsQueue.client.on('connect', () => {
-  console.log('🐮/stats: Redis connection OK');
+  // console.log('🐮/stats: Redis connection OK');
 });
 
 statsQueue.client.on('close', () => {
-  console.log('🐮/stats: Redis connection closed');
+  // console.log('🐮/stats: Redis connection closed');
 });
 
 statsQueue.on('error', (err) => {

--- a/api/shared/worker/queues-emails.js
+++ b/api/shared/worker/queues-emails.js
@@ -7,11 +7,11 @@ const Sentry = require('../providers/sentry/sentry');
  */
 const emailsQueue = Queue('emails');
 emailsQueue.client.on('connect', () => {
-  console.log('🐮/emails: Redis connection OK');
+  // console.log('🐮/emails: Redis connection OK');
 });
 
 emailsQueue.client.on('close', () => {
-  console.log('🐮/emails: Redis connection closed');
+  // console.log('🐮/emails: Redis connection closed');
 });
 
 emailsQueue.on('error', (err) => {


### PR DESCRIPTION
Retrieve an existing journey based on `journey_id` before duplicating from _safe journeys_ to avoid duplicates.