### PR TITLE
Front/sprint 11 quick fixes

### DIFF
--- a/api/services/user/src/templates/email_changed.hbs
+++ b/api/services/user/src/templates/email_changed.hbs
@@ -2,7 +2,7 @@
 
 <p style="text-align:left;color:#000">Vous avez demandé à changer votre adresse email sur le Registre de Preuve de Covoiturage.</p>
 
-<p style="text-align:left;color:#000">Si vous n’êtes pas à l’origine de cette modification, veuillez contacter l’adminsitrateur du service. </p>
+<p style="text-align:left;color:#000">Si vous n’êtes pas à l’origine de cette modification, veuillez contacter l’administrateur du service. </p>
 
 <p style="text-align:left;color:#000">A bientôt</p>
 

--- a/dashboard/src/app/core/components/dialog/confirm-dialog.component.scss
+++ b/dashboard/src/app/core/components/dialog/confirm-dialog.component.scss
@@ -1,5 +1,16 @@
 ::ng-deep .mat-dialog-container {
   .mat-dialog-actions {
     justify-content: space-between;
+    margin-top: 5px;
+    margin-bottom: 0;
+    padding-bottom: 0;
+    min-height: auto;
+
+    margin-left: -10px;
+    margin-right: -10px;
+  }
+
+  .mat-dialog-actions > * {
+    margin: 0 10px;
   }
 }

