### PR TITLE
Corrections des statistiques de covoiturage - prod

### DIFF
--- a/api/services/trip/src/providers/TripPgRepositoryProvider.ts
+++ b/api/services/trip/src/providers/TripPgRepositoryProvider.ts
@@ -311,18 +311,18 @@ export class TripPgRepositoryProvider implements TripPgRepositoryInterface {
           case 'date':
             if (filter.value.start && filter.value.end) {
               return {
-                text: '($#::timestamp < start_datetime AND start_datetime < $#::timestamp)',
+                text: '($#::timestamp <= start_datetime AND start_datetime <= $#::timestamp)',
                 values: [filter.value.start, filter.value.end],
               };
             }
             if (filter.value.start) {
               return {
-                text: '$#::timestamp < start_datetime',
+                text: '$#::timestamp <= start_datetime',
                 values: [filter.value.start],
               };
             }
             return {
-              text: 'start_datetime < $#::timestamp',
+              text: 'start_datetime <= $#::timestamp',
               values: [filter.value.end],
             };
           case 'ranks':
@@ -401,7 +401,7 @@ export class TripPgRepositoryProvider implements TripPgRepositoryInterface {
           SELECT
             min(start_datetime::date) as day,
             max(distance) as distance,
-            sum(seats) as carpoolers,
+            sum(seats+1) as carpoolers,
             count(*) FILTER (WHERE array_length(incentives, 1) > 0)::int as carpoolers_subsidized
           FROM trip_participants
           ${where ? where.text : ''}

--- a/dashboard/src/app/modules/stat/services/stat-format.service.ts
+++ b/dashboard/src/app/modules/stat/services/stat-format.service.ts
@@ -146,7 +146,7 @@ export class StatFormatService {
         petrol: (get(d, 'distance.total', 0) * petrolFactor) | 0,
         co2: (get(d, 'distance.total', 0) * co2Factor) | 0,
         carpoolersPerVehicule: get(d, 'carpoolers_per_vehicule.total', 0)
-          ? (Number(get(d, 'carpoolers_per_vehicule.total', 0)) + 1).toFixed(2) // todo: this +1 should be done in back
+          ? Number(get(d, 'carpoolers_per_vehicule.total', 0)).toFixed(2)
           : 0,
         operators: get(d, 'operators.total', 0),
       },


### PR DESCRIPTION
* prendre en compte le conducteur dans le nombre de covoitureurs
* utiliser <= et => pour le filtre par date des statistiques & trajets