### PR TITLE
Feature Flag

### DIFF
--- a/api/providers/middleware/src/FeatureFlag/FeatureFlagMiddleware.ts
+++ b/api/providers/middleware/src/FeatureFlag/FeatureFlagMiddleware.ts
@@ -1,0 +1,29 @@
+import { env } from '@ilos/core';
+import { middleware, MiddlewareInterface, ParamsType, ContextType, ResultType, NotFoundException } from '@ilos/common';
+
+export interface FeatureFlagOptions {
+  allow: string[];
+  deny: string[];
+}
+
+@middleware()
+export class FeatureFlagMiddleware implements MiddlewareInterface {
+  async process(
+    params: ParamsType,
+    context: ContextType,
+    next: Function,
+    environments: Partial<FeatureFlagOptions>,
+  ): Promise<ResultType> {
+    const appEnv = env('NODE_ENV') as string;
+
+    if ('allow' in environments && environments.allow.indexOf(appEnv) > -1) {
+      return next(params, context);
+    }
+
+    if ('deny' in environments && environments.deny.indexOf(appEnv) > -1) {
+      throw new NotFoundException('Missing action');
+    }
+
+    return next(params, context);
+  }
+}

--- a/api/providers/middleware/src/index.ts
+++ b/api/providers/middleware/src/index.ts
@@ -1,8 +1,10 @@
-export * from './ScopeToSelf/ScopeToSelfMiddleware';
-export * from './FilterOutput/FilterOutputMiddleware';
-export * from './ContentWhitelist/ContentWhitelistMiddleware';
-export * from './ContentBlacklist/ContentBlacklistMiddleware';
 export * from './ChannelTransport/ChannelTransportMiddleware';
+export * from './ContentBlacklist/ContentBlacklistMiddleware';
+export * from './ContentWhitelist/ContentWhitelistMiddleware';
 export * from './ContextExtract/ContextExtractMiddleware';
+export * from './FeatureFlag/FeatureFlagMiddleware';
+export * from './FilterOutput/FilterOutputMiddleware';
+export * from './ScopeToSelf/ScopeToSelfMiddleware';
+
 export { ChannelServiceBlacklistMiddleware } from './ChannelService/ChannelServiceBlacklistMiddleware';
 export { ChannelServiceWhitelistMiddleware } from './ChannelService/ChannelServiceWhitelistMiddleware';

--- a/api/proxy/src/HttpTransport.ts
+++ b/api/proxy/src/HttpTransport.ts
@@ -81,7 +81,8 @@ export class HttpTransport implements TransportInterface {
     this.registerStatsRoutes();
     this.registerAuthRoutes();
     this.registerApplicationRoutes();
-    this.registerCertificateRoutes();
+    // feature flag certificates until properly tested by operators
+    if (env('NODE_ENV') !== 'production') this.registerCertificateRoutes();
     this.registerAcquisitionRoutes();
     this.registerHonorRoutes();
     this.registerUptimeRoute();

--- a/api/services/certificate/src/ServiceProvider.ts
+++ b/api/services/certificate/src/ServiceProvider.ts
@@ -2,7 +2,7 @@ import { serviceProvider, NewableType, ExtensionInterface } from '@ilos/common';
 import { ServiceProvider as AbstractServiceProvider } from '@ilos/core';
 import { PostgresConnection } from '@ilos/connection-postgres';
 import { ValidatorExtension, ValidatorMiddleware } from '@pdc/provider-validator';
-import { ChannelServiceWhitelistMiddleware } from '@pdc/provider-middleware';
+import { ChannelServiceWhitelistMiddleware, FeatureFlagMiddleware } from '@pdc/provider-middleware';
 import { PermissionMiddleware } from '@pdc/provider-acl';
 import { DateProvider } from '@pdc/provider-date';
 import { QrcodeProvider } from '@pdc/provider-qrcode';
@@ -38,6 +38,7 @@ import { binding as listBinding } from './shared/certificate/list.schema';
     ['validate', ValidatorMiddleware],
     ['can', PermissionMiddleware],
     ['channel.service.only', ChannelServiceWhitelistMiddleware],
+    ['featureflag', FeatureFlagMiddleware],
   ],
   connections: [[PostgresConnection, 'connections.postgres']],
   handlers: [DownloadCertificateAction, CreateCertificateAction, FindCertificateAction, ListCertificateAction],

