### PR TITLE
cleanup and fix interfaces

### DIFF
--- a/api/services/acquisition/src/actions/LogErrorAction.ts
+++ b/api/services/acquisition/src/actions/LogErrorAction.ts
@@ -21,6 +21,6 @@ export class LogErrorAction extends AbstractAction {
     // clean up sensitive data
     delete params.headers.authorization;
     delete params.headers.cookie;
-    return this.repo.create({ error_resolved: false, ...params });
+    return this.repo.log({ error_resolved: false, ...params });
   }
 }

--- a/api/services/acquisition/src/actions/LogRequestAction.ts
+++ b/api/services/acquisition/src/actions/LogRequestAction.ts
@@ -1,16 +1,16 @@
+import { get } from 'lodash';
 import { Action as AbstractAction } from '@ilos/core';
 import { handler, ContextType } from '@ilos/common';
 
 import { handlerConfig, ParamsInterface, ResultInterface } from '../shared/acquisition/logrequest.contract';
-// import { alias } from '../shared/acquisition/logerror.schema';
 import { ErrorRepositoryProviderInterfaceResolver } from '../interfaces/ErrorRepositoryProviderInterface';
+import { ErrorStage } from '../shared/acquisition/common/interfaces/AcquisitionErrorInterface';
 
 @handler({
   ...handlerConfig,
   middlewares: [
-    // ['channel.service.only', ['proxy']],
+    ['channel.service.only', ['proxy']],
     // ['can', ['acquisition.logrequest']],
-    // ['validate', alias],
   ],
 })
 export class LogRequestAction extends AbstractAction {
@@ -22,6 +22,17 @@ export class LogRequestAction extends AbstractAction {
     // clean up sensitive data
     delete params.headers.cookie;
 
-    await this.repo.create(params);
+    await this.repo.log({
+      error_stage: ErrorStage.Acquisition,
+      error_line: null,
+      operator_id: get(context, 'call.user.operator_id', 0),
+      journey_id: params.journey_id,
+      source: 'logrequest',
+      error_message: null,
+      error_code: null,
+      auth: get(context, 'call.user'),
+      headers: get(context, 'call.metadata.req.headers', {}),
+      body: params,
+    });
   }
 }

--- a/api/services/acquisition/src/interfaces/ErrorRepositoryProviderInterface.ts
+++ b/api/services/acquisition/src/interfaces/ErrorRepositoryProviderInterface.ts
@@ -1,27 +1,42 @@
 import { AcquisitionErrorInterface } from '../shared/acquisition/common/interfaces/AcquisitionErrorInterface';
