### PR TITLE
Gestion utilisateurs pour les admins aom & territoires

### DIFF
--- a/dashboard/src/app/modules/administration/administration-layout/administration-layout.component.ts
+++ b/dashboard/src/app/modules/administration/administration-layout/administration-layout.component.ts
@@ -25,12 +25,12 @@ export class AdministrationLayoutComponent implements OnInit {
       groups: [UserGroupEnum.OPERATOR],
       label: 'Opérateur',
     },
-    // {
-    //   path: '/admin/users',
-    //   groups: ['operator', 'territory'],
-    //   role: 'admin',
-    //   label: 'Utilisateurs & accès',
-    // },
+    {
+      path: '/admin/users',
+      groups: [UserGroupEnum.OPERATOR, UserGroupEnum.TERRITORY],
+      role: 'admin',
+      label: 'Utilisateurs & accès',
+    },
     {
       path: '/admin/all-users',
       groups: [UserGroupEnum.REGISTRY],

--- a/dashboard/src/app/modules/administration/pages/users/users.component.html
+++ b/dashboard/src/app/modules/administration/pages/users/users.component.html
@@ -17,10 +17,7 @@
   <div class="Users-list">
     <app-users-list *ngIf="usersToShow" [users]="usersToShow"></app-users-list>
   </div>
-  <div
-    class="Users-add"
-    *ngIf="authenticationService.hasAnyPermission(['user.create', 'territory.users.add', 'operator.users.add'])"
-  >
+  <div class="Users-add" *ngIf="canToCreateUser">
     <button
       mat-flat-button
       class="large"
@@ -34,9 +31,12 @@
       <h2>
         Ajouter un utilisateur
       </h2>
-      <div class="Users-form">
-        <app-create-edit-user-form [isCreating]="true" (onCloseEditUser)="closeUserForm()"></app-create-edit-user-form>
-      </div>
+      <app-create-edit-user-form
+        [user]="newUser"
+        [groupEditable]="false"
+        [isCreating]="true"
+        (onCloseEditUser)="closeUserForm()"
+      ></app-create-edit-user-form>
     </ng-template>
   </div>
 </div>

--- a/dashboard/src/app/modules/administration/pages/users/users.component.ts
+++ b/dashboard/src/app/modules/administration/pages/users/users.component.ts
@@ -6,6 +6,8 @@ import { AuthenticationService } from '~/core/services/authentication/authentica
 import { User } from '~/core/entities/authentication/user';
 import { UserService } from '~/modules/user/services/user.service';
 import { DestroyObservable } from '~/core/components/destroy-observable';
+import { UserGroupEnum } from '~/core/enums/user/user-group.enum';
+import { UserRoleEnum } from '~/core/enums/user/user-role.enum';
 
 @Component({
   selector: 'app-users',
@@ -17,6 +19,7 @@ export class UsersComponent extends DestroyObservable implements OnInit {
   users: User[];
   searchFilters: FormGroup;
   showCreateUserForm = false;
+  newUser = new User();
 
   constructor(
     public authenticationService: AuthenticationService,
@@ -33,10 +36,54 @@ export class UsersComponent extends DestroyObservable implements OnInit {
 
   addUser() {
     this.showCreateUserForm = true;
+    if (this.currentOperator) {
+      this.newUser = new User({
+        _id: null,
+        email: null,
+        firstname: null,
+        lastname: null,
+        phone: null,
+        group: this.currentGroup,
+        operator: this.currentOperator,
+        role: UserRoleEnum.USER,
+        permissions: [],
+      });
+      console.log(this.newUser);
+    }
+    if (this.currentTerritory) {
+      console.log('territory', this.currentTerritory);
+      this.newUser = new User({
+        _id: null,
+        email: null,
+        firstname: null,
+        lastname: null,
+        phone: null,
+        group: this.currentGroup,
+        territory: this.currentTerritory,
+        role: UserRoleEnum.USER,
+        permissions: [],
+      });
+    }
   }
 
   closeUserForm() {
     this.showCreateUserForm = false;
+  }
+
+  get canToCreateUser(): boolean {
+    return this.authenticationService.hasAnyPermission(['user.create', 'territory.users.add', 'operator.users.add']);
+  }
+
+  get currentGroup(): UserGroupEnum {
+    return this.authenticationService.user.group;
+  }
+
+  get currentOperator(): string {
+    return this.authenticationService.user.operator;
+  }
+
+  get currentTerritory(): string {
+    return this.authenticationService.user.territory;
   }
 
   private loadUsers() {

--- a/dashboard/src/app/modules/user/modules/ui-user/components/create-edit-user-form/create-edit-user-form.component.html
+++ b/dashboard/src/app/modules/user/modules/ui-user/components/create-edit-user-form/create-edit-user-form.component.html
@@ -26,7 +26,7 @@
 
   <mat-form-field appearance="outline" *ngIf="groupEditable && isCreating">
     <mat-label>Groupe</mat-label>
-    <mat-select required formControlName="group">
+    <mat-select required formControlName="group" (selectionChange)="onGroupChange()">
       <mat-option *ngFor="let group of groups" [value]="group">{{ getFrenchGroup(group) }}</mat-option>
     </mat-select>
   </mat-form-field>

--- a/dashboard/src/app/modules/user/modules/ui-user/components/create-edit-user-form/create-edit-user-form.component.ts
+++ b/dashboard/src/app/modules/user/modules/ui-user/components/create-edit-user-form/create-edit-user-form.component.ts
@@ -161,13 +161,14 @@ export class CreateEditUserFormComponent extends DestroyObservable implements On
       const territoryEditable = formVal.group === UserGroupEnum.TERRITORY;
       if (territoryEditable !== this.territoryEditable) {
         this.territoryEditable = territoryEditable;
-        if (!territoryEditable) this.createEditUserForm.patchValue({ territory: '' });
+        // if (!territoryEditable) this.createEditUserForm.patchValue({ territory: '' });
       }
 
       const operatorEditable = formVal.group === UserGroupEnum.OPERATOR;
       if (operatorEditable !== this.operatorEditable) {
         this.operatorEditable = operatorEditable;
-        if (operatorEditable) this.createEditUserForm.patchValue({ operator: '' });
+        // todo: not sure this is valid, operator should not be reset during edition of form
+        // if (operatorEditable) this.createEditUserForm.patchValue({ operator: '' });
       }
     });
 

--- a/dashboard/src/app/modules/user/modules/ui-user/components/create-edit-user-form/create-edit-user-form.component.ts
+++ b/dashboard/src/app/modules/user/modules/ui-user/components/create-edit-user-form/create-edit-user-form.component.ts
@@ -141,6 +141,11 @@ export class CreateEditUserFormComponent extends DestroyObservable implements On
     return USER_GROUPS_FR[group];
   }
 
+  onGroupChange(): void {
+    this.createEditUserForm.get('operator').setValue(null);
+    this.createEditUserForm.get('territory').setValue(null);
+  }
+
   private initForm(
     isCreating: boolean = this.isCreating,
     groupEditable: boolean = this.groupEditable,


### PR DESCRIPTION
* adaptation du formulaire utilisateur

@jonathanfallon : il reste un bug : l'utilisateur admin connecté n'est pas retourné dans user:list.  

pour info : 
- affichage (vous) &  mise à jour du tableau après suppression d'un utilisateur fixé dans pr #349 

closes #170