### PR TITLE
Cacher la statistique opérateur

### DIFF
--- a/dashboard/src/app/modules/stat/config/stat.ts
+++ b/dashboard/src/app/modules/stat/config/stat.ts
@@ -4,7 +4,8 @@ export const petrolFactor = 0.0000636;
 export const co2Factor = 0.000195;
 
 export const TERRITORY_STATS = {
-  names: <statDataNameType[]>['trips', 'distance', 'carpoolers', 'petrol', 'co2', 'carpoolersPerVehicule', 'operators'],
+  // todo: add 'operators' when ready
+  names: <statDataNameType[]>['trips', 'distance', 'carpoolers', 'petrol', 'co2', 'carpoolersPerVehicule'],
   defaultGraphName: <statDataNameType>'trips',
 };
 


### PR DESCRIPTION
En attendant de finir l'implémentation, la statistique du nombre d'opérateur n'est pas affichée. 

