### PR TITLE
add contacts to patch schema

### DIFF
--- a/api/providers/schema/src/models/operator/schemas/operatorPatchSchema.ts
+++ b/api/providers/schema/src/models/operator/schemas/operatorPatchSchema.ts
@@ -20,7 +20,7 @@ export const operatorPatchSchema = {
         company: companySchema,
         address: addressSchema,
         bank: bankSchema,
-        // contacts: contactsSchema,
+        contacts: contactsSchema,
       },
     },
   },

--- a/api/providers/schema/src/models/territory/schemas/territoryPatchSchema.ts
+++ b/api/providers/schema/src/models/territory/schemas/territoryPatchSchema.ts
@@ -29,7 +29,7 @@ export const territoryPatchSchema = {
         company: companySchema,
         address: addressSchema,
         bank: bankSchema,
-        // contacts: contactsSchema,
+        contacts: contactsSchema,
         cgu: cguSchema,
       },
     },


### PR DESCRIPTION
Add `contacts` to patch to let administrators modify the contacts as well as the other information.

Keep patchContact route and schemas.

#475 