### PR TITLE
fix des autocompletes

### DIFF
--- a/dashboard/src/app/modules/operator/modules/operator-ui/components/operators-autocomplete/operators-autocomplete.component.ts
+++ b/dashboard/src/app/modules/operator/modules/operator-ui/components/operators-autocomplete/operators-autocomplete.component.ts
@@ -1,5 +1,5 @@
 import { Component, ElementRef, Input, OnInit, ViewChild } from '@angular/core';
-import { takeUntil, tap } from 'rxjs/operators';
+import { filter, takeUntil, tap } from 'rxjs/operators';
 import { FormControl, FormGroup } from '@angular/forms';
 import { MatAutocompleteSelectedEvent } from '@angular/material';
 
@@ -35,7 +35,10 @@ export class OperatorsAutocompleteComponent extends DestroyObservable implements
     this.loadOperators();
     this.operatorCtrl.valueChanges
       .pipe(takeUntil(this.destroy$))
-      .pipe(tap((literal) => this.filterOperators(literal)))
+      .pipe(
+        filter((literal) => !!literal),
+        tap((literal: string) => this.filterOperators(literal)),
+      )
       .subscribe();
   }
 

--- a/dashboard/src/app/modules/territory/modules/territory-ui/components/territories-autocomplete/territories-autocomplete.component.ts
+++ b/dashboard/src/app/modules/territory/modules/territory-ui/components/territories-autocomplete/territories-autocomplete.component.ts
@@ -1,7 +1,7 @@
 import { Component, ElementRef, Input, OnInit, ViewChild } from '@angular/core';
 import { FormControl, FormGroup } from '@angular/forms';
 import { MatAutocompleteSelectedEvent } from '@angular/material';
-import { takeUntil, tap } from 'rxjs/operators';
+import { filter, takeUntil, tap } from 'rxjs/operators';
 
 import { TerritoryNameInterface } from '~/core/interfaces/territory/territoryInterface';
 import { DestroyObservable } from '~/core/components/destroy-observable';
@@ -33,7 +33,10 @@ export class TerritoriesAutocompleteComponent extends DestroyObservable implemen
     this.initTerritories();
     this.territoryCtrl.valueChanges
       .pipe(takeUntil(this.destroy$))
-      .pipe(tap((literal) => this.filterTerritories(literal)))
+      .pipe(
+        filter((literal) => !!literal),
+        tap((literal: string) => this.filterTerritories(literal)),
+      )
       .subscribe();
   }
 


### PR DESCRIPTION
problème résolue: on ne pas sélectionné qu'un opérateur ou territoire dans les auto-completes, lié à la réinitialisation du champs à la valeur null. 