### PR TITLE
Fix/dev fixes

### DIFF
--- a/api/db/migrations/trip/20191125100001_create_trip_view.up.sql
+++ b/api/db/migrations/trip/20191125100001_create_trip_view.up.sql
@@ -11,9 +11,9 @@ CREATE MATERIALIZED VIEW trip.list AS (
     extract(hour from cp.datetime) as dayhour,
 
     cis.town as start_town,
-    tis.territory_id::int as start_territory_id,
+    tis.territory_id as start_territory_id,
     cie.town as end_town,
-    tie.territory_id::int as end_territory_id,
+    tie.territory_id as end_territory_id,
     (CASE WHEN cp.distance <> null THEN cp.distance ELSE (cp.meta::json->>'calc_distance')::int END) as distance,
     cp.seats as seats,
     cp.is_driver as is_driver

--- a/api/db/migrations/trip/20191125100001_create_trip_view.up.sql
+++ b/api/db/migrations/trip/20191125100001_create_trip_view.up.sql
@@ -15,10 +15,21 @@ CREATE MATERIALIZED VIEW trip.list AS (
     cie.town as end_town,
     tie.territory_id::int as end_territory_id,
     (CASE WHEN cp.distance <> null THEN cp.distance ELSE (cp.meta::json->>'calc_distance')::int END) as distance,
-    cp.seats as seats
+    cp.seats as seats,
+    cp.is_driver as is_driver
   FROM carpool.carpools as cp
   JOIN common.insee as cis ON cp.start_insee = cis._id
   JOIN common.insee as cie ON cp.end_insee = cie._id
   JOIN territory.insee as tis ON cp.start_insee = tis._id
   JOIN territory.insee as tie ON cp.end_insee = tie._id
 );
+
+CREATE INDEX ON trip.list (start_territory_id);
+CREATE INDEX ON trip.list (end_territory_id);
+CREATE INDEX ON trip.list (operator_id);
+CREATE INDEX ON trip.list (datetime);
+CREATE INDEX ON trip.list (weekday);
+CREATE INDEX ON trip.list (dayhour);
+CREATE INDEX ON trip.list (distance);
+CREATE INDEX ON trip.list (operator_class);
+CREATE INDEX ON trip.list (is_driver);

--- a/api/db/migrations/trip/20191125100001_create_trip_view.up.sql
+++ b/api/db/migrations/trip/20191125100001_create_trip_view.up.sql
@@ -3,7 +3,7 @@ CREATE MATERIALIZED VIEW trip.list AS (
     cp.trip_id as trip_id,
     cp.start_insee as start_insee,
     cp.end_insee as end_insee,
-    cp.operator_id as operator_id,
+    cp.operator_id::int as operator_id,
     cp.operator_class as operator_class,
 
     cp.datetime as datetime,
@@ -11,9 +11,9 @@ CREATE MATERIALIZED VIEW trip.list AS (
     extract(hour from cp.datetime) as dayhour,
 
     cis.town as start_town,
-    tis.territory_id as start_territory_id,
+    tis.territory_id::int as start_territory_id,
     cie.town as end_town,
-    tie.territory_id as end_territory_id,
+    tie.territory_id::int as end_territory_id,
     (CASE WHEN cp.distance <> null THEN cp.distance ELSE (cp.meta::json->>'calc_distance')::int END) as distance,
     cp.seats as seats
   FROM carpool.carpools as cp

--- a/api/db/migrations/trip/20191125100001_create_trip_view.up.sql
+++ b/api/db/migrations/trip/20191125100001_create_trip_view.up.sql
@@ -3,7 +3,7 @@ CREATE MATERIALIZED VIEW trip.list AS (
     cp.trip_id as trip_id,
     cp.start_insee as start_insee,
     cp.end_insee as end_insee,
-    cp.operator_id::int as operator_id,
+    cp.operator_id as operator_id,
     cp.operator_class as operator_class,
 
     cp.datetime as datetime,

--- a/api/services/trip/src/providers/TripRepositoryProvider.ts
+++ b/api/services/trip/src/providers/TripRepositoryProvider.ts
@@ -157,7 +157,7 @@ export class TripRepositoryProvider implements TripRepositoryInterface {
       text: `
       SELECT
         datetime::date as day,
-        sum(distance*seats)::int as distance,
+        sum(distance*seats)::bigint as distance,
         sum(seats+1)::int as carpoolers,
         count(*)::int as trip,
         '0'::int as trip_subsidized,

--- a/api/services/trip/src/providers/TripRepositoryProvider.ts
+++ b/api/services/trip/src/providers/TripRepositoryProvider.ts
@@ -53,12 +53,12 @@ export class TripRepositoryProvider implements TripRepositoryInterface {
           switch (filter.key) {
             case 'territory_id':
               return {
-                text: '(start_territory_id = ANY ($#::int[]) OR end_territory_id = ANY ($#::int[]))',
+                text: '(start_territory_id = ANY ($#::text[]) OR end_territory_id = ANY ($#::text[]))',
                 values: [filter.value, filter.value],
               };
             case 'operator_id':
               return {
-                text: 'operator_id = ANY ($#::int[])',
+                text: 'operator_id = ANY ($#::text[])',
                 values: [filter.value],
               };
             case 'status':
@@ -140,6 +140,9 @@ export class TripRepositoryProvider implements TripRepositoryInterface {
     }
 
     if (!orderedFilters.text.length) return null;
+
+    // remove duplicates
+    orderedFilters.text.push('is_driver = false');
 
     const whereClauses = `WHERE ${orderedFilters.text.join(' AND ')}`;
     const whereClausesValues = orderedFilters.values;

--- a/api/services/trip/src/providers/TripRepositoryProvider.ts
+++ b/api/services/trip/src/providers/TripRepositoryProvider.ts
@@ -63,11 +63,25 @@ export class TripRepositoryProvider implements TripRepositoryInterface {
               };
             case 'status':
               throw new Error('Unimplemented');
+
             case 'date':
+              if (filter.value.start && filter.value.end) {
+                return {
+                  text: '($#::timestamp <= datetime AND datetime <= $#::timestamp)',
+                  values: [filter.value.start, filter.value.end],
+                };
+              }
+              if (filter.value.start) {
+                return {
+                  text: '$#::timestamp <= datetime',
+                  values: [filter.value.start],
+                };
+              }
               return {
-                text: '(datetime BETWEEN $#::timestamp AND $#::timestamp)',
-                values: [filter.value.start, filter.value.end],
+                text: 'datetime <= $#::timestamp',
+                values: [filter.value.end],
               };
+
             case 'ranks':
               return {
                 text: 'operator_class = ANY ($#::text[])',

--- a/api/services/user/src/actions/MeUserAction.ts
+++ b/api/services/user/src/actions/MeUserAction.ts
@@ -1,5 +1,6 @@
 import { Action as AbstractAction } from '@ilos/core';
 import { handler, UnauthorizedException } from '@ilos/common';
+import { get } from 'lodash';
 
 import { handlerConfig, ParamsInterface, ResultInterface } from '../shared/user/me.contract';
 import { ActionMiddleware } from '../shared/common/ActionMiddlewareInterface';
@@ -18,7 +19,7 @@ export class MeUserAction extends AbstractAction {
   }
 
   public async handle(params: ParamsInterface, context: UserContextInterface): Promise<ResultInterface> {
-    const _id = context.call && context.call.user && context.call.user._id ? context.call.user._id : null;
+    const _id = get(context, 'call.user._id', null);
     if (!_id) {
       throw new UnauthorizedException('No connected user');
     }

--- a/dashboard/src/app/core/entities/authentication/user.ts
+++ b/dashboard/src/app/core/entities/authentication/user.ts
@@ -103,12 +103,13 @@ export class User extends BaseUser
 
     formVal.phone = formVal.phone ? formVal.phone : null;
 
+    delete this.permissions;
+
     if (this._id) {
       delete this.territory_id;
       delete this.operator_id;
       delete this.group;
       delete this.role;
-      delete this.permissions;
     } else {
       if (formVal.territory_id) this.email = formVal.email;
       else delete this.territory_id;

--- a/dashboard/src/app/modules/filter/services/filter.service.ts
+++ b/dashboard/src/app/modules/filter/services/filter.service.ts
@@ -43,8 +43,10 @@ export class FilterService {
     if (filter.date.start === null && filter.date.end === null) {
       delete filter.date;
     } else {
-      if (filter.date.start) filter.date.start = filter.date.start.toDate();
-      if (filter.date.end) filter.date.end = filter.date.end.toDate();
+      // set start at the beginning of the day and end at the end.
+      // DO NOT convert to UTC to avoid days overlapping!
+      if (filter.date.start) filter.date.start = `${filter.date.start.toISOString(true).substr(0, 10)}T00:00:00Z`;
+      if (filter.date.end) filter.date.end = `${filter.date.end.toISOString(true).substr(0, 10)}T23:59:59Z`;
     }
 
     if (filter.hour.start === null && filter.hour.end === null) {


### PR DESCRIPTION
Fix des routes `trip:stats` et `trip:list` pour les vues stats et liste détaillées du registre, des opérateurs et des territoires.

Correction de la date de début et de fin des filtres pour éviter les overlap à minuit dus au décalage horaire (ex. date de début le 1 mai à Paris --> 30 avril à 22h00 en UTC).
Permet à l'utilisateur d'avoir des résultats en phase avec le filtre choisi.