### PR TITLE
use ilos@0.4.1 on master branch

### DIFF
--- a/api/scalingo/prebuild.sh
+++ b/api/scalingo/prebuild.sh
@@ -8,6 +8,7 @@ yarn global add npm-run-all lerna typescript
 # install ilos dev branch
 git clone https://github.com/betagouv/ilos
 cd ilos
-git checkout dev
+# 2020/03/02 use tagged master@0.4.1 until ilos is published or completely cleaned
+git checkout 0.4.1
 yarn
 yarn build


### PR DESCRIPTION
Pour pouvoir appliquer les mises à jour de Ilos sur sa branche `dev`, on taggue la branche `master` de l'application en 0.4.1 dans le script de déploiement. Jusque là, la version utilisée était `dev`.