### PR TITLE
Code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -34,7 +34,19 @@
 ################################################################################
 
 /dashboard/cypress					@samueleyre
-/dashboard/src						@gillesboisson
+/dashboard/src/app/modules/administration   @gillesboisson
+/dashboard/src/app/modules/authentication   @gillesboisson
+/dashboard/src/app/modules/campaign @samueleyre
+/dashboard/src/app/modules/company  @gillesboisson
+/dashboard/src/app/modules/filter   @samueleyre
+/dashboard/src/app/modules/operator @gillesboisson
+/dashboard/src/app/modules/stat @samueleyre
+/dashboard/src/app/modules/territory @gillesboisson
+/dashboard/src/app/modules/trip @samueleyre @gillesboisson
+/dashboard/src/app/modules/ui-guide @samueleyre @gillesboisson
+/dashboard/src/app/modules/user @gillesboisson
+/dashboard/src/app/shared   @samueleyre @gillesboisson
+/dashboard/src/app/core @samueleyre @gillesboisson
 
 ################################################################################
 #						         Shared Resources

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,53 @@
+################################################################################
+#							    Backend services
+################################################################################
+
+# Resources
+/api/db								@jonathanfallon @nmrgt
+
+# Reverse Proxy
+/api/proxy							@jonathanfallon @nmrgt
+
+# API services
+/api/services/acquisition			@jonathanfallon
+/api/services/application			@jonathanfallon
+/api/services/certificate			@jonathanfallon
+/api/services/company				@nmrgt
+/api/services/fraud					@nmrgt
+/api/services/normalization			@jonathanfallon
+/api/services/operator				@jonathanfallon
+/api/services/policy				@nmrgt
+/api/services/territory				@jonathanfallon
+/api/services/trip					@nmrgt
+/api/services/user					@jonathanfallon
+
+/api/providers/crypto				@nmrgt
+/api/providers/geo					@jonathanfallon
+/api/providers/middleware			@nmrgt
+/api/providers/notification			@nmrgt
+/api/providers/sentry				@jonathanfallon
+/api/providers/token				@jonathanfallon
+/api/providers/validator			@jonathanfallon
+
+################################################################################
+#							       Frontend
+################################################################################
+
+/dashboard/cypress					@samueleyre
+/dashboard/src						@gillesboisson
+
+################################################################################
+#						         Shared Resources
+################################################################################
+/api/shared							@jonathanfallon @gillesboisson
+/docker-compose*					@jonathanfallon
+/docker								@jonathanfallon
+/api/scalingo						@jonathanfallon
+/scalingo.json						@jonathanfallon
+
+/.circleci							@jonathanfallon
+
+/CHANGELOG.md						@jonathanfallon
+/LICENSE							@jonathanfallon
+/README.md							@jonathanfallon
+

