### PR TITLE
Refacto/policy process dev

### DIFF
--- a/api/db/migrations/20200212223138-create-idx-trip-id.js
+++ b/api/db/migrations/20200212223138-create-idx-trip-id.js
@@ -1,0 +1,8 @@
+'use strict';
+
+var { createMigration } = require('../helpers/createMigration');
+var { setup, up, down } = createMigration(['policy/20200212223138_create_idx_trip_id'], __dirname);
+
+exports.setup = setup;
+exports.up = up;
+exports.down = down;

--- a/api/db/migrations/20200304000000-carpool-create-operator-trip-idx.js
+++ b/api/db/migrations/20200304000000-carpool-create-operator-trip-idx.js
@@ -1,0 +1,8 @@
+'use strict';
+
+var { createMigration } = require('../helpers/createMigration');
+var { setup, up, down } = createMigration(['carpool/20200304000000_create_operator_trip_id_index'], __dirname);
+
+exports.setup = setup;
+exports.up = up;
+exports.down = down;

--- a/api/db/migrations/carpool/20191130003916_create_unique_index.down.sql
+++ b/api/db/migrations/carpool/20191130003916_create_unique_index.down.sql
@@ -1,1 +1,1 @@
-DROP INDEX IF EXISTS carpools_acquisition_id_is_driver_idx;
+DROP INDEX IF EXISTS carpool.carpools_acquisition_id_is_driver_idx;

--- a/api/db/migrations/carpool/20200304000000_create_operator_trip_id_index.down.sql
+++ b/api/db/migrations/carpool/20200304000000_create_operator_trip_id_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS carpool.carpools_operator_trip_id_idx;

--- a/api/db/migrations/carpool/20200304000000_create_operator_trip_id_index.up.sql
+++ b/api/db/migrations/carpool/20200304000000_create_operator_trip_id_index.up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS carpools_operator_trip_id_idx ON carpool.carpools (operator_trip_id);

--- a/api/db/migrations/policy/20200212223138_create_idx_trip_id.down.sql
+++ b/api/db/migrations/policy/20200212223138_create_idx_trip_id.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS policy.trips_trip_id_idx;

--- a/api/db/migrations/policy/20200212223138_create_idx_trip_id.up.sql
+++ b/api/db/migrations/policy/20200212223138_create_idx_trip_id.up.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS policy.trips_trip_id_idx;
+CREATE INDEX ON policy.trips (trip_id);

--- a/api/rebuild.sh
+++ b/api/rebuild.sh
@@ -4,9 +4,13 @@ echo "---------------------------------------------"
 echo "            Rebuid ilos && app               "
 echo "---------------------------------------------"
 