-import { ParamsInterface as ResolveInterface } from '../shared/acquisition/resolveerror.contract';
-import { ParamsInterface as SearchErrorsInterface } from '../shared/acquisition/searcherrors.contract';
-import { ParamsInterface as SummaryErrorsInterface } from '../shared/acquisition/summaryerrors.contract';
-import { ResultInterface as SummaryResultInterface } from '../shared/acquisition/summaryerrors.contract';
+import {
+  ParamsInterface as LogParamsInterface,
+  ResultInterface as LogResultInterface,
+} from '../shared/acquisition/logerror.contract';
+import {
+  ParamsInterface as ResolveParamsInterface,
+  ResultInterface as ResolveResultInterface,
+} from '../shared/acquisition/resolveerror.contract';
+import {
+  ParamsInterface as SearchParamsInterface,
+  ResultInterface as SearchResultInterface,
+} from '../shared/acquisition/searcherrors.contract';
+import {
+  ParamsInterface as SummaryParamsInterface,
+  ResultInterface as SummaryResultInterface,
+} from '../shared/acquisition/summaryerrors.contract';
 
 export interface ErrorRepositoryProviderInterface {
-  create(data: AcquisitionErrorInterface): Promise<{ _id: number; created_at: Date }>;
+  search(data: SearchParamsInterface): Promise<AcquisitionErrorInterface[]>;
+  log(data: LogParamsInterface): Promise<LogResultInterface>;
+  resolve(data: ResolveParamsInterface): Promise<number>;
+  summary(filter: SummaryParamsInterface): Promise<SummaryResultInterface>;
 }
 
 export abstract class ErrorRepositoryProviderInterfaceResolver implements ErrorRepositoryProviderInterface {
-  async search(data: SearchErrorsInterface): Promise<AcquisitionErrorInterface[]> {
+  async search(data: SearchParamsInterface): Promise<SearchResultInterface> {
     throw new Error('Not implemented');
   }
 
-  async create(data: AcquisitionErrorInterface): Promise<{ _id: number; created_at: Date }> {
+  async log(data: LogParamsInterface): Promise<LogResultInterface> {
     throw new Error('Not implemented');
   }
 
-  async resolve(data: ResolveInterface): Promise<number> {
+  async resolve(data: ResolveParamsInterface): Promise<ResolveResultInterface> {
     throw new Error('Not implemented');
   }
 
-  async summary(filter: SummaryErrorsInterface): Promise<SummaryResultInterface> {
+  async summary(filter: SummaryParamsInterface): Promise<SummaryResultInterface> {
     throw new Error('Not implemented');
   }
 }

--- a/api/services/acquisition/src/providers/ErrorPgRepositoryProvider.ts
+++ b/api/services/acquisition/src/providers/ErrorPgRepositoryProvider.ts
@@ -5,11 +5,22 @@ import {
   ErrorRepositoryProviderInterface,
   ErrorRepositoryProviderInterfaceResolver,
 } from '../interfaces/ErrorRepositoryProviderInterface';
-import { ParamsInterface as CreateInterface } from '../shared/acquisition/logerror.contract';
-import { ParamsInterface as ResolveInterface } from '../shared/acquisition/resolveerror.contract';
-import { ParamsInterface as SearchErrorsInterface } from '../shared/acquisition/searcherrors.contract';
-import { ParamsInterface as SummaryErrorsInterface } from '../shared/acquisition/summaryerrors.contract';
-import { ResultInterface as SummaryResultInterface } from '../shared/acquisition/summaryerrors.contract';
+import {
+  ParamsInterface as LogParamsInterface,
+  ResultInterface as LogResultInterface,
+} from '../shared/acquisition/logerror.contract';
+import {
+  ParamsInterface as ResolveParamsInterface,
+  ResultInterface as ResolveResultInterface,
+} from '../shared/acquisition/resolveerror.contract';
+import {
+  ParamsInterface as SearchParamsInterface,
+  ResultInterface as SearchResultInterface,
+} from '../shared/acquisition/searcherrors.contract';
+import {
+  ParamsInterface as SummaryParamsInterface,
+  ResultInterface as SummaryResultInterface,
+} from '../shared/acquisition/summaryerrors.contract';
 import { AcquisitionErrorInterface } from '../shared/acquisition/common/interfaces/AcquisitionErrorInterface';
 
 @provider({
@@ -20,7 +31,7 @@ export class ErrorPgRepositoryProvider implements ErrorRepositoryProviderInterfa
 
   constructor(protected connection: PostgresConnection) {}
 
-  protected searchWhere(data: SearchErrorsInterface): { wheres: string[]; values: any[] } {
+  protected searchWhere(data: SearchParamsInterface): { wheres: string[]; values: any[] } {
     const wheres = [];
     const values = [];
 
@@ -60,7 +71,7 @@ export class ErrorPgRepositoryProvider implements ErrorRepositoryProviderInterfa
     };
   }
 
-  async summary(filter: SummaryErrorsInterface): Promise<SummaryResultInterface> {
+  async summary(filter: SummaryParamsInterface): Promise<SummaryResultInterface> {
     const { wheres, values } = this.searchWhere(filter);
 
     const query = {
@@ -81,7 +92,7 @@ export class ErrorPgRepositoryProvider implements ErrorRepositoryProviderInterfa
     return res;
   }
 
-  async search(filter: SearchErrorsInterface): Promise<AcquisitionErrorInterface[]> {
+  async search(filter: SearchParamsInterface): Promise<SearchResultInterface> {
     const { wheres, values } = this.searchWhere(filter);
 
     const query = {
@@ -92,7 +103,7 @@ export class ErrorPgRepositoryProvider implements ErrorRepositoryProviderInterfa
     return (await this.connection.getClient().query<AcquisitionErrorInterface>(query)).rows;
   }
 
-  async resolve(data: ResolveInterface): Promise<number> {
+  async resolve(data: ResolveParamsInterface): Promise<ResolveResultInterface> {
     const query = {
       text: `
         UPDATE ${this.table} SET error_resolved = TRUE
@@ -104,7 +115,7 @@ export class ErrorPgRepositoryProvider implements ErrorRepositoryProviderInterfa
     return await (await this.connection.getClient().query(query)).rows.length;
   }
 
-  async create(data: CreateInterface): Promise<{ _id: number; created_at: Date }> {
+  async log(data: LogParamsInterface): Promise<LogResultInterface> {
     let attempt: number;
     if (data.error_attempt == undefined) {
       const query = {

--- a/shared/acquisition/create.contract.ts
+++ b/shared/acquisition/create.contract.ts
@@ -1,9 +1,10 @@
 import { JourneyInterface } from '../common/interfaces/JourneyInterface';
 
-declare type ResultType = { journey_id: string; created_at: Date };
-
 export interface ParamsInterface extends JourneyInterface {}
-export type ResultInterface = ResultType | ResultType[];
+export interface ResultInterface {
+  journey_id: string;
+  created_at: Date;
+}
 export const handlerConfig = {
   service: 'acquisition',
   method: 'create',

--- a/shared/acquisition/logerror.contract.ts
+++ b/shared/acquisition/logerror.contract.ts
@@ -9,6 +9,7 @@ export interface ParamsInterface {
   error_message: string | null;
   error_code: string | null;
   error_line: number | null;
+  error_resolved?: boolean;
   auth: any;
   headers: any;
   body: any;

--- a/shared/acquisition/logrequest.contract.ts
+++ b/shared/acquisition/logrequest.contract.ts
@@ -1,13 +1,6 @@
-export interface ParamsInterface {
-  operator_id: number;
-  source: string;
-  error_message: string | null;
-  error_code: string | null;
-  error_line: number | null;
-  auth: any;
-  headers: any;
-  body: any;
-}
+import { ParamsInterface as LogErrorParamsInterface } from './logerror.contract';
+
+export interface ParamsInterface extends LogErrorParamsInterface {}
 
 export type ResultInterface = void;
 


### PR DESCRIPTION
Normalisation des interfaces d'entrée et sortie des actions. Nettoyage et fix de LogRequest.

Renommage de `create` en `log` pour enregistrer une erreur afin d'éviter la confusion avec `create` de Journey (notamment dans les interfaces).