### PR TITLE
set response status in journeys/push

### DIFF
--- a/api/proxy/src/HttpTransport.ts
+++ b/api/proxy/src/HttpTransport.ts
@@ -162,7 +162,8 @@ export class HttpTransport implements TransportInterface {
       '/journeys/push',
       asyncHandler(async (req, res, next) => {
         const user = get(req, 'session.user', {});
-        res.json(await this.kernel.handle(makeCall('acquisition:create', req.body, { user })));
+        const response = await this.kernel.handle(makeCall('acquisition:create', req.body, { user }));
+        res.status(mapStatusCode(response)).json(response);
       }),
     );
   }


### PR DESCRIPTION
Un micro-fix pour avoir les codes HTTP de réponse sur `/journeys/push`