### PR TITLE
return a 401 on unfound user in user:me call

### DIFF
--- a/api/services/user/src/actions/MeUserAction.ts
+++ b/api/services/user/src/actions/MeUserAction.ts
@@ -24,6 +24,9 @@ export class MeUserAction extends AbstractAction {
       throw new UnauthorizedException('No connected user');
     }
 
-    return this.userRepository.find(_id);
+    const user = await this.userRepository.find(_id);
+    if (!user) throw new UnauthorizedException('No connected user');
+
+    return user;
   }
 }


### PR DESCRIPTION
Return a 401 instead of crashing (500) when the cookie is valid in the Express session (Redis) but the user isn't found in the database. (Happens on `dev` and `staging` after flashing the database)