--- a/dashboard/src/app/core/entities/territory/territory.ts
+++ b/dashboard/src/app/core/entities/territory/territory.ts
@@ -71,8 +71,6 @@ class Territory {
     const val: any = fullformMode
       ? {
           shortname: '',
-          // insee: '',
-          // acronym: '',
           ...this,
           company: { ...new Company(this.company).toFormValues(), siret: this.siret },
           contacts: new Contacts(this.contacts).toFormValues(),

--- a/dashboard/src/app/core/entities/utils.ts
+++ b/dashboard/src/app/core/entities/utils.ts
@@ -1,3 +1,5 @@
+import { FormArray, FormGroup } from '@angular/forms';
+
 export function hasOneNotEmptyProperty(object: any, maxRec = 3) {
   if (!object) return false;
 
@@ -18,4 +20,22 @@ export function hasOneNotEmptyProperty(object: any, maxRec = 3) {
   }
 
   return hasNonEmpty;
+}
+
+// return invalid controls names
+export function findInvalidControlsRecursive(formToInvestigate: FormGroup | FormArray): string[] {
+  const invalidControls: string[] = [];
+  const recursiveFunc = (form: FormGroup | FormArray) => {
+    Object.keys(form.controls).forEach((field) => {
+      const control = form.get(field);
+      if (control.invalid) invalidControls.push(field);
+      if (control instanceof FormGroup) {
+        recursiveFunc(control);
+      } else if (control instanceof FormArray) {
+        recursiveFunc(control);
+      }
+    });
+  };
+  recursiveFunc(formToInvestigate);
+  return invalidControls;
 }

--- a/dashboard/src/app/modules/operator/modules/operator-ui/components/operator-form/operator-form.component.ts
+++ b/dashboard/src/app/modules/operator/modules/operator-ui/components/operator-form/operator-form.component.ts
@@ -67,6 +67,7 @@ export class OperatorFormComponent extends DestroyObservable implements OnInit, 
 
   public onSubmit(): void {
     const operator = new Operator(this.operatorForm.value);
+    operator.siret = this.operatorForm.value.company.siret;
     if (this.editedOperatorId) {
       const patch$ = this.fullFormMode
         ? this._operatorService.updateList(new Operator({ ...operator, _id: this.editedOperatorId }))

--- a/dashboard/src/app/modules/operator/modules/operator-ui/components/operator-form/operator-form.component.ts
+++ b/dashboard/src/app/modules/operator/modules/operator-ui/components/operator-form/operator-form.component.ts
@@ -1,5 +1,5 @@
 import { Component, EventEmitter, Input, OnChanges, OnInit, Output, SimpleChanges } from '@angular/core';
-import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { FormArray, FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { filter, takeUntil, tap, throttleTime } from 'rxjs/operators';
 import { ToastrService } from 'ngx-toastr';
 import { Subject } from 'rxjs';
@@ -67,8 +67,6 @@ export class OperatorFormComponent extends DestroyObservable implements OnInit, 
 
   public onSubmit(): void {
     const operator = new Operator(this.operatorForm.value);
-
-    console.log('operator : ', operator);
     if (this.editedOperatorId) {
       const patch$ = this.fullFormMode
         ? this._operatorService.updateList(new Operator({ ...operator, _id: this.editedOperatorId }))
@@ -122,6 +120,45 @@ export class OperatorFormComponent extends DestroyObservable implements OnInit, 
     const operatorConstruct = operatorFt.toFormValues(this.fullFormMode);
 
     this.operatorForm.setValue(operatorConstruct);
+  }
+
+  private updateValidation() {
+    if (this.operatorForm && this.fullFormMode) {
+      this.operatorForm.controls['name'].setValidators(this.fullFormMode ? Validators.required : null);
+      this.operatorForm.controls['legal_name'].setValidators(this.fullFormMode ? Validators.required : null);
+    }
+  }
+
+  private initOperatorForm(): void {
+    let formOptions: any = {
+      contacts: this.fb.group({
+        gdpr_dpo: this.fb.group(new FormContact(new Contact({ firstname: null, lastname: null, email: null }))),
+        gdpr_controller: this.fb.group(new FormContact(new Contact({ firstname: null, lastname: null, email: null }))),
+        technical: this.fb.group(new FormContact(new Contact({ firstname: null, lastname: null, email: null }))),
+      }),
+    };
+
+    if (this.fullFormMode) {
+      formOptions = {
+        ...formOptions,
+        name: [''],
+        legal_name: [''],
+        address: this.fb.group(
+          new FormAddress(
+            new Address({
+              street: null,
+              city: null,
+              country: null,
+              postcode: null,
+            }),
+          ),
+        ),
+        company: this.fb.group(new FormCompany({ siret: '', company: new Company() })),
+        bank: this.fb.group(new FormBank(new Bank()), { validators: bankValidator }),
+      };
+    }
+
+    this.operatorForm = this.fb.group(formOptions);
 
     const stopFindCompany = new Subject();
 
@@ -163,45 +200,6 @@ export class OperatorFormComponent extends DestroyObservable implements OnInit, 
             }
           });
       });
-  }
-
-  private updateValidation() {
-    if (this.operatorForm && this.fullFormMode) {
-      this.operatorForm.controls['name'].setValidators(this.fullFormMode ? Validators.required : null);
-      this.operatorForm.controls['legal_name'].setValidators(this.fullFormMode ? Validators.required : null);
-    }
-  }
-
-  private initOperatorForm(): void {
-    let formOptions: any = {
-      contacts: this.fb.group({
-        gdpr_dpo: this.fb.group(new FormContact(new Contact({ firstname: null, lastname: null, email: null }))),
-        gdpr_controller: this.fb.group(new FormContact(new Contact({ firstname: null, lastname: null, email: null }))),
-        technical: this.fb.group(new FormContact(new Contact({ firstname: null, lastname: null, email: null }))),
-      }),
-    };
-
-    if (this.fullFormMode) {
-      formOptions = {
-        ...formOptions,
-        name: [''],
-        legal_name: [''],
-        address: this.fb.group(
-          new FormAddress(
-            new Address({
-              street: null,
-              city: null,
-              country: null,
-              postcode: null,
-            }),
-          ),
-        ),
-        company: this.fb.group(new FormCompany({ siret: '', company: new Company() })),
-        bank: this.fb.group(new FormBank(new Bank()), { validators: bankValidator }),
-      };
-    }
-
-    this.operatorForm = this.fb.group(formOptions);
 
     this.updateValidation();
   }

--- a/dashboard/src/app/modules/operator/modules/operator-ui/components/operator-list-view/operator-list-view.component.ts
+++ b/dashboard/src/app/modules/operator/modules/operator-ui/components/operator-list-view/operator-list-view.component.ts
@@ -74,8 +74,10 @@ export class OperatorListViewComponent extends DestroyObservable implements OnIn
 
   pipeEdit(operator: any) {
     this.isCreating = false;
-    this.operator$.next(operator);
-    this.showForm = true;
+    this._operatorService.get(operator._id).subscribe((newOperator) => {
+      this.operator$.next(newOperator);
+      this.showForm = true;
+    });
   }
 
   close() {

--- a/dashboard/src/app/modules/territory/modules/territory-ui/components/territory-form/territory-form.component.ts
+++ b/dashboard/src/app/modules/territory/modules/territory-ui/components/territory-form/territory-form.component.ts
@@ -150,31 +150,11 @@ export class TerritoryFormComponent extends DestroyObservable implements OnInit,
       };
     }
 
