### PR TITLE
Prise en compte de l'environnement sur cypress 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,7 +97,7 @@ jobs:
           key: v1-deps-{{ .Branch }}-{{ checksum "package.json" }}
           paths:
             - ~/.cache
-      - run: npx start-server-and-test 'http-server -s -p 4200 -P "http://localhost:4200?" dist/dashboard' 4200 '$(yarn bin)/cypress run --record --key $CYPRESS_RECORD_KEY'
+      - run: npx start-server-and-test 'http-server -s -p 4200 -P "http://localhost:4200?" dist/dashboard' 4200 '$(yarn bin)/cypress run --record --key $CYPRESS_RECORD_KEY --env ENV_NAME=dev'
 
   front-deploy:
     docker:

--- a/dashboard/cypress.json
+++ b/dashboard/cypress.json
@@ -4,5 +4,8 @@
   "pageLoadTimeout": 60000,
   "viewportWidth": 1200,
   "viewportHeight": 800,
-  "projectId": "j8ihas"
+  "projectId": "j8ihas",
+  "env": {
+    "ENV_NAME": "default"
+  }
 }

--- a/dashboard/cypress/integration/territory-e2e.ts
+++ b/dashboard/cypress/integration/territory-e2e.ts
@@ -1,8 +1,7 @@
-import { environment } from '../../src/environments/environment';
 import { testTerritoryE2EStory } from '../support/stories/territory.e2e.story';
 
 context('TERRITORY E2E', () => {
-  if (environment.name !== 'local') {
+  if (!Cypress.env('ENV_NAME') || Cypress.env('ENV_NAME') !== 'local') {
     return;
   }
   Cypress.Cookies.defaults({

--- a/dashboard/cypress/support/generators/stats.generator.ts
+++ b/dashboard/cypress/support/generators/stats.generator.ts
@@ -1,97 +1,15 @@
 // tslint:disable
 import { mockDates } from './const/dates';
-import { CalculatedStat } from '~/core/entities/stat/calculatedStat';
-
-export const mockStatsData = {
-  distance: {
-    days: [...Array(mockDates.days.length)].map(() => ~~(Math.random() * 500000)),
-    months: [...Array(mockDates.months.length)].map(() => ~~(Math.random() * 10000000)),
-  },
-  carpoolers: {
-    days: [...Array(mockDates.days.length)].map(() => ~~(Math.random() * 40)),
-    months: [...Array(mockDates.months.length)].map(() => ~~(Math.random() * 400)),
-  },
-  carpoolers_per_vehicule: {
-    days: [...Array(mockDates.days.length)].map((val, idx) => (Math.random() * idx) / 50 + 2),
-    months: [...Array(mockDates.months.length)].map((val, idx) => (Math.random() * idx) / 50 + 2),
-  },
-  trips: {
-    days: [...Array(mockDates.days.length)].map(() => ~~(Math.random() * 100)),
-    months: [...Array(mockDates.months.length)].map(() => ~~(Math.random() * 3000)),
-  },
-};
+import { StatInterface } from '~/core/interfaces/stat/StatInterface';
 
 export class StatsGenerator {
-  static get generateStats(): CalculatedStat {
-    return {
-      _id: 'randomStatId',
-      carpoolers: {
-        total: 5678,
-        days: mockStatsData.carpoolers.days.map((val, idx) => {
-          return {
-            day: mockDates.days[idx],
-            total: val,
-          };
-        }),
-        months: mockStatsData.carpoolers.months.map((val, idx) => {
-          return {
-            date: mockDates.months[idx],
-            total: val,
-          };
-        }),
-      },
-      carpoolers_per_vehicule: {
-        total: 2.5,
-        days: mockStatsData.carpoolers_per_vehicule.days.map((val, idx) => {
-          return {
-            day: mockDates.days[idx],
-            total: val,
-          };
-        }),
-        months: mockStatsData.carpoolers_per_vehicule.months.map((val, idx) => {
-          return {
-            date: mockDates.months[idx],
-            total: val,
-          };
-        }),
-      },
-      distance: {
-        total: 1000780000,
-        days: mockStatsData.distance.days.map((val, idx) => {
-          return {
-            day: mockDates.days[idx],
-            total: val,
-          };
-        }),
-        months: mockStatsData.distance.months.map((val, idx) => {
-          return {
-            date: mockDates.months[idx],
-            total: val,
-          };
-        }),
-      },
-      operators: {
-        total: 5,
-        imgIds: [],
-      },
-      trips: {
-        total: 68008,
-        total_subsidized: 62000,
-        days: mockStatsData.trips.days.map((val, idx) => {
-          return {
-            day: mockDates.days[idx],
-            total: val,
-            total_subsidized: val / 2,
-          };
-        }),
-        months: mockStatsData.trips.months.map((val, idx) => {
-          return {
-            date: mockDates.months[idx],
-            total: val,
-            total_subsidized: val / 2,
-          };
-        }),
-      },
-    };
+  static get generateStats(): StatInterface[] {
+    return mockDates.days.map((day: string) => ({
+      day,
+      carpoolers: ~~((Math.random() + 1) * 40),
+      distance: ~~((Math.random() + 1) * 500000),
+      trip: ~~((Math.random() + 1) * 100),
+      trip_subsidized: ~~((Math.random() + 1) * 80),
+    }));
   }
 }

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -9,8 +9,8 @@
     "build": "ng build --configuration=$NODE_ENV",
     "lint": "ng lint",
     "format:fix": "pretty-quick --staged",
-    "test": "yarn run cypress run",
-    "open:cypress": "$(npm bin)/cypress open"
+    "test": "yarn run cypress run --env ENV_NAME=local",
+    "open:cypress": "$(npm bin)/cypress open --env ENV_NAME=local"
   },
   "private": true,
   "dependencies": {

--- a/dashboard/src/app/core/entities/stat/calculatedStat.ts
+++ b/dashboard/src/app/core/entities/stat/calculatedStat.ts
@@ -1,24 +1,20 @@
-import {
-  StatDateTotalInterface,
-  StatDayTotalInterface,
-  CalculatedStatInterface,
-} from '../../interfaces/stat/calculatedStatInterface';
+import { StatDateTotalInterface, CalculatedStatInterface } from '../../interfaces/stat/calculatedStatInterface';
 
 export class CalculatedStat {
   public carpoolers: {
     total: number;
-    days: StatDayTotalInterface[];
+    days: StatDateTotalInterface[];
     months: StatDateTotalInterface[];
   };
   // tslint:disable-next-line:variable-name
   public carpoolers_per_vehicule: {
     total: number;
-    days: StatDayTotalInterface[];
+    days: StatDateTotalInterface[];
     months: StatDateTotalInterface[];
   };
   public distance: {
     total: number;
-    days: StatDayTotalInterface[];
+    days: StatDateTotalInterface[];
     months: StatDateTotalInterface[];
   };
   public operators?: {

--- a/dashboard/src/app/core/interfaces/stat/calculatedStatInterface.ts
+++ b/dashboard/src/app/core/interfaces/stat/calculatedStatInterface.ts
@@ -1,17 +1,17 @@
 export interface CalculatedStatInterface {
   carpoolers: {
     total: number;
-    days: StatDayTotalInterface[];
+    days: StatDateTotalInterface[];
     months: StatDateTotalInterface[];
   };
   carpoolers_per_vehicule: {
     total: number;
-    days: StatDayTotalInterface[];
+    days: StatDateTotalInterface[];
     months: StatDateTotalInterface[];
   };
   distance: {
     total: number;
-    days: StatDayTotalInterface[];
+    days: StatDateTotalInterface[];
     months: StatDateTotalInterface[];
   };
   operators?: {
@@ -36,10 +36,5 @@ export interface CalculatedStatInterface {
 
 export interface StatDateTotalInterface {
   date: string;
-  total: number;
-}
-
-export interface StatDayTotalInterface {
-  day: string;
   total: number;
 }

--- a/dashboard/src/app/modules/campaign/components/campaign-form/step-2/filters-form/filters-form.component.html
+++ b/dashboard/src/app/modules/campaign/components/campaign-form/step-2/filters-form/filters-form.component.html
@@ -151,7 +151,10 @@
           </mat-panel-description>
         </mat-expansion-panel-header>
         <div class="RulesForm-operators CampaignSubForm-inputs">
-          <app-operators-autocomplete [parentForm]="filtersForm"></app-operators-autocomplete>
+          <app-operators-autocomplete
+            [parentForm]="filtersForm"
+            [fieldName]="'operator_ids'"
+          ></app-operators-autocomplete>
         </div>
       </mat-expansion-panel>
     </mat-accordion>

--- a/dashboard/src/app/modules/operator/modules/operator-ui/components/operators-autocomplete/operators-autocomplete.component.ts
+++ b/dashboard/src/app/modules/operator/modules/operator-ui/components/operators-autocomplete/operators-autocomplete.component.ts
@@ -22,6 +22,9 @@ export class OperatorsAutocompleteComponent extends DestroyObservable implements
   // with operatorIds control
   @Input() parentForm: FormGroup;
 
+  // if different from default
+  @Input() fieldName = 'operatorIds';
+
   @ViewChild('operatorInput', { static: false }) operatorInput: ElementRef;
 
   constructor(private commonDataService: CommonDataService) {
@@ -37,7 +40,7 @@ export class OperatorsAutocompleteComponent extends DestroyObservable implements
   }
 
   get operatorIdsControl(): FormControl {
-    return <FormControl>this.parentForm.get('operatorIds');
+    return <FormControl>this.parentForm.get(this.fieldName);
   }
 
   /**


### PR DESCRIPTION
* enlever les tests e2e de l'intégration continue
* génération des stats pour les 'stubs' au bon format pour cypress
* correction de l'autocomplete operators ( ajout d'un champ fieldname pour fixer les différents appels au component quand on passe des formgroups au format différents ) 