--- a/README.md
+++ b/README.md
@@ -4,25 +4,6 @@ Le registre de preuve de covoiturage est un projet beta.gouv.fr qui a pour but d
 
 [http://covoiturage.beta.gouv.fr/](http://covoiturage.beta.gouv.fr/)
 
-<!--
-## Contribution à la liste des cartes de transport et des Titres-Mobilité
-
-Les listes des cartes de transport et des Titres-Mobilité autorisés sont disponibles dans la configuration. Il est possible de soumettre des _Pull Requests_ pour en ajouter.
-
-- [Cartes de transport](api/config/travel-pass.yml)
-- [Titres-Mobilité](api/config/mobility-pass.yml)
-
-> Merci d'utiliser le modèle de _Pull Request_ quand vous soumettez des modifications.
-
-Merci pour votre contribution !
-
-## Pour contribuer
-
-1. Créer un _fork_ du _repository_ dans votre compte Github
-2. Commitez vos modifications sur une nouvelle branche de _feature_
-3. Proposez une _Pull Request_ sur le _repository_ principal
--->
-
 ### Docker Services
 
 An easy way to boot the application on your local machine is by using Docker.
@@ -32,11 +13,13 @@ You will need `docker` and `docker-compose`.
 | --------------- | ----------- | ---------------- | --------------------------------- | ---------- |
 | Frontend        | `dashboard` | APP_APP_URL      | http://localhost:4200             | /dashboard |
 | API             | `api`       | APP_API_URL      | http://localhost:8080             | /api       |
-| MongoDB         | `mongo`     | APP_MONGO_URL    | mongodb://mongo:mongo@mongo:27017 | -          |
+| MongoDB \*      | `mongo`     | APP_MONGO_URL    | mongodb://mongo:mongo@mongo:27017 | -          |
 | Redis           | `redis`     | APP_REDIS_URL    | redis://redis:6379                | -          |
 | Redis Client    | `arena`     | -                | http://localhost:4567             | -          |
 | Postgres        | `postgres`  | APP_POSTGRES_URL | postgresql://postgres:post        | -          |
 | Postgres Client | `pgadmin`   | -                | http://localhost:5050             | -          |
+
+- Mongo is being deprecated and will be removed when Postgres migration is complete.
 
 > `docker-compose.yml` is used in `local` environment only
 
@@ -44,18 +27,20 @@ You will need `docker` and `docker-compose`.
 
 1. Clone the repository and `cd` to it
 2. `cp api/.env.example api/.env`
-3. Edit the `api/proxy/.env` file
+3. Edit the `api/.env` file
 4. `docker-compose build`
 5. `docker-compose run api yarn`
 6. `docker-compose run api yarn run build`
 7. `docker-compose run dashboard yarn`
    <!-- 8. `docker-compose run worker yarn` -->
 8. `docker-compose run api yarn migrate`
-9. `docker-compose run api yarn seed`
+9. `docker-compose run api yarn set-permissions`
 
 #### clone ilos locally
 
-You can clone the ilos framework locally to use different branches, tags or contribute.
+Ilos is the _progressive micro-service framework_ behind the application.
+You can clone the ilos framework locally to use different branches, tags or contribute. To do so, create the `api/ilos` folder, check the `dev` branch out and run `yarn build`.  
+Workspaces are handled properly when `yarn` commands are run from the `/api` folder.
 
 > the current `dev` branch of the application runs on Ilos `dev` branch.
 
@@ -76,8 +61,8 @@ yarn run build
 2. [Access the dashboard](http://localhost:4200)
 3. Connect with one of the following test users:
    - admin with `admin@example.com` / `admin1234`
-     <!-- - aom with `aom@example.com` / `aom1234`
-   - operator with `operator@example.com` / `operator` -->
+     <!-- - territory with `territory@example.com` / `admin1234`
+   - operator with `operator@example.com` / `admin1234` -->
 
 `Ctrl-C` to kill the process
 
@@ -89,7 +74,7 @@ For all **secrets**, use the `.env` file which is **NOT COMMITED** to Git.
 
 For none secret values configuring the system, commit the ENV vars in `docker-compose.yml`
 
-For _static_ application configuration (INSEE codes, timeout, etc.) edit/add the `.ts` files in each service `config/` folder.
+For _static_ application configuration (timeout, etc.) edit/add the `.ts` files in each service `config/` folder.
 
 ### Access the database in the docker container
 
@@ -130,15 +115,13 @@ $ docker-compose exec mongo mongorestore -u mongo -p mongo \
 ##### inside the `api` container
 
 <!--
-- `yarn seed` Seed the database (based on the NODE_ENV var)
-- `yarn process {?safe_journey_id}` re-process a safe-journey to a journey
-- `yarn process-trip {?journey_id}` re-process a journey to consolidate trips
 - `yarn migrate` run up migrations
+- `yarn migrate:down` run down migrations
 - `yarn lint`
 - `yarn test` run the tests
 -->
 
-- `yarn fix-permissions` reset all users' permissions based on their group and role
+- `yarn set-permissions` reset all users' permissions based on their group and role
 - `yarn workspace @pdc/... run test`
 - `yarn workspace @pdc/... run test:integration`
 

--- a/api/.github/PULL_REQUEST_TEMPLATE/mobility-pass.md
+++ b/api/.github/PULL_REQUEST_TEMPLATE/mobility-pass.md
@@ -1,8 +1,0 @@
-# Ajout / Modification d'un « Titre-Mobilité »
-
-J'ajoute le Titre-Mobilité **Nom du titre**, disponible sur le territoire **Nom du territoire**.
-
-### Checklist
-
-- [ ] `name` correspond au nom commercial du titre
-- [ ] `slug` est un identifiant unique composé uniquement de minuscules, de chiffres et de tirets (`^[a-z0-9-]{3,32}$`)


### PR DESCRIPTION
Ajout du fichier `.github/CODEOWNERS` pour définir les responsabilités sur les différentes parties de l'application (back et front).

Les responsables seront automatiquement assignés comme _reviewers_ sur les PR qui touchent leur code.

Plus d'infos:
https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners

@gillesboisson, @samueleyre et @nmrgt merci de relire la répartition des dossiers pour valider que ça vous va.
Nous avions déjà détaillé par micro-service dans le backend. Vous avez la main sur le frontend.
