### PR TITLE
Hotfix/fkeys application check

### DIFF
--- a/api/proxy/src/middlewares/serverTokenMiddleware.ts
+++ b/api/proxy/src/middlewares/serverTokenMiddleware.ts
@@ -71,6 +71,11 @@ export function serverTokenMiddleware(kernel: KernelInterface, tokenProvider: To
         throw new ForbiddenException();
       }
 
+      // cast foreign keys to integer
+      if ('o' in payload && typeof payload.o === 'string') {
+        payload.o = parseInt(payload.o, 10);
+      }
+
       // Check and get the app
       const app = await checkApplication(kernel, payload);
 


### PR DESCRIPTION
Cast de la valeur de `owner_id` du token applicatif en _integer_ pour permettre la vérification de celle-ci contre les données de la table `application.applications` qui ont été migrée.

Permet de conserver la compatibilité des tokens applicatifs utilisés par les opérateurs.