### PR TITLE
change global_rules name max_trip_restriction. fix #914

### DIFF
--- a/api/db/migrations/20200921102502-fix-global-rule-name.js
+++ b/api/db/migrations/20200921102502-fix-global-rule-name.js
@@ -1,0 +1,8 @@
+'use strict';
+
+var { createMigration } = require('../helpers/createMigration');
+var { setup, up, down } = createMigration(['policy/20200921102502_fix_global_rule_name'], __dirname);
+
+exports.setup = setup;
+exports.up = up;
+exports.down = down;

--- a/api/db/migrations/policy/20200921102502_fix_global_rule_name.down.sql
+++ b/api/db/migrations/policy/20200921102502_fix_global_rule_name.down.sql
@@ -1,0 +1,5 @@
+-- replace rule name in all policies
+
+UPDATE policy.policies
+SET global_rules = REPLACE(global_rules::text, 'max_trip_restriction', 'max_trip_per_target_restriction')::json
+WHERE global_rules::text LIKE '%max_trip_restriction%';

--- a/api/db/migrations/policy/20200921102502_fix_global_rule_name.up.sql
+++ b/api/db/migrations/policy/20200921102502_fix_global_rule_name.up.sql
@@ -1,0 +1,5 @@
+-- replace rule name in all policies
+
+UPDATE policy.policies
+SET global_rules = REPLACE(global_rules::text, 'max_trip_per_target_restriction', 'max_trip_restriction')::json
+WHERE global_rules::text LIKE '%max_trip_per_target_restriction%';


### PR DESCRIPTION
Modification du nom de la règle `max_trip_per_target_restriction` en `max_trip_restriction` dans toutes les campagnes portant ce slug.
La règle a changé de nom sans que les données soient mises à jour.