### PR TITLE
remove outline on :focus

### DIFF
--- a/dashboard/src/styles.scss
+++ b/dashboard/src/styles.scss
@@ -71,3 +71,7 @@ a.link:visited {
   color: $color-primary-dark;
   text-decoration: underline;
 }
+
+:focus {
+  outline: none;
+}


### PR DESCRIPTION
fix outline on focused elements on Chrome-like browsers