### PR TITLE
override Access-Allow-Control-Origin with request Host in dev

### DIFF
--- a/api/proxy/src/HttpTransport.ts
+++ b/api/proxy/src/HttpTransport.ts
@@ -24,6 +24,7 @@ import { asyncHandler } from './helpers/asyncHandler';
 import { makeCall } from './helpers/routeMapping';
 import { nestParams } from './helpers/nestParams';
 import { serverTokenMiddleware } from './middlewares/serverTokenMiddleware';
+import { openCorsInDev } from './middlewares/openCorsInDev';
 
 export class HttpTransport implements TransportInterface {
   app: express.Express;
@@ -147,6 +148,7 @@ export class HttpTransport implements TransportInterface {
   }
 
   private registerGlobalMiddlewares() {
+    this.app.use(openCorsInDev);
     this.app.use(signResponseMiddleware);
     this.app.use(dataWrapMiddleware);
   }

--- a/api/proxy/src/config/proxy.ts
+++ b/api/proxy/src/config/proxy.ts
@@ -21,4 +21,4 @@ export const rpc = {
   endpoint: env('APP_RPC_ENDPOINT', '/rpc'),
 };
 
-export const cors = ['review', 'dev'].indexOf(env('APP_ENV', 'local')) > -1 ? '*' : appUrl;
+export const cors = appUrl;

--- a/api/proxy/src/middlewares/openCorsInDev.ts
+++ b/api/proxy/src/middlewares/openCorsInDev.ts
@@ -1,0 +1,17 @@
+import expressMung from 'express-mung';
+
+export const openCorsInDev = expressMung.json((body, req, res) => {
+  if (process.env.NODE_ENV !== 'dev') return;
+
+  // get the origin domain from the request
+  const protocol = `http${req.connection.encrypted ? 's' : ''}`;
+  const origin = req.get('origin') ? req.get('origin') : req.get('host');
+
+  // filter out using a whitelist
+  if (['localhost:4200', 'dev.covoiturage.beta.gouv.fr'].indexOf(origin) === -1) return;
+
+  // override the Access-Control-Allow-Origin header with the calling Origin
+  // to let the request pass. This is required due to the presence
+  // of Access-Control-Allow-Credentials being true
+  res.header('Access-Control-Allow-Origin', `${protocol}://${origin}`);
+});


### PR DESCRIPTION
To allow access from local machines as well as from the deployed frontend, `Access-Allow-Control-Origin` is set to the Request Host dynamically.

Domains are whitelisted.
Runs in `dev` only.