+if [ ${PWD##*/} != "api" ]; then
+  echo 'Error: run me from "api" folder';
+  exit 1;
+fi
+
 rm -rf ./**/dist
 rm -rf ./**/node_modules
-rm -rf ./node_modules
 
 cd ilos
 yarn

--- a/api/services/policy/src/actions/ApplyAction.ts
+++ b/api/services/policy/src/actions/ApplyAction.ts
@@ -25,23 +25,26 @@ export class ApplyAction extends AbstractAction {
   }
 
   public async handle(params: ParamsInterface): Promise<ResultInterface> {
-    // 1. Find trip
-    const trip = await this.tripRepository.findByTripId(params.trip_id);
-    if (!trip) {
-      // Throw Error ?
-      return;
-    }
+    // 1. Find trips
+    const trips = await this.tripRepository.findTripsById(params.trips);
 
-    // 2. Find applicable campaign for this trip
-    const campaigns = await this.campaignRepository.findApplicableCampaigns(trip.territories, trip.datetime);
+    for (const trip of trips) {
+      // 2. Find applicable campaign for this trip
+      const campaigns = await this.campaignRepository.findApplicableCampaigns(trip.territories, trip.datetime);
 
-    // 3. For each campaign, use policy engine to generate incentive
-    for (const campaign of campaigns) {
-      const incentives: IncentiveInterface[] = await this.engine.process(trip, campaign);
-      // 4. Save it to db
-      // TODO: add a create many method
-      for (const incentive of incentives) {
-        await this.incentiveRepository.create(incentive);
+      // 3. For each campaign, use policy engine to generate incentive
+      for (const campaign of campaigns) {
+        const incentives: IncentiveInterface[] = await this.engine.process(trip, campaign);
+        // 4. Save it to db
+        // TODO: add a create many method
+        for (const incentive of incentives) {
+          await this.incentiveRepository.create(incentive);
+        }
+
+        console.log(
+          `>>> Incentives calculated for ${(trip.people[0] as any).trip_id}:`,
+          incentives.map((i) => i.amount).join(','),
+        );
       }
     }
   }

--- a/api/services/policy/src/actions/ApplyAction.ts
+++ b/api/services/policy/src/actions/ApplyAction.ts
@@ -29,10 +29,6 @@ export class ApplyAction extends AbstractAction {
     console.log('>>> search trips');
     const trips = await this.tripRepository.findTripsById(params.trips);
 
-    // TMP - optimized for IDFM campaign
-    // console.log('>>> search applicable campaigns');
-    // const campaigns = await this.campaignRepository.findApplicableCampaigns([239], new Date('2020-01-27T00:00:00Z'));
-
     let allIncentives = [];
 
     console.log('>>> process campaigns for all trips');

--- a/api/services/policy/src/commands/PolicyProcessCommand.ts
+++ b/api/services/policy/src/commands/PolicyProcessCommand.ts
@@ -1,3 +1,24 @@
+/**
+ * Process policies on a set of trips from the `policy.trips` table
+ *
+ * ! Note: run all these commands in the workspace. prefix with before the policy:process action:
+ *         `docker-compose run api yarn workspace @pdc/service-policy ilos`
+ *
+ * The basic signature is to pass a trip_id as this :
+ * $ ilos policy:process {trip_id}
+ *
+ * Run the command as detached (requires workers to handle the jobs from the Redis queues)
+ * $ ilos policy:process {trip_id} -d
+ *
+ * Leaving the {trip_id} will process all matching trips which can be filtered by :
+ * -a / --after         pass a start date (e.g. '2020-01-01T00:00:00Z')
+ * -u / --until         pass an end date (e.g. '2020-01-01T00:00:00Z')
+ * -t / --territory     pass a territory ID from the `territory.territories` table
+ * -l / --limit         pass an integer to limit the number of trips to process
+ * -u / --database-uri  pass a PostgreSQL URI to connect. Defaults to APP_POSTGRES_URL env var
+ *                      e.g. postgresql://{username}:{password}@{host}:{port}/{database}
+ */
+
 import { command, CommandInterface, CommandOptionType, KernelInterfaceResolver } from '@ilos/common';
 import { promisify } from 'util';
 import { PostgresConnection, Cursor } from '@ilos/connection-postgres';
@@ -27,6 +48,11 @@ export class PolicyProcessCommand implements CommandInterface {
       description: 'Process all trip id given territory',
     },
     {
+      signature: '-b, --batch <batch>',
+      description: 'Batch size',
+      default: 1000,
+    },
+    {
       signature: '-l, --limit <limit>',
       description: 'Limit',
     },
@@ -37,19 +63,32 @@ export class PolicyProcessCommand implements CommandInterface {
     },
   ];
 
+  private context = {
+    call: {
+      user: {},
+    },
+    channel: {
+      service: 'campaign',
+      transport: 'cli',
+    },
+  };
+
   constructor(protected kernel: KernelInterfaceResolver) {}
 
-  public async call(id, options): Promise<string> {
-    const { territory, after, until, databaseUri, detach, limit } = options;
+  public async call(id: string, options): Promise<string> {
+    const { territory, after, until, databaseUri, detach, limit, batch } = options;
 
     if (id) {
-      await this.processOne(id, detach);
-      return `Operation done for ${id}`;
+      await this.process(id, detach);
+      console.log(`>> Operation done for ${id}`);
     }
 
     if (!databaseUri) {
-      return 'If id is not provided, you must specify a database uri';
+      console.log('>> If id is not provided, you must specify a database uri');
     }
+
+    // cap the batch size by the limit
+    const batchSize = limit && limit < batch ? limit : batch;
 
     let whereClause = '';
     const values = [];
@@ -62,7 +101,7 @@ export class PolicyProcessCommand implements CommandInterface {
       values.push(territory);
     } else if (after) {
       const afterDate = new Date(after);
-      console.log(`Processing for trip after ${afterDate.toISOString()}`);
+      console.log(`>> Processing for trip after ${afterDate.toISOString()}`);
       whereClause = `WHERE datetime > $1::timestamp`;
       values.push(afterDate);
     }
@@ -76,7 +115,7 @@ export class PolicyProcessCommand implements CommandInterface {
     const client = await connection.getClient().connect();
     const query = `
     SELECT
-      trip_id
+      distinct trip_id
     FROM ${this.table}
       ${whereClause}
       ${limit ? `LIMIT ${limit}` : ''}
@@ -85,47 +124,40 @@ export class PolicyProcessCommand implements CommandInterface {
     const cursor = client.query(new Cursor(query, values));
 
     const promisifiedCursorRead = promisify(cursor.read.bind(cursor));
-    const ROW_COUNT = 1000;
     let count = 0;
 
     do {
-      const result = await promisifiedCursorRead(ROW_COUNT);
+      const result = await promisifiedCursorRead(batchSize);
       count = result.length;
-      for (const line of result) {
-        const { trip_id } = line;
-        try {
-          await this.processOne(trip_id, detach);
-          console.log(`Operation done for ${trip_id}`);
-        } catch (e) {
-          console.log(`Operation failed for ${trip_id} (${e.message})`);
-        }
-      }
-    } while (count !== 0);
 
-    await client.release();
+      const ids = [];
+      for (const line of result) {
+        ids.push(line.trip_id);
+      }
+
+      try {
+        if (ids.length) {
+          await this.process(ids, detach);
+          console.log(`>> Operation done for batch ${result.length - count + 1}`);
+        }
+      } catch (e) {
+        console.log(`>> Operation failed for (${e.message})`);
+      }
+    } while (count > 1);
+
+    client.release();
     await connection.down();
-    return 'Done!';
+
+    return '';
   }
 
-  protected async processOne(tripId: number, detach = false): Promise<void> {
-    const context = {
-      call: {
-        user: {},
-      },
-      channel: {
-        service: 'campaign',
-        transport: 'cli',
-      },
-    };
-
-    const params: any = {
-      trip_id: tripId,
-    };
+  protected async process(ids: string | string[], detach = false): Promise<void> {
+    const trips = Array.isArray(ids) ? ids : [ids];
 
     if (detach) {
-      return this.kernel.notify(this.processAction, params, context);
+      return this.kernel.notify(this.processAction, { trips }, this.context);
     }
 
-    return this.kernel.call(this.processAction, params, context);
+    return this.kernel.call(this.processAction, { trips }, this.context);
   }
 }

--- a/api/services/policy/src/commands/PolicyProcessCommand.ts
+++ b/api/services/policy/src/commands/PolicyProcessCommand.ts
@@ -85,11 +85,11 @@ export class PolicyProcessCommand implements CommandInterface {
 
     if (id) {
       await this.process(id, detach);
-      console.log(`>> Operation done for ${id}`);
+      return `>> Operation done for ${id}`;
     }
 
     if (!databaseUri) {
-      console.log('>> If id is not provided, you must specify a database uri');
+      return '>> If id is not provided, you must specify a database uri';
     }
 
     // cap the batch size by the limit

--- a/api/services/policy/src/commands/PolicyProcessCommand.ts
+++ b/api/services/policy/src/commands/PolicyProcessCommand.ts
@@ -142,9 +142,12 @@ export class PolicyProcessCommand implements CommandInterface {
     const client = await connection.getClient().connect();
     const query = `
       SELECT
-        distinct trip_id
+        trip_id,
+        min(datetime) as min_date
       FROM ${this.table}
         ${whereClause}
+        GROUP BY trip_id
+        ORDER BY min_date ASC
         ${limit ? `LIMIT ${limit}` : ''}
     `;
 

--- a/api/services/policy/src/commands/PolicyProcessCommand.ts
+++ b/api/services/policy/src/commands/PolicyProcessCommand.ts
@@ -50,7 +50,7 @@ export class PolicyProcessCommand implements CommandInterface {
     {
       signature: '-b, --batch <batch>',
       description: 'Batch size',
-      default: 1000,
+      default: 10000,
     },
     {
       signature: '-l, --limit <limit>',
@@ -137,13 +137,13 @@ export class PolicyProcessCommand implements CommandInterface {
 
       try {
         if (ids.length) {
+          console.log(`>> process ${ids.length} trips`);
           await this.process(ids, detach);
-          console.log(`>> Operation done for batch ${result.length - count + 1}`);
         }
       } catch (e) {
         console.log(`>> Operation failed for (${e.message})`);
       }
-    } while (count > 1);
+    } while (count > 0);
 
     client.release();
     await connection.down();

--- a/api/services/policy/src/engine/rules/posts/IdfmRegular.spec.ts
+++ b/api/services/policy/src/engine/rules/posts/IdfmRegular.spec.ts
@@ -12,13 +12,35 @@ const meta = new MetadataWrapper(1, 'default', {});
 chai.use(chaiAsync);
 const { expect } = chai;
 const test = new IdfmRegular({
-  territory_id: 11,
-  paris_insee_code: ['75115', '75116'],
+  territory_id: 1,
+  paris_insee_code: [
+    '75056',
+    '75101',
+    '75102',
+    '75103',
+    '75104',
+    '75105',
+    '75106',
+    '75107',
+    '75108',
+    '75109',
+    '75110',
+    '75111',
+    '75112',
+    '75113',
+    '75114',
+    '75115',
+    '75116',
+    '75117',
+    '75118',
+    '75119',
+    '75120',
+  ],
 });
 
 const defaultTripParams = {
-  start_territory_id: 11,
-  end_territory_id: 11,
+  start_territory_id: 1,
+  end_territory_id: 1,
 };
 
 describe('Policy rule: IdfmRegular', () => {
@@ -457,5 +479,69 @@ describe('Policy rule: IdfmRegular', () => {
     };
     await test.apply(context);
     expect(context.result).to.eq(150);
+  });
+
+  it('case 14', async () => {
+    const trip = faker.trip([
+      {
+        ...defaultTripParams,
+        is_driver: true,
+        distance: 18948,
+        cost: 0,
+        start_insee: '75056', // would make it fail. No Paris to Paris
+        end_insee: '75056',
+      },
+      {
+        ...defaultTripParams,
+        is_driver: false,
+        distance: 6, // makes it fail. passenger dist must be > 2000
+        seats: 1,
+        cost: 0,
+        start_insee: '94021',
+        end_insee: '75056',
+      },
+    ]);
+
+    const context = {
+      stack: [],
+      result: 0,
+      person: trip.people[0],
+      trip,
+      meta,
+    };
+
+    await expect(test.apply(context)).to.rejectedWith(NotApplicableTargetException);
+  });
+
+  it('case 15', async () => {
+    const trip = faker.trip([
+      {
+        ...defaultTripParams,
+        is_driver: true,
+        distance: 15463,
+        cost: 0,
+        start_insee: '75056',
+        end_insee: '91027',
+      },
+      {
+        ...defaultTripParams,
+        is_driver: false,
+        distance: 15, // makes it fail. passenger dist must be > 2000
+        seats: 1,
+        cost: 0,
+        start_insee: '75056',
+        end_insee: '91027',
+      },
+    ]);
+
+    const context = {
+      stack: [],
+      result: 0,
+      person: trip.people[0],
+      trip,
+      meta,
+    };
+
+    await expect(test.apply(context)).to.rejectedWith(NotApplicableTargetException);
   });
 });

--- a/api/services/policy/src/engine/rules/posts/IdfmRegular.ts
+++ b/api/services/policy/src/engine/rules/posts/IdfmRegular.ts
@@ -31,10 +31,25 @@ export class IdfmRegular extends PostRule<IdfmParametersInterface> {
     }
 
     const eligibleJourneys = ctx.trip.people
+      // Uncomment this for debug
+      // .map((p) => {
+      //   console.log({
+      //     is_not_driver: !p.is_driver,
+      //     is_over_18: p.is_over_18 !== false,
+      //     start_idf: p.start_territory_id === this.parameters.territory_id,
+      //     end_idf: p.end_territory_id === this.parameters.territory_id,
+      //     not_pp: !(
+      //       this.parameters.paris_insee_code.indexOf(p.start_insee) >= 0 &&
+      //       this.parameters.paris_insee_code.indexOf(p.end_insee) >= 0
+      //     ),
+      //     above_2km: p.distance >= 2000,
+      //   });
+      //   return p;
+      // })
       .filter(
         (p) =>
           !p.is_driver &&
-          p.is_over_18 &&
+          p.is_over_18 !== false && // accept TRUE and NULL @issue #848
           p.start_territory_id === this.parameters.territory_id && // au départ
           p.end_territory_id === this.parameters.territory_id && // et à l'arrivée de l'ile de france
           p.distance >= 2000 && // trajet supérieur à 2km seulement
@@ -48,7 +63,7 @@ export class IdfmRegular extends PostRule<IdfmParametersInterface> {
       .sort((p1, p2) => (p1.distance > p2.distance ? 1 : p1.distance < p2.distance ? -1 : 0));
 
     if (eligibleJourneys.length === 0) {
-      throw new NotApplicableTargetException(IdfmRegular.slug);
+      throw new NotApplicableTargetException(`Campaign "${IdfmRegular.slug}" not Application on target`);
     }
 
     let result = 0;

--- a/api/services/policy/src/engine/rules/posts/IdfmStrikeJan2020.ts
+++ b/api/services/policy/src/engine/rules/posts/IdfmStrikeJan2020.ts
@@ -1,0 +1,72 @@
+import { NotApplicableTargetException } from '../../exceptions/NotApplicableTargetException';
+import { PostRule } from '../PostRule';
+import { RuleHandlerParamsInterface } from '../../interfaces';
+
+interface IdfmParametersInterface {
+  territory_id: number;
+  paris_insee_code: string[];
+}
+
+export class IdfmStrikeJan2020 extends PostRule<IdfmParametersInterface> {
+  static readonly slug: string = 'idfm_strike_jan2020';
+  static readonly description: string = 'Politique de grève IDFM janvier 2020';
+  static readonly schema: { [k: string]: any } = {
+    type: 'object',
+    required: ['territory_id', 'paris_insee_code'],
+    properties: {
+      territory_id: {
+        type: 'number',
+      },
+      paris_insee_code: {
+        type: 'array',
+        items: {
+          type: 'string',
+        },
+      },
+    },
+  };
+  async apply(ctx: RuleHandlerParamsInterface): Promise<void> {
+    if (!ctx.person.is_driver) {
+      throw new NotApplicableTargetException(IdfmStrikeJan2020.slug);
+    }
+
+    const eligibleJourneys = ctx.trip.people
+      // Uncomment this for debug
+      // .map((p) => {
+      //   console.log({
+      //     is_not_driver: !p.is_driver,
+      //     is_over_18: p.is_over_18 !== false,
+      //     start_idf: p.start_territory_id === this.parameters.territory_id,
+      //     end_idf: p.end_territory_id === this.parameters.territory_id,
+      //     not_pp: !(
+      //       this.parameters.paris_insee_code.indexOf(p.start_insee) >= 0 &&
+      //       this.parameters.paris_insee_code.indexOf(p.end_insee) >= 0
+      //     ),
+      //     above_2km: p.distance >= 2000,
+      //   });
+      //   return p;
+      // })
+      .filter(
+        (p) =>
+          !p.is_driver &&
+          p.is_over_18 !== false && // accept TRUE and NULL @issue #848
+          p.start_territory_id === this.parameters.territory_id && // au départ
+          p.end_territory_id === this.parameters.territory_id && // et à l'arrivée de l'ile de france
+          p.distance >= 2000 && // trajet supérieur à 2km seulement
+          !(
+            this.parameters.paris_insee_code.indexOf(p.start_insee) >= 0 &&
+            this.parameters.paris_insee_code.indexOf(p.end_insee) >= 0
+          ),
+        // mais pas Paris-Paris
+      )
+      .map((p) => ({ distance: p.distance, seats: p.seats }))
+      .sort((p1, p2) => (p1.distance > p2.distance ? 1 : p1.distance < p2.distance ? -1 : 0));
+
+    if (eligibleJourneys.length === 0) {
+      throw new NotApplicableTargetException(`Campaign "${IdfmStrikeJan2020.slug}" not Application on target`);
+    }
+
+    // give 4€ for any distance
+    ctx.result = 400;
+  }
+}

--- a/api/services/policy/src/engine/rules/posts/index.ts
+++ b/api/services/policy/src/engine/rules/posts/index.ts
@@ -2,5 +2,6 @@ import { MetaAmountPost } from './MetaAmountPost';
 import { StaticRuleInterface } from '../../interfaces';
 import { MetaTripPost } from './MetaTripPost';
 import { IdfmRegular } from './IdfmRegular';
+import { IdfmStrikeJan2020 } from './IdfmStrikeJan2020';
 
-export const posts: StaticRuleInterface[] = [MetaAmountPost, MetaTripPost, IdfmRegular];
+export const posts: StaticRuleInterface[] = [MetaAmountPost, MetaTripPost, IdfmRegular, IdfmStrikeJan2020];

--- a/api/services/policy/src/interfaces/IncentiveRepositoryProviderInterface.ts
+++ b/api/services/policy/src/interfaces/IncentiveRepositoryProviderInterface.ts
@@ -2,10 +2,14 @@ import { IncentiveInterface } from './IncentiveInterface';
 
 export interface IncentiveRepositoryProviderInterface {
   create(data: IncentiveInterface): Promise<void>;
+  createMany(data: IncentiveInterface[]): Promise<void>;
 }
 
 export abstract class IncentiveRepositoryProviderInterfaceResolver implements IncentiveRepositoryProviderInterface {
   async create(data: IncentiveInterface): Promise<void> {
+    throw new Error();
+  }
+  async createMany(data: IncentiveInterface[]): Promise<void> {
     throw new Error();
   }
 }

--- a/api/services/policy/src/interfaces/IncentiveRepositoryProviderInterface.ts
+++ b/api/services/policy/src/interfaces/IncentiveRepositoryProviderInterface.ts
@@ -1,12 +1,16 @@
+import { PoolClient } from '@ilos/connection-postgres';
+
 import { IncentiveInterface } from './IncentiveInterface';
 
+export type IncentiveCreateOptionsType = { connection?: PoolClient | null; release?: boolean };
+
 export interface IncentiveRepositoryProviderInterface {
-  create(data: IncentiveInterface): Promise<void>;
+  create(data: IncentiveInterface, options?: IncentiveCreateOptionsType): Promise<void>;
   createMany(data: IncentiveInterface[]): Promise<void>;
 }
 
 export abstract class IncentiveRepositoryProviderInterfaceResolver implements IncentiveRepositoryProviderInterface {
-  async create(data: IncentiveInterface): Promise<void> {
+  async create(data: IncentiveInterface, options?: IncentiveCreateOptionsType): Promise<void> {
     throw new Error();
   }
   async createMany(data: IncentiveInterface[]): Promise<void> {

--- a/api/services/policy/src/interfaces/TripRepositoryProviderInterface.ts
+++ b/api/services/policy/src/interfaces/TripRepositoryProviderInterface.ts
@@ -1,11 +1,11 @@
 import { TripInterface } from './TripInterface';
 
 export interface TripRepositoryProviderInterface {
-  findByTripId(id: string): Promise<TripInterface>;
+  findTripsById(ids: string[]): Promise<TripInterface[]>;
 }
 
 export abstract class TripRepositoryProviderInterfaceResolver implements TripRepositoryProviderInterface {
-  async findByTripId(id: string): Promise<TripInterface> {
+  async findTripsById(ids: string[]): Promise<TripInterface[]> {
     throw new Error();
   }
 }

--- a/api/services/policy/src/interfaces/index.ts
+++ b/api/services/policy/src/interfaces/index.ts
@@ -10,6 +10,7 @@ export {
 export {
   IncentiveRepositoryProviderInterface,
   IncentiveRepositoryProviderInterfaceResolver,
+  IncentiveCreateOptionsType,
 } from './IncentiveRepositoryProviderInterface';
 export {
   TripRepositoryProviderInterface,

--- a/api/services/policy/src/providers/IncentiveRepositoryProvider.ts
+++ b/api/services/policy/src/providers/IncentiveRepositoryProvider.ts
@@ -1,10 +1,11 @@
 import { provider } from '@ilos/common';
-import { PostgresConnection } from '@ilos/connection-postgres';
+import { PostgresConnection, PoolClient } from '@ilos/connection-postgres';
 
 import {
   IncentiveInterface,
   IncentiveRepositoryProviderInterface,
   IncentiveRepositoryProviderInterfaceResolver,
+  IncentiveCreateOptionsType,
 } from '../interfaces';
 
 @provider({
@@ -12,10 +13,17 @@ import {
 })
 export class IncentiveRepositoryProvider implements IncentiveRepositoryProviderInterface {
   public readonly table = 'policy.incentives';
+  private connSingleton: Promise<PoolClient> = null;
 
   constructor(protected connection: PostgresConnection) {}
 
-  async create(data: IncentiveInterface): Promise<void> {
+  async create(data: IncentiveInterface, options: IncentiveCreateOptionsType = {}): Promise<void> {
+    const opts = { connection: null, release: true, ...options };
+
+    if (opts.connection === null) {
+      opts.connection = await this.getConnection();
+    }
+
     const query = {
       text: `
         INSERT INTO ${this.table} (
@@ -35,26 +43,42 @@ export class IncentiveRepositoryProvider implements IncentiveRepositoryProviderI
       values: [data.carpool_id, data.policy_id, data.amount, data.status || 'validated', data.detail || '{}'],
     };
 
-    const result = await this.connection.getClient().query(query);
+    const result = await opts.connection.query(query);
     if (result.rowCount !== 1) {
       throw new Error(`Unable to create incentive (${JSON.stringify(data)})`);
+    }
+
+    if (opts.release) {
+      opts.connection.release();
     }
 
     return;
   }
 
   async createMany(data: IncentiveInterface[]): Promise<void> {
+    const conn: PoolClient = await this.getConnection();
+
     try {
-      await this.connection.getClient().query('BEGIN');
+      await conn.query('BEGIN');
 
       for (const item of data) {
-        await this.create(item);
+        await this.create(item, { connection: conn, release: false });
       }
 
-      await this.connection.getClient().query('COMMIT');
+      await conn.query('COMMIT');
     } catch (e) {
       console.log('Failed Incentive CreateMany: ', e.message);
-      await this.connection.getClient().query('ROLLBACK');
+      await conn.query('ROLLBACK');
     }
+
+    conn.release();
+  }
+
+  private async getConnection(): Promise<PoolClient> {
+    if (this.connSingleton === null) {
+      this.connSingleton = this.connection.getClient().connect();
+    }
+
+    return this.connSingleton;
   }
 }

--- a/api/services/policy/src/providers/IncentiveRepositoryProvider.ts
+++ b/api/services/policy/src/providers/IncentiveRepositoryProvider.ts
@@ -42,4 +42,19 @@ export class IncentiveRepositoryProvider implements IncentiveRepositoryProviderI
 
     return;
   }
+
+  async createMany(data: IncentiveInterface[]): Promise<void> {
+    try {
+      await this.connection.getClient().query('BEGIN');
+
+      for (const item of data) {
+        await this.create(item);
+      }
+
+      await this.connection.getClient().query('COMMIT');
+    } catch (e) {
+      console.log('Failed Incentive CreateMany: ', e.message);
+      await this.connection.getClient().query('ROLLBACK');
+    }
+  }
 }

--- a/api/services/policy/src/providers/IncentiveRepositoryProvider.ts
+++ b/api/services/policy/src/providers/IncentiveRepositoryProvider.ts
@@ -13,15 +13,13 @@ import {
 })
 export class IncentiveRepositoryProvider implements IncentiveRepositoryProviderInterface {
   public readonly table = 'policy.incentives';
-  private connSingleton: Promise<PoolClient> = null;
-
   constructor(protected connection: PostgresConnection) {}
 
   async create(data: IncentiveInterface, options: IncentiveCreateOptionsType = {}): Promise<void> {
     const opts = { connection: null, release: true, ...options };
 
     if (opts.connection === null) {
-      opts.connection = await this.getConnection();
+      opts.connection = await this.connection.getClient().connect();
     }
 
     const query = {
@@ -56,7 +54,7 @@ export class IncentiveRepositoryProvider implements IncentiveRepositoryProviderI
   }
 
   async createMany(data: IncentiveInterface[]): Promise<void> {
-    const conn: PoolClient = await this.getConnection();
+    const conn: PoolClient = await this.connection.getClient().connect();
 
     try {
       await conn.query('BEGIN');
@@ -72,13 +70,5 @@ export class IncentiveRepositoryProvider implements IncentiveRepositoryProviderI
     }
 
     conn.release();
-  }
-
-  private async getConnection(): Promise<PoolClient> {
-    if (this.connSingleton === null) {
-      this.connSingleton = this.connection.getClient().connect();
-    }
-
-    return this.connSingleton;
   }
 }

--- a/api/services/policy/src/providers/TripRepositoryProvider.ts
+++ b/api/services/policy/src/providers/TripRepositoryProvider.ts
@@ -11,65 +11,78 @@ export class TripRepositoryProvider implements TripRepositoryProviderInterface {
 
   constructor(protected connection: PostgresConnection) {}
 
-  async findByTripId(trip_id: string): Promise<TripInterface> {
-    const query = {
-      text: `
-        SELECT
-          identity_uuid,
-          carpool_id,
-          operator_id::integer,
-          operator_class,
-          is_over_18,
-          is_driver,
-          has_travel_pass,
-          datetime,
-          start_insee,
-          end_insee,
-          seats,
-          duration,
-          distance,
-          cost,
-          start_territory_id,
-          end_territory_id
-        FROM ${this.table} WHERE trip_id = $1`,
-      values: [trip_id],
-    };
-
-    const results = await this.connection.getClient().query(query);
+  async findTripsById(trip_ids: string[]): Promise<TripInterface[]> {
+    const results = await this.connection.getClient().query(`
+      SELECT
+        trip_id,
+        identity_uuid,
+        carpool_id,
+        operator_id::integer,
+        operator_class,
+        is_over_18,
+        is_driver,
+        has_travel_pass,
+        datetime,
+        start_insee,
+        end_insee,
+        seats,
+        duration,
+        distance,
+        cost,
+        start_territory_id,
+        end_territory_id
+      FROM ${this.table}
+      WHERE trip_id IN ('${trip_ids.join("','")}')
+      ORDER BY trip_id
+    `);
 
     if (results.rowCount < 1) {
       return;
     }
 
-    let hasDriver = false;
-
-    const trip = results.rows.reduce(
-      (acc, row) => {
-        if (row.is_driver && hasDriver) {
-          return acc;
-        }
-
-        if (row.is_driver && !hasDriver) {
-          hasDriver = true;
-        }
-
-        acc.people.push(row);
-        acc.territories.add(row.start_territory_id);
-        acc.territories.add(row.end_territory_id);
-        acc.datetime = acc.datetime === null ? row.datetime : acc.datetime > row.datetime ? row.datetime : acc.datetime;
+    // TODO group by trip_id
+    const iterator = results.rows
+      .reduce((acc, trip, idx) => {
+        const value = acc.get(trip.trip_id) || [];
+        value.push(trip);
+        acc.set(trip.trip_id, value);
 
         return acc;
-      },
-      {
-        territories: new Set(),
-        datetime: null,
-        people: [],
-      },
-    );
+      }, new Map())
+      .values();
 
-    return {
-      ...trip,
-      territories: [...trip.territories],
-    };
+    return [...iterator].map((tuple) => {
+      let hasDriver = false;
+
+      const trip = tuple.reduce(
+        (acc, row) => {
+          if (row.is_driver && hasDriver) {
+            return acc;
+          }
+
+          if (row.is_driver && !hasDriver) {
+            hasDriver = true;
+          }
+
+          acc.people.push(row);
+          acc.territories.add(row.start_territory_id);
+          acc.territories.add(row.end_territory_id);
+          acc.datetime =
+            acc.datetime === null ? row.datetime : acc.datetime > row.datetime ? row.datetime : acc.datetime;
+
+          return acc;
+        },
+        {
+          territories: new Set(),
+          datetime: null,
+          people: [],
+        },
+      );
+
+      return {
+        ...trip,
+        territories: [...trip.territories],
+      };
+    });
   }
 }

--- a/api/shared/policy/apply.contract.ts
+++ b/api/shared/policy/apply.contract.ts
@@ -22,7 +22,7 @@
 // }
 
 export interface ParamsInterface {
-  trip_id: string;
+  trips: string[];
 }
 
 export type ResultInterface = void;

--- a/api/yarn.lock
+++ b/api/yarn.lock
@@ -1175,9 +1175,9 @@
     "@types/node" "*"
 
 "@types/bull@^3.5.11":
-  version "3.12.0"
-  resolved "https://registry.yarnpkg.com/@types/bull/-/bull-3.12.0.tgz#683d7a08db64823076c4b5ac00eea73e5b6947fa"
-  integrity sha512-oKj9X8bxBF7OyAsCPGg2hu9msQPM/WwIRJfUHd0xzmKDMYOBepzbWdIuQDoX1xyvDskdjbW2Io7chbxqARae7A==
+  version "3.12.1"
+  resolved "https://registry.yarnpkg.com/@types/bull/-/bull-3.12.1.tgz#dcf1ac40c4314a3dfa1a4a12662ce7201b2e4efa"
+  integrity sha512-mn1xmqKBNxllUGuOSBDOvsRpLHPDTSOsGQiHTv6t1gvGtIc/L1IFsN3YTmwf3AZenKzUcBQDGFLrCKt+abhrvQ==
   dependencies:
     "@types/ioredis" "*"
 
@@ -1188,10 +1188,15 @@
   dependencies:
     "@types/chai" "*"
 
-"@types/chai@*", "@types/chai@^4.1.7", "@types/chai@^4.2.0", "@types/chai@^4.2.7":
+"@types/chai@*", "@types/chai@^4.2.0", "@types/chai@^4.2.7":
   version "4.2.8"
   resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.2.8.tgz#c8d645506db0d15f4aafd4dfa873f443ad87ea59"
   integrity sha512-U1bQiWbln41Yo6EeHMr+34aUhvrMVyrhn9lYfPSpLTCrZlGxU4Rtn1bocX+0p2Fc/Jkd2FanCEXdw0WNfHHM0w==
+
+"@types/chai@^4.1.7":
+  version "4.2.9"
+  resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.2.9.tgz#194332625ed2ae914aef00b8d5ca3b77e7924cc6"
+  integrity sha512-NeXgZj+MFL4izGqA4sapdYzkzQG+MtGra9vhQ58dnmDY++VgJaRUws+aLVV5zRJCYJl/8s9IjMmhiUw1WsKSmw==
 
 "@types/color-name@^1.1.1":
   version "1.1.1"
@@ -2015,20 +2020,20 @@ builtins@^1.0.3:
   integrity sha1-y5T662HIaWRR2zZTThQi+U8K7og=
 
 bull@^3.7.0:
-  version "3.12.1"
-  resolved "https://registry.yarnpkg.com/bull/-/bull-3.12.1.tgz#ced62d0afca81c9264b44f1b6f39243df5d2e73f"
-  integrity sha512-X3bSP7gTqPXLYVSyUtQuTOqZuU0GwVbV304Et84Z8bxYP60R1VD3FUOLsESVRA9LIUEOWVH3hE8MFqlszmO0Gw==
+  version "3.13.0"
+  resolved "https://registry.yarnpkg.com/bull/-/bull-3.13.0.tgz#232935f9a5c0c87be6eb2aa95e434ff115bacd7a"
+  integrity sha512-nP8ICMNHGYDNt6cgPqBPm90n57xA+/Om2wI2EGEOIJtWutjrYt8JAWiiFYjZKrly9UkKlrfG9qgOCwFFdS5xaw==
   dependencies:
     cron-parser "^2.13.0"
     debuglog "^1.0.0"
-    get-port "^5.0.0"
+    get-port "^5.1.1"
     ioredis "^4.14.1"
     lodash "^4.17.15"
-    p-timeout "^3.1.0"
-    promise.prototype.finally "^3.1.1"
+    p-timeout "^3.2.0"
+    promise.prototype.finally "^3.1.2"
     semver "^6.3.0"
-    util.promisify "^1.0.0"
-    uuid "^3.3.3"
+    util.promisify "^1.0.1"
+    uuid "^3.4.0"
 
 byline@^5.0.0:
   version "5.0.0"
@@ -4051,7 +4056,7 @@ get-port@^4.2.0:
   resolved "https://registry.yarnpkg.com/get-port/-/get-port-4.2.0.tgz#e37368b1e863b7629c43c5a323625f95cf24b119"
   integrity sha512-/b3jarXkH8KJoOMQc3uVGHASwGLPq3gSFJ7tgJm2diza+bydJPTGOibin2steecKeOylE8oY2JERlVWkAJO6yw==
 
-get-port@^5.0.0:
+get-port@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/get-port/-/get-port-5.1.1.tgz#0469ed07563479de6efb986baf053dcd7d4e3193"
   integrity sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ==
@@ -6136,9 +6141,9 @@ mocha@^7.0.0:
     yargs-unparser "1.6.0"
 
 mock-fs@^4.9.0:
-  version "4.10.4"
-  resolved "https://registry.yarnpkg.com/mock-fs/-/mock-fs-4.10.4.tgz#4eaa3d6f7da2f44e1f3dd6b462cbbcb7b082e3d4"
-  integrity sha512-gDfZDLaPIvtOusbusLinfx6YSe2YpQsDT8qdP41P47dQ/NQggtkHukz7hwqgt8QvMBmAv+Z6DGmXPyb5BWX2nQ==
+  version "4.11.0"
+  resolved "https://registry.yarnpkg.com/mock-fs/-/mock-fs-4.11.0.tgz#0828107e4b843a6ba855ecebfe3c6e073b69db92"
+  integrity sha512-Yp4o3/ZA15wsXqJTT+R+9w2AYIkD1i80Lds47wDbuUhOvQvm+O2EfjFZSz0pMgZZSPHRhGxgcd2+GL4+jZMtdw==
 
 modify-values@^1.0.0:
   version "1.0.1"
@@ -6868,7 +6873,7 @@ p-reduce@^1.0.0:
   resolved "https://registry.yarnpkg.com/p-reduce/-/p-reduce-1.0.0.tgz#18c2b0dd936a4690a529f8231f58a0fdb6a47dfa"
   integrity sha1-GMKw3ZNqRpClKfgjH1ig/bakffo=
 
-p-timeout@^3.1.0:
+p-timeout@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/p-timeout/-/p-timeout-3.2.0.tgz#c7e17abc971d2a7962ef83626b35d635acf23dfe"
   integrity sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==
@@ -7112,9 +7117,9 @@ pg-connection-string@0.1.3:
   integrity sha1-2hhHsglA5C7hSSvq9l1J2RskXfc=
 
 pg-cursor@^2.0.0:
-  version "2.1.5"
-  resolved "https://registry.yarnpkg.com/pg-cursor/-/pg-cursor-2.1.5.tgz#912096479cd8263b9eba38e84d9d64c641a55c0a"
-  integrity sha512-+LSPIxw7awEhQrb8sqT2Sxr+8RoEAzURMX18oaOQebItqaO94WUh3deHQs9vh3m14E2lz7q7ebRl1s/ODfJAkQ==
+  version "2.1.6"
+  resolved "https://registry.yarnpkg.com/pg-cursor/-/pg-cursor-2.1.6.tgz#1cca3f30525a7d02c39ffb4d48383a55f963beb5"
+  integrity sha512-61En061/NFsfKOY0EvIdcl1l2FDvoeFSD2RLe57qA0rX0TbNxQ1TK9JOZaTTKrxk6L8opiHAv/IRAoHFMacKEQ==
 
 pg-int8@1.0.1:
   version "1.0.1"
@@ -7143,9 +7148,9 @@ pg-types@^2.1.0:
     postgres-interval "^1.1.0"
 
 pg@^7.12.1:
-  version "7.18.1"
-  resolved "https://registry.yarnpkg.com/pg/-/pg-7.18.1.tgz#67f59c47a99456fcb34f9fe53662b79d4a992f6d"
-  integrity sha512-1KtKBKg/zWrjEEv//klBbVOPGucuc7HHeJf6OEMueVcUeyF3yueHf+DvhVwBjIAe9/97RAydO/lWjkcMwssuEw==
+  version "7.18.2"
+  resolved "https://registry.yarnpkg.com/pg/-/pg-7.18.2.tgz#4e219f05a00aff4db6aab1ba02f28ffa4513b0bb"
+  integrity sha512-Mvt0dGYMwvEADNKy5PMQGlzPudKcKKzJds/VbOeZJpb6f/pI3mmoXX0JksPgI3l3JPP/2Apq7F36O63J7mgveA==
   dependencies:
     buffer-writer "2.0.0"
     packet-reader "1.0.0"
@@ -7300,7 +7305,7 @@ promise-retry@^1.1.1:
     err-code "^1.0.0"
     retry "^0.10.0"
 
-promise.prototype.finally@^3.1.1:
+promise.prototype.finally@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/promise.prototype.finally/-/promise.prototype.finally-3.1.2.tgz#b8af89160c9c673cefe3b4c4435b53cfd0287067"
   integrity sha512-A2HuJWl2opDH0EafgdjwEw7HysI8ff/n4lW4QEVBCUXFk9QeGecBWv0Deph0UmLe3tTNYegz8MOjsVuE6SMoJA==
@@ -8887,7 +8892,12 @@ tslib@1.9.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.0.tgz#e37a86fda8cbbaf23a057f473c9f4dc64e5fc2e8"
   integrity sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ==
 
-tslib@^1.7.1, tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
+tslib@^1.7.1, tslib@^1.8.0:
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.11.1.tgz#eb15d128827fbee2841549e171f45ed338ac7e35"
+  integrity sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==
+
+tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
   integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==
@@ -9180,7 +9190,7 @@ util-promisify@^2.1.0:
   dependencies:
     object.getownpropertydescriptors "^2.0.3"
 
-util.promisify@^1.0.0:
+util.promisify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/util.promisify/-/util.promisify-1.0.1.tgz#6baf7774b80eeb0f7520d8b81d07982a59abbaee"
   integrity sha512-g9JpC/3He3bm38zsLupWryXHoEcS22YHthuPQSJdMy6KNrzIRzWqcsHzD/WUnqe45whVou4VIsPew37DoXWNrA==
@@ -9195,7 +9205,7 @@ utils-merge@1.0.1:
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=
 
-uuid@^3.0.1, uuid@^3.3.2, uuid@^3.3.3:
+uuid@^3.0.1, uuid@^3.3.2, uuid@^3.3.3, uuid@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==


### PR DESCRIPTION
- Ajout de `--until` pour cadrer la date de fin
- Ajout de `--operator` pour limiter à un opérateur
- Réécriture de la génération de la clause `WHERE`
- Envoi d'un batch de trips pour limiter le nombre de requêtes a la DB.

A tester avant de fusionner : 
- [ ] Utilisation du calcul en flux tendu quand les preuves arrivent dans carpool.
- [x] Passer un [id] seul à la commande
- [x] Passer -t / --territory
- [x] Passer -o / --operator
- [x] Passer -a / --after
- [x] Passer -u / --until
- [x] Mixer les commandes entre elles
