### PR TITLE
Feat/pgadmin

### DIFF
--- a/api/services/trip/src/actions/ListAction.spec.ts
+++ b/api/services/trip/src/actions/ListAction.spec.ts
@@ -1,6 +1,4 @@
-import { expect } from 'chai';
-import path from 'path';
-// import { describe } from 'mocha';
+import { describe } from 'mocha';
 
 import { Kernel as AbstractKernel } from '@ilos/framework';
 import { kernel as kernelDecorator } from '@ilos/common';

--- a/api/services/trip/src/actions/ListAction.ts
+++ b/api/services/trip/src/actions/ListAction.ts
@@ -1,11 +1,10 @@
-// tslint:disable:variable-name
 import { Action } from '@ilos/core';
-import { handler, ContextType, KernelInterfaceResolver, ConfigInterfaceResolver } from '@ilos/common';
+import { handler, ContextType } from '@ilos/common';
 import { TripSearchInterface } from '@pdc/provider-schema/dist';
 
 import { TripPgRepositoryProvider } from '../providers/TripPgRepositoryProvider';
 
-/*
+/**
  * List trips
  */
 @handler({

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - ./db/postgres:/var/lib/postgresql/data/pgdata
 
   pgadmin:
-    image: dpage/pgadmin4
+    build: ./docker/pgadmin
     networks:
       - front
       - back
@@ -28,7 +28,7 @@ services:
       PGADMIN_DEFAULT_EMAIL: admin@example.com
       PGADMIN_DEFAULT_PASSWORD: admin1234
     volumes:
-      - ./db/pgadmin:/root/.pgadmin
+      - ./db/pgadmin:/pgadmin4/volume
   mongo:
     image: 'mongo:4.0'
     ports:

--- a/docker/pgadmin/Dockerfile
+++ b/docker/pgadmin/Dockerfile
@@ -1,0 +1,4 @@
+FROM dpage/pgadmin4
+RUN mkdir -p /pgadmin4/volume/sessions
+RUN mkdir -p /pgadmin4/volume/storage
+COPY config_local.py /pgadmin4/

--- a/docker/pgadmin/config_local.py
+++ b/docker/pgadmin/config_local.py
@@ -1,0 +1,5 @@
+LOG_FILE = '/pgadmin4/volume/pgadmin4.log'
+SQLITE_PATH = '/pgadmin4/volume/pgadmin4.db'
+SESSION_DB_PATH = '/pgadmin4/volume/sessions'
+STORAGE_DIR = '/pgadmin4/volume/storage'
+SERVER_MODE = True


### PR DESCRIPTION
Utilisation d'une image Docker pour configurer les dossiers persistants de pgAdmin (storage, sqlite, sessions...)

Pour mettre à jour :
```
docker-compose up --build pgadmin
```

Accès : http://localhost:5050
Login (local only) :
- admin@example.com
- admin1234

Ajouter un serveur (local only) : 
1. Add Server
2. Onglet _General_:
	- Name: postgres
3. Onglet _Connection_:
	- Host: postgres
	- Username: postgres
	- Password: postgres
	- Save Password: true

Restauration de la BDD : 
1. Clic-droit sur database > Create...
	- Name: pdc-local
2. Clic-droit sur pdc-local > Restore...
	- Upload du fichier de dump
	- Restauration du fichier

:clap: 