### PR TITLE
Cache des statistiques

### DIFF
--- a/api/services/trip/src/config/cache.ts
+++ b/api/services/trip/src/config/cache.ts
@@ -1,0 +1,4 @@
+/**
+ * cache expiration in hours (used in stat_cache)
+ */
+export const expireInHours = 6;

--- a/api/services/trip/src/providers/StatCacheRepositoryProvider.ts
+++ b/api/services/trip/src/providers/StatCacheRepositoryProvider.ts
@@ -1,4 +1,4 @@
-import { provider } from '@ilos/common';
+import { provider, ConfigInterfaceResolver } from '@ilos/common';
 import { PostgresConnection } from '@ilos/connection-postgres';
 
 import { StatInterface } from '../interfaces/StatInterface';
@@ -6,6 +6,13 @@ import {
   StatCacheRepositoryProviderInterface,
   StatCacheRepositoryProviderInterfaceResolver,
 } from '../interfaces/StatCacheRepositoryProviderInterface';
+
+interface TargetInterface {
+  public?: boolean;
+  operator_id?: number;
+  territory_id?: number;
+}
+
 /*
  * Trip stat repository
  */
@@ -15,22 +22,31 @@ import {
 export class StatCacheRepositoryProvider implements StatCacheRepositoryProviderInterface {
   public readonly table = 'trip.stat_cache';
 
-  constructor(public connection: PostgresConnection) {}
+  constructor(public connection: PostgresConnection, private config: ConfigInterfaceResolver) {}
 
   public async getGeneralOrBuild(fn: Function): Promise<StatInterface[]> {
-    const result = await this.connection.getClient().query(`
-        SELECT
-          data
-        FROM ${this.table}
-        WHERE is_public = true AND operator_id IS NULL AND territory_id IS NULL
-        AND (extract(epoch from age(now(), updated_at)) / 3600) < 24
-        LIMIT 1
-      `);
+    const result = await this.connection.getClient().query({
+      text: `
+      SELECT
+        data
+      FROM ${this.table}
+      WHERE is_public = true AND operator_id IS NULL AND territory_id IS NULL
+      AND (extract(epoch from age(now(), updated_at)) / 3600) < $1
+      LIMIT 1
+    `,
+      values: [this.config.get('cache.expireInHours', 24)],
+    });
+
     if (result.rowCount !== 1) {
+      console.log('[stat cache miss] public');
+
       const data = await fn();
       await this.save({ public: true }, data);
       return data;
     }
+
+    console.log('[stat cache hit] public');
+
     return result.rows[0].data;
   }
 
@@ -41,16 +57,21 @@ export class StatCacheRepositoryProvider implements StatCacheRepositoryProviderI
           data
         FROM ${this.table}
         WHERE territory_id = $1::int
-        AND extract(hour from age(now(), updated_at)) < 24
+        AND (extract(epoch from age(now(), updated_at)) / 3600) < $2
         LIMIT 1
       `,
-      values: [territory_id],
+      values: [territory_id, this.config.get('cache.expireInHours', 24)],
     });
     if (result.rowCount !== 1) {
+      console.log(`[stat cache miss] territory ${territory_id}`);
+
       const data = await fn();
       await this.save({ territory_id, public: false }, data);
       return data;
     }
+
+    console.log(`[stat cache hit] territory ${territory_id}`);
+
     return result.rows[0].data;
   }
 
@@ -61,29 +82,36 @@ export class StatCacheRepositoryProvider implements StatCacheRepositoryProviderI
           data
         FROM ${this.table}
         WHERE operator_id = $1::int
-        AND extract(hour from age(now(), updated_at)) < 24
+        AND (extract(epoch from age(now(), updated_at)) / 3600) < $2
         LIMIT 1
       `,
-      values: [operator_id],
+      values: [operator_id, this.config.get('cache.expireInHours', 24)],
     });
     if (result.rowCount !== 1) {
+      console.log(`[stat cache miss] operator ${operator_id}`);
+
       const data = await fn();
       await this.save({ operator_id, public: false }, data);
       return data;
     }
+
+    console.log(`[stat cache hit] operator ${operator_id}`);
+
     return result.rows[0].data;
   }
 
-  protected async save(
-    target: {
-      public?: boolean;
-      operator_id?: number;
-      territory_id?: number;
-    },
-    data: StatInterface,
-  ): Promise<void> {
-    const query = {
-      text: `
+  /**
+   * Save the stat_cache entry
+   */
+  protected async save(target: TargetInterface, data: StatInterface): Promise<void> {
+    // first, clean up the matching target before recreating
+    // UNIQUE index fails on NULL values. It is safer to force delete
+    // the entry before redoing the insert.
+    await this.cleanup(target);
+
+    try {
+      const result = await this.connection.getClient().query({
+        text: `
         INSERT INTO ${this.table} (
           is_public,
           territory_id,
@@ -95,24 +123,45 @@ export class StatCacheRepositoryProvider implements StatCacheRepositoryProviderI
           $3::int,
           $4::json
         )
-        ON CONFLICT (is_public, territory_id, operator_id)
-        DO UPDATE SET
-          data = $4::json,
-          updated_at = $5
       `,
-      values: [
-        'public' in target ? target.public : false,
-        target.territory_id,
-        target.operator_id,
-        JSON.stringify(data),
-        new Date(),
-      ],
-    };
+        values: [
+          'public' in target ? target.public : false,
+          target.territory_id,
+          target.operator_id,
+          JSON.stringify(data),
+        ],
+      });
 
-    const result = await this.connection.getClient().query(query);
-    if (result.rowCount !== 1) {
-      throw new Error(`Unable to create or update stats cache for ${JSON.stringify(target)}`);
+      if (result.rowCount !== 1) {
+        throw new Error(`Unable to create or update stats cache for ${JSON.stringify(target)}`);
+      }
+
+      return;
+    } catch (e) {
+      console.log('[stat cache save]', e.message);
     }
-    return;
+  }
+
+  /**
+   * Remove the matching stat_cache entry
+   */
+  protected async cleanup(target: TargetInterface): Promise<boolean> {
+    try {
+      // make sure the _id are numbers and write them in the query to avoid complex building of the values array
+      const territoryClause = target.territory_id
+        ? `territory_id=${Number(target.territory_id)}`
+        : 'territory_id IS NULL';
+      const operatorClause = target.operator_id ? `operator_id=${Number(target.operator_id)}` : 'operator_id IS NULL';
+
+      const deleted = await this.connection.getClient().query({
+        text: `DELETE FROM ${this.table} WHERE is_public=$1::boolean AND ${territoryClause} AND ${operatorClause}`,
+        values: [!!target.public],
+      });
+
+      return deleted.rowCount === 1;
+    } catch (e) {
+      console.log('[stat cache cleanup]', e.message);
+      return false;
+    }
   }
 }


### PR DESCRIPTION
#786 

Fix de l'invalidation de la cache des statistiques pour les stats globales, opérateur et territoire.

- [x] Utilisation de la config pour définir l'expiration en heures.
- [x] Configuré sur 6 heures.
- [x] Log des _Hit_ et _Miss_