### PR TITLE
Correctif front : affichage campagne

### DIFF
--- a/dashboard/src/app/modules/campaign/modules/campaign-ui/components/campaign-main-metrics/campaign-main-metrics.component.html
+++ b/dashboard/src/app/modules/campaign/modules/campaign-ui/components/campaign-main-metrics/campaign-main-metrics.component.html
@@ -12,7 +12,7 @@
     <p>
       Rétribution totale :<br />
       <span class="campaignMainMetrics-budgetSpend"
-        ><b>{{ budgetSpent | currency: 'EUR':'symbol':'1.0-2' }}</b></span
+        ><b>{{ budgetSpent / 100 | currency: 'EUR':'symbol':'1.0-2' }}</b></span
       >
       sur <b>{{ budgetTotal | currency: 'EUR':'symbol':'1.0-2' }}</b>
     </p>

--- a/dashboard/src/app/modules/campaign/modules/campaign-ui/components/campaign-main-metrics/campaign-main-metrics.component.ts
+++ b/dashboard/src/app/modules/campaign/modules/campaign-ui/components/campaign-main-metrics/campaign-main-metrics.component.ts
@@ -3,6 +3,7 @@ import * as moment from 'moment';
 import { ChartData, ChartOptions } from 'chart.js';
 
 import { CampaignUx } from '~/core/entities/campaign/ux-format/campaign-ux';
+import { IncentiveUnitEnum } from '~/core/enums/campaign/incentive-unit.enum';
 
 @Component({
   selector: 'app-campaign-main-metrics',
@@ -74,7 +75,12 @@ export class CampaignMainMetricsComponent implements OnInit, OnChanges {
   private initBudget(): void {
     this.budgetTotal = this.campaign ? this.campaign.max_amount : 0;
 
-    this.budgetSpent = this.campaign && this.campaign.state ? this.campaign.state.amount : 0;
+    this.budgetSpent =
+      this.campaign && this.campaign.state
+        ? this.campaign.unit === IncentiveUnitEnum.EUR
+          ? this.campaign.state.amount / 100
+          : this.campaign.state.amount
+        : 0;
     this.budgetRemaining = this.campaign ? this.budgetTotal - this.budgetSpent : 1;
   }
 

--- a/dashboard/src/app/modules/campaign/services/campaign-ui.service.ts
+++ b/dashboard/src/app/modules/campaign/services/campaign-ui.service.ts
@@ -332,7 +332,9 @@ export class CampaignUiService {
     // MAXIMUM AMOUNT
     summaryText += `
       <p>Cette campagne est limitée à
-        <b>${campaign.max_amount} ${unit}${campaign.max_amount > 1 ? 's' : ''}</b>.
+        <b>${campaign.max_amount} ${unit}${campaign.max_amount > 1 ? 's' : ''} et ${campaign.max_trips} trajet${
+      campaign.max_trips > 1 ? 's' : ''
+    } </b>.
       </p>
     `;
 


### PR DESCRIPTION
- nombre de trajet max dans le récap
- erreur de division par 100 pour les rétribution dans le graphique de progression de la campagne