--- a/api/services/certificate/src/actions/CreateCertificateAction.ts
+++ b/api/services/certificate/src/actions/CreateCertificateAction.ts
@@ -17,6 +17,8 @@ import { IdentityIdentifiersInterface } from '../shared/certificate/common/inter
 @handler({
   ...handlerConfig,
   middlewares: [
+    // feature flag certificates until properly tested by operators
+    ['featureflag', { deny: ['production'] }],
     ['validate', alias],
     ['can', ['certificate.create']],
   ],

--- a/api/services/certificate/src/actions/DownloadCertificateAction.ts
+++ b/api/services/certificate/src/actions/DownloadCertificateAction.ts
@@ -14,6 +14,8 @@ import { CertificateRepositoryProviderInterfaceResolver } from '../interfaces/Ce
 @handler({
   ...handlerConfig,
   middlewares: [
+    // feature flag certificates until properly tested by operators
+    ['featureflag', { deny: ['production'] }],
     ['validate', alias],
     ['can', ['certificate.download']],
     ['channel.service.only', ['proxy']],

--- a/api/services/certificate/src/actions/FindCertificateAction.ts
+++ b/api/services/certificate/src/actions/FindCertificateAction.ts
@@ -5,7 +5,14 @@ import { CertificateRepositoryProviderInterfaceResolver } from '../interfaces/Ce
 import { handlerConfig, ResultInterface, ParamsInterface } from '../shared/certificate/find.contract';
 import { alias } from '../shared/certificate/find.schema';
 
-@handler({ ...handlerConfig, middlewares: [['validate', alias]] })
+@handler({
+  ...handlerConfig,
+  middlewares: [
+    // feature flag certificates until properly tested by operators
+    ['featureflag', { deny: ['production'] }],
+    ['validate', alias],
+  ],
+})
 export class FindCertificateAction extends AbstractAction {
   constructor(private certRepository: CertificateRepositoryProviderInterfaceResolver) {
     super();

--- a/api/services/certificate/src/actions/ListCertificateAction.ts
+++ b/api/services/certificate/src/actions/ListCertificateAction.ts
@@ -13,6 +13,8 @@ import { alias } from '../shared/certificate/list.schema';
 @handler({
   ...handlerConfig,
   middlewares: [
+    // feature flag certificates until properly tested by operators
+    ['featureflag', { deny: ['production'] }],
     ['validate', alias],
     ['can', ['certificate.list']],
   ],

--- a/dashboard/src/app/core/interfaces/admin/adminLayoutInterface.ts
+++ b/dashboard/src/app/core/interfaces/admin/adminLayoutInterface.ts
@@ -8,4 +8,5 @@ export interface MenuTabInterface {
   label: string | SafeHtml;
   groups?: UserGroupEnum[];
   role?: UserRoleEnum | UserManyRoleEnum;
+  hideIn?: string[];
 }

--- a/dashboard/src/app/modules/administration/administration-layout/administration-layout.component.html
+++ b/dashboard/src/app/modules/administration/administration-layout/administration-layout.component.html
@@ -1,14 +1,12 @@
 <div class="Administration">
   <app-page-header>
-    <h1 class="page-title">
-      Administration
-    </h1>
+    <h1 class="page-title">Administration</h1>
     <div class="page-menu">
       <nav mat-tab-nav-bar>
         <ng-container *ngFor="let link of menu">
           <a
             mat-tab-link
-            *ngIf="authenticationService.hasAnyGroup(link.groups) && authenticationService.hasRole(link.role)"
+            *ngIf="showTab(link)"
             [routerLink]="link.path"
             routerLinkActive
             #rla="routerLinkActive"

--- a/dashboard/src/app/modules/administration/administration-layout/administration-layout.component.ts
+++ b/dashboard/src/app/modules/administration/administration-layout/administration-layout.component.ts
@@ -5,6 +5,8 @@ import { AuthenticationService } from '~/core/services/authentication/authentica
 import { UserGroupEnum } from '~/core/enums/user/user-group.enum';
 import { UserManyRoleEnum } from '~/core/enums/user/user-role.enum';
 
+import { environment } from '../../../../environments/environment';
+
 @Component({
   selector: 'app-administration-layout',
   templateUrl: './administration-layout.component.html',
@@ -66,10 +68,28 @@ export class AdministrationLayoutComponent implements OnInit {
       role: UserManyRoleEnum.ADMIN,
       groups: [UserGroupEnum.OPERATOR, UserGroupEnum.REGISTRY],
       label: 'Attestations',
+      // feature flag the certificates in production for now
+      hideIn: ['production'],
     },
   ];
 
   constructor(public authenticationService: AuthenticationService) {}
 
   ngOnInit(): void {}
+
+  showTab(link: MenuTabInterface): boolean {
+    return (
+      !this.shouldHide(link) &&
+      this.authenticationService.hasAnyGroup(link.groups) &&
+      this.authenticationService.hasRole(link.role)
+    );
+  }
+
+  shouldHide(link: MenuTabInterface): boolean {
+    if ('hideIn' in link && link.hideIn.indexOf(environment.name) > -1) {
+      return true;
+    }
+
+    return false;
+  }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,7 +49,6 @@ services:
       - 8080:8080
     env_file: ./api/.env
     environment:
-      NODE_ENV: local
       PORT: 8080
     networks:
       - front


### PR DESCRIPTION
- [x] ajouter un middleware `featureflag` avec les options `allow` et `deny`
- [x] désactiver les routes vers les certificats dans le proxy uniquement sur la prod
- [x] désactiver les actions des certificats en utilisant le middleware uniquement sur la prod
- [x] désactiver l'onglet 'Attestations' dans le front

fix #1136