### PR TITLE
Améliorer les filtres sur les périodes en prenant en compte les…

### DIFF
--- a/dashboard/cypress/support/expectedApiPayload/expectedCampaign.ts
+++ b/dashboard/cypress/support/expectedApiPayload/expectedCampaign.ts
@@ -33,7 +33,7 @@ export class CypressExpectedCampaign {
     .startOf('day');
   static endMoment = Cypress.moment()
     .add(3, 'months')
-    .startOf('day');
+    .endOf('day');
 
   static maxAmount = 10000;
   static maxTrips = 50000;
@@ -57,10 +57,10 @@ export class CypressExpectedCampaign {
   static secondRestrictionAmount = 6;
 
   static get(): Campaign {
-    const campaign = new Campaign({
+    return new Campaign({
       _id: null,
-      start_date: CypressExpectedCampaign.startMoment.toDate(),
-      end_date: CypressExpectedCampaign.endMoment.toDate(),
+      start_date: <any>CypressExpectedCampaign.startMoment.toISOString(),
+      end_date: <any>CypressExpectedCampaign.endMoment.toISOString(),
       unit: IncentiveUnitEnum.EUR,
       description: CypressExpectedCampaign.description,
       name: CypressExpectedCampaign.campaignName,
@@ -159,11 +159,6 @@ export class CypressExpectedCampaign {
       parent_id: null,
       territory_id: cypress_logging_users[UserGroupEnum.TERRITORY].territory_id,
     });
-
-    campaign.start_date = <any>campaign.start_date.toISOString();
-    campaign.end_date = <any>campaign.end_date.toISOString();
-
-    return campaign;
   }
 
   static getAfterCreate(): Campaign {

--- a/dashboard/cypress/support/expectedApiPayload/expectedFilter.ts
+++ b/dashboard/cypress/support/expectedApiPayload/expectedFilter.ts
@@ -14,13 +14,13 @@ export const filterStartMoment = Cypress.moment()
   .startOf('day');
 export const filterEndMoment = Cypress.moment()
   .add(3, 'months')
-  .startOf('day');
+  .endOf('day');
 
 export const expectedFilter: FilterInterface = {
   campaign_id: [campaignStubs[0]._id, campaignStubs[1]._id],
   date: <any>{
-    start: `${filterStartMoment.toISOString(true).substr(0, 10)}T00:00:00Z`,
-    end: `${filterEndMoment.toISOString(true).substr(0, 10)}T23:59:59Z`,
+    start: filterStartMoment.toISOString(),
+    end: filterEndMoment.toISOString(),
   },
   hour: {
     start: 18,

--- a/dashboard/cypress/support/reusables/filter/cypress_filter.ts
+++ b/dashboard/cypress/support/reusables/filter/cypress_filter.ts
@@ -1,3 +1,5 @@
+import * as moment from 'moment';
+
 import { UserGroupEnum } from '~/core/enums/user/user-group.enum';
 import { DEFAULT_TRIP_LIMIT } from '~/core/const/filter.const';
 
@@ -106,6 +108,17 @@ export function cypress_filter(e2e = false, group: UserGroupEnum) {
 
         const filter = {
           ...expectedFilter,
+          hour: {
+            // time zone hacky fix until ddb has timezones
+            start: moment()
+              .hours(expectedFilter.hour.start)
+              .utc()
+              .hours(),
+            end: moment()
+              .hours(expectedFilter.hour.end)
+              .utc()
+              .hours(),
+          },
           skip: 0,
           limit: DEFAULT_TRIP_LIMIT,
         };

--- a/dashboard/cypress/support/reusables/user/users.cypress.ts
+++ b/dashboard/cypress/support/reusables/user/users.cypress.ts
@@ -2,7 +2,6 @@ import { UserGroupEnum } from '~/core/enums/user/user-group.enum';
 
 /// <reference types="Cypress" />
 import { cypress_addUser } from './addUser.cypress';
-import { expectedNewUsers } from '../../expectedApiPayload/expectedUser';
 import { closeNotification } from '../notification.cypress';
 
 export function cypress_users(e2e = false) {
@@ -26,10 +25,4 @@ export function cypress_users(e2e = false) {
     cypress_addUser(UserGroupEnum.OPERATOR);
   });
   closeNotification();
-
-  // update territory
-
-  // update operator
-
-  // delete user
 }

--- a/dashboard/src/app/modules/campaign/services/campaign-formating.service.ts
+++ b/dashboard/src/app/modules/campaign/services/campaign-formating.service.ts
@@ -484,8 +484,8 @@ export class CampaignFormatingService {
       rules: campaignRetributionRules,
       global_rules: campaignGlobalRetributionRules,
       // format dates : moment --> Date
-      start_date: campaignUx.start.toDate(),
-      end_date: campaignUx.end.toDate(),
+      start_date: <any>campaignUx.start.startOf('day').toISOString(),
+      end_date: <any>campaignUx.end.endOf('day').toISOString(),
     });
 
     //  remove empty or null values

--- a/dashboard/src/app/modules/filter/services/filter.service.ts
+++ b/dashboard/src/app/modules/filter/services/filter.service.ts
@@ -50,9 +50,8 @@ export class FilterService {
       delete filter.date;
     } else {
       // set start at the beginning of the day and end at the end.
-      // DO NOT convert to UTC to avoid days overlapping!
-      if (filter.date.start) filter.date.start = `${filter.date.start.toISOString(true).substr(0, 10)}T00:00:00Z`;
-      if (filter.date.end) filter.date.end = `${filter.date.end.toISOString(true).substr(0, 10)}T23:59:59Z`;
+      if (filter.date.start) filter.date.start = filter.date.start.startOf('day').toDate();
+      if (filter.date.end) filter.date.end = filter.date.end.endOf('day').toDate();
     }
 
     if (filter.hour.start === null && filter.hour.end === null) {

--- a/dashboard/src/app/modules/filter/services/filter.service.ts
+++ b/dashboard/src/app/modules/filter/services/filter.service.ts
@@ -2,11 +2,11 @@
 import { Injectable } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
 import * as _ from 'lodash';
+import * as moment from 'moment';
 
 import { FilterUxInterface } from '~/core/interfaces/filter/filterUxInterface';
 import { Filter } from '~/core/entities/filter/filter';
 import { FilterInterface } from '~/core/interfaces/filter/filterInterface';
-import { FilterModule } from '~/modules/filter/filter.module';
 import { InseeAndTerritoryInterface } from '~/core/entities/campaign/ux-format/incentive-filters';
 
 @Injectable({
@@ -58,14 +58,22 @@ export class FilterService {
       delete filter.hour;
     } else {
       // only get hours
+      // time zone hacky fix until ddb has timezones
       if (filter.hour.start && filter.hour.start.length > 1) {
-        filter.hour.start = Number(filter.hour.start.slice(0, 2));
+        filter.hour.start = moment()
+          .hours(filter.hour.start.slice(0, 2))
+          .utc()
+          .hours();
       } else {
         filter.hour.start = 0;
       }
 
       if (filter.hour.end && filter.hour.end.length > 1) {
-        filter.hour.end = Number(filter.hour.end.slice(0, 2));
+        // time zone hacky fix until ddb has timezones
+        filter.hour.end = moment()
+          .hours(filter.hour.end.slice(0, 2))
+          .utc()
+          .hours();
       } else {
         filter.hour.end = 23;
       }

--- a/dashboard/src/app/modules/stat/services/stat-filtered.service.ts
+++ b/dashboard/src/app/modules/stat/services/stat-filtered.service.ts
@@ -4,6 +4,7 @@ import { BehaviorSubject, Observable } from 'rxjs';
 import { HttpClient } from '@angular/common/http';
 import { map, take, tap } from 'rxjs/operators';
 import * as _ from 'lodash';
+import * as moment from 'moment';
 
 import { JsonRPCService } from '~/core/services/api/json-rpc.service';
 import { JsonRPCParam } from '~/core/entities/api/jsonRPCParam';
@@ -39,6 +40,13 @@ export class StatFilteredService {
     }
     if (user && user.group === UserGroupEnum.OPERATOR) {
       params['operator_id'] = [user.operator_id];
+    }
+
+    if ('date' in filter && filter.date.start) {
+      params.date.start = filter.date.start.toISOString();
+    }
+    if ('date' in filter && filter.date.end) {
+      params.date.end = filter.date.end.toISOString();
     }
     this._loading$.next(true);
     const jsonRPCParam = new JsonRPCParam(`trip:stats`, params);

--- a/dashboard/src/app/modules/trip/pages/trip-export/trip-export.component.ts
+++ b/dashboard/src/app/modules/trip/pages/trip-export/trip-export.component.ts
@@ -49,8 +49,11 @@ export class TripExportComponent implements OnInit {
   private initForm() {
     const start = moment()
       .subtract(1, 'month')
+      .startOf('day')
       .toDate();
-    const end = new Date();
+    const end = moment()
+      .endOf('day')
+      .toDate();
     this.exportFilterForm = this._fb.group({
       date: this._fb.group({
         start: [start],

--- a/dashboard/src/app/modules/trip/pages/trip-list/trip-list.component.ts
+++ b/dashboard/src/app/modules/trip/pages/trip-list/trip-list.component.ts
@@ -81,6 +81,7 @@ export class TripListComponent extends DestroyObservable implements OnInit {
     if (this.tripService.loading) {
       return;
     }
+
     this.tripService
       .load(filter)
       .pipe(takeUntil(this.destroy$))

--- a/dashboard/src/app/modules/trip/services/trip.service.ts
+++ b/dashboard/src/app/modules/trip/services/trip.service.ts
@@ -59,8 +59,12 @@ export class TripService {
     // map moment to date
     const params = {
       date: {
-        start: moment(filter.date.start).toDate(),
-        end: moment(filter.date.end).toDate(),
+        start: moment(filter.date.start)
+          .startOf('day')
+          .toISOString(),
+        end: moment(filter.date.end)
+          .endOf('day')
+          .toISOString(),
       },
     };
     const loggedUser = this._authService.user;
@@ -82,6 +86,12 @@ export class TripService {
     }
     if (loggedUser && loggedUser.group === UserGroupEnum.OPERATOR) {
       params['operator_id'] = [loggedUser.operator_id];
+    }
+    if ('date' in filter && filter.date.start) {
+      params.date.start = filter.date.start.toISOString();
+    }
+    if ('date' in filter && filter.date.end) {
+      params.date.end = filter.date.end.toISOString();
     }
     this._listFilters = params;
     this._loading$.next(true);


### PR DESCRIPTION
Au niveau des filtres ( campagne, trajets, stats, export ) le "start" est au début de la journée, le "end" à la fin de la journée et les données sont envoyé au format UTC en prenant en compte le décalage lié au fuseau horaire de la france métropolitaine. 

ex: début : 3 mai 2019 ==> start : 2019-05-02T22:00:00.000Z
fin : 5 mai 2019 ==> start : 2019-05-02T23:59:59.999Z