### PR TITLE
Correctif filtre de recherche

### DIFF
--- a/dashboard/src/app/modules/administration/pages/all-users/all-users.component.ts
+++ b/dashboard/src/app/modules/administration/pages/all-users/all-users.component.ts
@@ -105,7 +105,7 @@ export class AllUsersComponent extends DestroyObservable implements OnInit {
   public filterUsers() {
     const query = this.searchFilters ? this.searchFilters.controls.query.value : '';
     this.usersToShow = this.users.filter(
-      (u) => (u.email.includes(query) || `${u.firstname} ${u.lastname}`.includes(query)) && this.userGroup === u.group,
+      (u) => `${u.email} ${u.firstname} ${u.lastname}`.toLowerCase().includes(query) && this.userGroup === u.group,
     );
   }
 }

--- a/dashboard/src/app/modules/administration/pages/users/users.component.ts
+++ b/dashboard/src/app/modules/administration/pages/users/users.component.ts
@@ -131,10 +131,10 @@ export class UsersComponent extends DestroyObservable implements OnInit {
       });
   }
 
-  private filterUsers() {
-    const query = this.searchFilters.controls.query.value;
-    this.usersToShow = this.users.filter(
-      (u) => u.email.includes(query) || `${u.firstname} ${u.lastname}`.includes(query),
+  public filterUsers() {
+    const query = this.searchFilters ? this.searchFilters.controls.query.value : '';
+    this.usersToShow = this.users.filter((u) =>
+      `${u.email} ${u.firstname} ${u.lastname}`.toLowerCase().includes(query),
     );
   }
 }

--- a/dashboard/src/app/modules/operator/modules/operator-ui/components/operator-list/operator-list.component.ts
+++ b/dashboard/src/app/modules/operator/modules/operator-ui/components/operator-list/operator-list.component.ts
@@ -52,7 +52,9 @@ export class OperatorListComponent extends DestroyObservable implements OnInit, 
   }
 
   filter() {
-    this.operatorsToShow = this.operators.filter((t) => t.nom_commercial.toLowerCase().includes(this.filterLiteral));
+    this.operatorsToShow = this.operators.filter((t) =>
+      t.nom_commercial.toLowerCase().includes(this.filterLiteral.toLowerCase()),
+    );
   }
 
   onEdit(operator) {

--- a/dashboard/src/app/modules/territory/modules/territory-ui/components/territory-list/territory-list.component.ts
+++ b/dashboard/src/app/modules/territory/modules/territory-ui/components/territory-list/territory-list.component.ts
@@ -51,7 +51,9 @@ export class TerritoryListComponent extends DestroyObservable implements OnInit,
   }
 
   filter() {
-    this.territoriesToShow = this.territories.filter((t) => t.name.toLowerCase().includes(this.filterLiteral));
+    this.territoriesToShow = this.territories.filter((t) =>
+      t.name.toLowerCase().includes(this.filterLiteral.toLowerCase()),
+    );
   }
 
   onEdit(territory: Territory) {


### PR DESCRIPTION
Ignore la capitalisation du texte lors de recherche dans les tableaux :
- opérateur
- territoire
- utilisateurs (admin + mes utilisateurs)