### PR TITLE
update apiUrl for new dev server in angular env

### DIFF
--- a/dashboard/src/environments/environment.dev.ts
+++ b/dashboard/src/environments/environment.dev.ts
@@ -1,5 +1,5 @@
 export const environment = {
   production: false,
   name: 'dev',
-  apiUrl: 'https://pdc-api-dev.scalingo.io/',
+  apiUrl: 'https://pdc-dev.osc-fr1.scalingo.io/',
 };


### PR DESCRIPTION
Mise à jour du domaine de l'API `dev` suite à la migration du serveur sur la région OSC-FR1