-    this.territoryForm = this.fb.group(formOptions);
-
-    this.updateValidation();
-  }
-
-  private updateValidation() {
-    if (this.territoryForm && this.fullFormMode) {
-      this.territoryForm.controls['name'].setValidators(this.fullFormMode ? Validators.required : null);
-      this.territoryForm.controls['shortname'].setValidators(this.fullFormMode ? Validators.max(12) : null);
-    }
-  }
-
-  // todo: ugly ...
-  private setTerritoryFormValue(territory: Territory) {
-    // base values for form
-    this.editedId = territory ? territory._id : null;
-
-    const territoryEd = new Territory(territory);
-    const formValues = territoryEd.toFormValues(this.fullFormMode);
-
-    this.territoryForm.setValue(formValues);
-
     const stopFindCompany = new Subject();
 
     const companyFormGroup: FormGroup = <FormGroup>this.territoryForm.controls.company;
+
+    this.territoryForm = this.fb.group(formOptions);
     companyFormGroup.controls.siret.valueChanges
       .pipe(
         throttleTime(300),
@@ -212,6 +192,26 @@ export class TerritoryFormComponent extends DestroyObservable implements OnInit,
             }
           });
       });
+
+    this.updateValidation();
+  }
+
+  private updateValidation() {
+    if (this.territoryForm && this.fullFormMode) {
+      this.territoryForm.controls['name'].setValidators(this.fullFormMode ? Validators.required : null);
+      this.territoryForm.controls['shortname'].setValidators(this.fullFormMode ? Validators.max(12) : null);
+    }
+  }
+
+  // todo: ugly ...
+  private setTerritoryFormValue(territory: Territory) {
+    // base values for form
+    this.editedId = territory ? territory._id : null;
+
+    const territoryEd = new Territory(territory);
+    const formValues = territoryEd.toFormValues(this.fullFormMode);
+
+    this.territoryForm.setValue(formValues);
   }
 
   private checkPermissions(): void {

--- a/dashboard/src/app/modules/user/modules/ui-user/components/create-edit-user-form/create-edit-user-form.component.ts
+++ b/dashboard/src/app/modules/user/modules/ui-user/components/create-edit-user-form/create-edit-user-form.component.ts
@@ -137,12 +137,6 @@ export class CreateEditUserFormComponent extends DestroyObservable implements On
 
   updateValidators(isCreating: boolean = this.isCreating, groupEditable: boolean = this.groupEditable) {
     if (this.createEditUserForm) {
-      /*
-      Object.keys(this.createEditUserForm.controls).forEach((key) => {
-        this.createEditUserForm.controls[key].setErrors(null);
-      });
-       */
-
       this.createEditUserForm.controls['role'].setValidators(isCreating ? Validators.required : null);
       this.createEditUserForm.controls['group'].setValidators(groupEditable ? Validators.required : null);
       console.log('operatorEditable', this.operatorEditable, 'territoryEditable', this.territoryEditable);


### PR DESCRIPTION
Correctifs :
fix #489 : déprécier / fixé par l'API company / Siret auto
fix #493 : déprécier / fixé par l'API company / Siret auto
fix #561 : utilisation d'un terme plus générique
fix #563 : correctifs texte changement email
fix #487 : Email perdu, correction de regression dans l'API
fix #448 : Utilisateur sans ou prénom ne pouvant pas être modifié : corrigé car le DB et le front ne laisse plus passé se genre de cas
