### PR TITLE
Fix/1169 trip export

### DIFF
--- a/api/proxy/src/QueueTransport.ts
+++ b/api/proxy/src/QueueTransport.ts
@@ -49,8 +49,6 @@ export class MyQueueTransport extends QueueTransport implements TransportInterfa
 
   async startServer() {
     const port = env('PORT', 8080);
-    this.server = this.app.listen(port, () =>
-      console.log(`Listening on port ${port}`),
-    );
+    this.server = this.app.listen(port, () => console.log(`Listening on port ${port}`));
   }
 }

--- a/dashboard/src/app/core/interfaces/filter/exportFilterInterface.ts
+++ b/dashboard/src/app/core/interfaces/filter/exportFilterInterface.ts
@@ -16,6 +16,12 @@ export interface ExportFilterUxInterface {
     start: Moment;
     end: Moment;
   };
-  territory_id?: number[];
-  operator_id?: number[];
+  operators: {
+    list: number[];
+    count: number;
+  };
+  territories: {
+    list: number[];
+    count: number;
+  };
 }

--- a/dashboard/src/app/core/services/authentication/authentication.service.ts
+++ b/dashboard/src/app/core/services/authentication/authentication.service.ts
@@ -104,6 +104,14 @@ export class AuthenticationService {
     return this.hasRole(UserManyRoleEnum.ADMIN);
   }
 
+  public get isOperator(): boolean {
+    return this.hasRole(UserManyRoleEnum.OPERATOR);
+  }
+
+  public get isTerritory(): boolean {
+    return this.hasRole(UserManyRoleEnum.TERRITORY);
+  }
+
   public get isDemo(): boolean {
     return this.user.role === UserRoleEnum.TERRITORY_DEMO;
   }

--- a/dashboard/src/app/modules/operator/modules/operator-ui/components/operators-checkboxes/operators-checkboxes.component.html
+++ b/dashboard/src/app/modules/operator/modules/operator-ui/components/operators-checkboxes/operators-checkboxes.component.html
@@ -1,0 +1,19 @@
+<div *ngIf="loading" class="loading-message">
+  <mat-spinner [diameter]="25"></mat-spinner>
+  <em>Chargement de la liste des opérateurs...</em>
+</div>
+
+<div class="actions" *ngIf="operators.length">
+  <span class="link" (click)="setAll(true)">Tout cocher</span> /
+  <span class="link" (click)="setAll(false)">Tout décocher</span>
+</div>
+
+<form [formGroup]="form">
+  <ul *ngIf="operators.length" class="mat-checkbox-list--vertical">
+    <li formArrayName="boxes" *ngFor="let item of checkboxes.controls; let i = index" class="mat-checkbox-list-item">
+      <mat-checkbox [formControlName]="i">
+        {{ operators[i].name }}
+      </mat-checkbox>
+    </li>
+  </ul>
+</form>

--- a/dashboard/src/app/modules/operator/modules/operator-ui/components/operators-checkboxes/operators-checkboxes.component.html
+++ b/dashboard/src/app/modules/operator/modules/operator-ui/components/operators-checkboxes/operators-checkboxes.component.html
@@ -1,19 +1,23 @@
-<div *ngIf="loading" class="loading-message">
-  <mat-spinner [diameter]="25"></mat-spinner>
-  <em>Chargement de la liste des opérateurs...</em>
-</div>
+<div class="app-operators-checkboxes">
+  <div *ngIf="loading" class="loading-message">
+    <mat-spinner [diameter]="25"></mat-spinner>
+    <em>Chargement de la liste des opérateurs...</em>
+  </div>
 
-<div class="actions" *ngIf="operators.length">
-  <span class="link" (click)="setAll(true)">Tout cocher</span> /
-  <span class="link" (click)="setAll(false)">Tout décocher</span>
-</div>
+  <div class="actions" *ngIf="operators.length">
+    <span class="link" (click)="setAll(true)">Tout cocher</span> /
+    <span class="link" (click)="setAll(false)">Tout décocher</span>
+  </div>
 
-<form [formGroup]="form">
-  <ul *ngIf="operators.length" class="mat-checkbox-list--vertical">
-    <li formArrayName="boxes" *ngFor="let item of checkboxes.controls; let i = index" class="mat-checkbox-list-item">
-      <mat-checkbox [formControlName]="i">
-        {{ operators[i].name }}
-      </mat-checkbox>
-    </li>
-  </ul>
-</form>
+  <form [formGroup]="form">
+    <ul *ngIf="operators.length" class="mat-checkbox-list--vertical">
+      <li formArrayName="boxes" *ngFor="let item of checkboxes.controls; let i = index" class="mat-checkbox-list-item">
+        <mat-checkbox [formControlName]="i">
+          {{ operators[i].name }}
+        </mat-checkbox>
+      </li>
+    </ul>
+  </form>
+
+  <mat-hint *ngIf="operators.length">*&nbsp;Décocher tous les opérateurs les exporte tous.</mat-hint>
+</div>

--- a/dashboard/src/app/modules/operator/modules/operator-ui/components/operators-checkboxes/operators-checkboxes.component.scss
+++ b/dashboard/src/app/modules/operator/modules/operator-ui/components/operators-checkboxes/operators-checkboxes.component.scss
@@ -38,4 +38,16 @@
       overflow: hidden;
     }
   }
+
+  .app-operators-checkboxes {
+    .mat-hint {
+      display: block;
+      margin-bottom: 2em;
+      margin-left: 0em;
+      font-weight: normal;
+      font-style: italic;
+      font-size: 0.8em;
+      text-align: right;
+    }
+  }
 }

--- a/dashboard/src/app/modules/operator/modules/operator-ui/components/operators-checkboxes/operators-checkboxes.component.scss
+++ b/dashboard/src/app/modules/operator/modules/operator-ui/components/operators-checkboxes/operators-checkboxes.component.scss
@@ -1,0 +1,41 @@
+@import '../../../../../../../styles/variables';
+
+.loading-message {
+  margin: 2em 0;
+  .mat-spinner {
+    float: left;
+    margin: -4px 0.5em 0 0;
+  }
+}
+
+.mat-checkbox-list--vertical {
+  list-style: none;
+  padding-left: 0.2em;
+  columns: 3;
+  @media only screen and (max-width: 640px) {
+    columns: 2;
+  }
+  .mat-checkbox-list-item {
+    padding: 0.2em 0.1em 0.3em;
+  }
+}
+
+.link {
+  color: $color-primary;
+  cursor: pointer;
+}
+
+// make css work on the mat-checkbox items
+::ng-deep {
+  .mat-checkbox-list-item {
+    .mat-checkbox,
+    .mat-checkbox .mat-checkbox-layout {
+      max-width: 100%;
+    }
+    .mat-checkbox-layout .mat-checkbox-label {
+      text-overflow: ellipsis;
+      max-width: 100%;
+      overflow: hidden;
+    }
+  }
+}

--- a/dashboard/src/app/modules/operator/modules/operator-ui/components/operators-checkboxes/operators-checkboxes.component.ts
+++ b/dashboard/src/app/modules/operator/modules/operator-ui/components/operators-checkboxes/operators-checkboxes.component.ts
@@ -1,0 +1,123 @@
+import { Subject } from 'rxjs';
+import { takeUntil, filter, debounceTime } from 'rxjs/operators';
+
+import { Component, forwardRef, OnInit } from '@angular/core';
+import {
+  ControlValueAccessor,
+  FormArray,
+  FormBuilder,
+  FormControl,
+  FormGroup,
+  NG_VALUE_ACCESSOR,
+} from '@angular/forms';
+
+import { CommonDataService } from '~/core/services/common-data.service';
+import { DestroyObservable } from '~/core/components/destroy-observable';
+import { AuthenticationService } from '~/core/services/authentication/authentication.service';
+
+type OperatorId = number;
+
+interface ListOperatorItem {
+  _id: OperatorId;
+  name: string;
+}
+
+interface ResultInterface {
+  list: OperatorId[];
+  count: number;
+}
+
+@Component({
+  selector: 'app-operators-checkboxes',
+  templateUrl: './operators-checkboxes.component.html',
+  styleUrls: ['./operators-checkboxes.component.scss'],
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => OperatorsCheckboxesComponent),
+      multi: true,
+    },
+  ],
+})
+export class OperatorsCheckboxesComponent extends DestroyObservable implements OnInit, ControlValueAccessor {
+  public form: FormGroup;
+  public operators: Array<ListOperatorItem> = [];
+  public result = new Subject<ResultInterface>();
+  public loading = true;
+
+  private disabled = false;
+
+  get checkboxes(): any {
+    return this.form.controls.boxes as FormArray;
+  }
+
+  constructor(
+    private formBuilder: FormBuilder,
+    private user: AuthenticationService,
+    private commonDataService: CommonDataService,
+  ) {
+    super();
+  }
+
+  ngOnInit(): void {
+    // init the form
+    this.form = this.formBuilder.group({ boxes: new FormArray([]), operator_count: 0 });
+
+    // bind checkboxes change
+    this.form.valueChanges.pipe(takeUntil(this.destroy$), debounceTime(100)).subscribe(({ boxes }) => {
+      // map operators and boxes arrays
+      // to get an array of operator _id
+      let i = 0;
+      const res = new Array(boxes.length);
+      for (i = 0; i < boxes.length; i++) {
+        if (boxes[i] && this.operators[i]) {
+          res.push(this.operators[i]._id);
+        }
+      }
+
+      this.writeValue({
+        list: res.filter((i) => !!i),
+        count: boxes.length,
+      });
+    });
+
+    // load operators
+    this.loading = true;
+    this.commonDataService.operators$
+      .pipe(
+        takeUntil(this.destroy$),
+        filter((list) => list && list.length > 0),
+      )
+      .subscribe((operators) => {
+        this.operators = operators.map(({ _id, name }) => ({ _id, name }));
+        this.operators.forEach(() => this.checkboxes.push(new FormControl(false)));
+        this.form.get('operator_count').setValue(this.operators.length);
+        this.loading = false;
+      });
+  }
+
+  // select all checkboxes
+  public setAll(value: boolean): void {
+    this.checkboxes.controls.forEach((chk: FormControl) => chk.setValue(value));
+  }
+
+  private onTouch = () => {};
+
+  writeValue(res: ResultInterface): void {
+    if (this.disabled) return;
+    this.result.next(res);
+    this.onTouch();
+  }
+
+  registerOnChange(fn: any): void {
+    this.result.subscribe(fn);
+  }
+
+  registerOnTouched(fn: any): void {
+    this.onTouch = fn;
+  }
+
+  setDisabledState?(isDisabled: boolean): void {
+    this.disabled = isDisabled;
+  }
+}

--- a/dashboard/src/app/modules/operator/modules/operator-ui/operator-ui.module.ts
+++ b/dashboard/src/app/modules/operator/modules/operator-ui/operator-ui.module.ts
@@ -19,6 +19,7 @@ import { OperatorListComponent } from './components/operator-list/operator-list.
 import { OperatorFilterComponent } from './components/operator-filter/operator-filter.component';
 import { OperatorDetailsComponent } from './components/operator-details/operator-details.component';
 import { OperatorLogoUploadComponent } from './components/operator-logo-upload/operator-logo-upload.component';
+import { OperatorsCheckboxesComponent } from './components/operators-checkboxes/operators-checkboxes.component';
 
 @NgModule({
   declarations: [
@@ -31,9 +32,11 @@ import { OperatorLogoUploadComponent } from './components/operator-logo-upload/o
     OperatorFilterComponent,
     OperatorDetailsComponent,
     OperatorLogoUploadComponent,
+    OperatorsCheckboxesComponent,
   ],
   exports: [
     OperatorsAutocompleteComponent,
+    OperatorsCheckboxesComponent,
     OperatorFormComponent,
     OperatorAutocompleteComponent,
     OperatorListViewComponent,

--- a/dashboard/src/app/modules/trip/pages/trip-export-dialog/trip-export-dialog.component.html
+++ b/dashboard/src/app/modules/trip/pages/trip-export-dialog/trip-export-dialog.component.html
@@ -3,7 +3,10 @@
   <p>Export des données au format CSV compressé (.zip)</p>
 
   <ul *ngIf="hasProps">
-    <li *ngFor="let item of props | keyvalue">{{ item.key }} : {{ item.value }}</li>
+    <li *ngFor="let item of props | keyvalue">
+      <span class="key">{{ item.key }}&nbsp;:</span>
+      {{ item.value }}
+    </li>
   </ul>
 
   <p>Le fichier vous sera envoyé par email dans quelques minutes.</p>

--- a/dashboard/src/app/modules/trip/pages/trip-export-dialog/trip-export-dialog.component.scss
+++ b/dashboard/src/app/modules/trip/pages/trip-export-dialog/trip-export-dialog.component.scss
@@ -1,4 +1,13 @@
+.mat-dialog-content {
+  min-width: 500px;
+}
+
 .mat-dialog-actions {
   margin-top: 1em;
   justify-content: flex-end;
+}
+
+.key {
+  display: inline-block;
+  min-width: 90px;
 }

--- a/dashboard/src/app/modules/trip/pages/trip-export-dialog/trip-export-dialog.component.ts
+++ b/dashboard/src/app/modules/trip/pages/trip-export-dialog/trip-export-dialog.component.ts
@@ -1,5 +1,6 @@
 import { get } from 'lodash';
 import { format } from 'date-fns';
+import { fr } from 'date-fns/locale';
 import { takeUntil } from 'rxjs/operators';
 
 import { Component, Inject, OnInit } from '@angular/core';
@@ -31,14 +32,16 @@ export class TripExportDialogComponent extends DestroyObservable implements OnIn
     const e = get(this.data, 'date.end');
     const o: number[] = get(this.data, 'operator_id', []);
 
-    if (s) p['Début'] = format(s, 'd MMMM yyyy');
-    if (e) p['Fin'] = format(e, 'd MMMM yyyy');
+    if (s) p['Début'] = format(s, 'PPPP', { locale: fr });
+    if (e) p['Fin'] = format(e, 'PPPP', { locale: fr });
     if (o) {
       // convert operator_id to operator names
       p[`Opérateur${o.length === 1 ? '' : 's'}`] = this.operators
         .filter((op) => o.indexOf(op._id) > -1)
         .map((op) => op.name)
-        .join(', ');
+        .sort()
+        .join(', ')
+        .trim();
     }
 
     return p;

--- a/dashboard/src/app/modules/trip/pages/trip-export-dialog/trip-export-dialog.component.ts
+++ b/dashboard/src/app/modules/trip/pages/trip-export-dialog/trip-export-dialog.component.ts
@@ -30,11 +30,14 @@ export class TripExportDialogComponent extends DestroyObservable implements OnIn
     const p = {};
     const s = get(this.data, 'date.start');
     const e = get(this.data, 'date.end');
-    const o: number[] = get(this.data, 'operator_id', []);
+    const o: number[] = get(this.data, 'operators.list', []);
+    const c: number = get(this.data, 'operators.count', 0);
 
     if (s) p['Début'] = format(s, 'PPPP', { locale: fr });
     if (e) p['Fin'] = format(e, 'PPPP', { locale: fr });
-    if (o) {
+    if (o.length === 0 || o.length === c) {
+      p['Opérateurs'] = 'tous';
+    } else if (o.length) {
       // convert operator_id to operator names
       p[`Opérateur${o.length === 1 ? '' : 's'}`] = this.operators
         .filter((op) => o.indexOf(op._id) > -1)

--- a/dashboard/src/app/modules/trip/pages/trip-export/trip-export.component.html
+++ b/dashboard/src/app/modules/trip/pages/trip-export/trip-export.component.html
@@ -10,9 +10,10 @@
     <p>Merci de votre compréhension</p>
   </div> -->
 
-  <form [formGroup]="exportFilterForm">
-    <div class="exportFilter-dates" formGroupName="date">
-      <div class="dates">
+  <form [formGroup]="form">
+    <div class="exportFilter-dates">
+      <div class="dates" formGroupName="date">
+        <!-- start -->
         <mat-form-field appearance="outline">
           <mat-label>Début</mat-label>
           <input
@@ -25,6 +26,8 @@
           <mat-datepicker-toggle matSuffix [for]="startDatePicker"></mat-datepicker-toggle>
           <mat-datepicker #startDatePicker></mat-datepicker>
         </mat-form-field>
+
+        <!-- end -->
         <mat-form-field appearance="outline">
           <mat-label>Fin</mat-label>
           <input matInput formControlName="end" [matDatepicker]="endDatePicker" placeholder="Choisir une date" />
@@ -33,12 +36,13 @@
         </mat-form-field>
       </div>
 
-      <app-operators-autocomplete
-        *ngIf="operatorFieldVisible | async"
-        fieldName="operator_id"
-        [onlyVisible]="operatorFieldVisibleOperatorOnly | async"
-        [parentForm]="exportFilterForm"
-      ></app-operators-autocomplete>
+      <!--
+        operators' list on 3 columns
+        - visible if territory or registry
+        - an operator is visible by a territory only if it accepted to be visible
+      -->
+      <h3 *ngIf="!user.isOperator">Opérateurs</h3>
+      <app-operators-checkboxes *ngIf="!user.isOperator" formControlName="operators"></app-operators-checkboxes>
 
       <div class="actions">
         <button
@@ -47,7 +51,7 @@
           color="primary"
           [appShowSpinner]="isExporting"
           [disabled]="isExporting"
-          (click)="exportTrips()"
+          (click)="export()"
         >
           Exporter les trajets
         </button>

--- a/dashboard/src/app/modules/trip/pages/trip-export/trip-export.component.ts
+++ b/dashboard/src/app/modules/trip/pages/trip-export/trip-export.component.ts
@@ -1,39 +1,31 @@
-import * as moment from 'moment';
-import { Observable } from 'rxjs';
 import { ToastrService } from 'ngx-toastr';
-import { takeUntil, map } from 'rxjs/operators';
+import { takeUntil } from 'rxjs/operators';
+import { sub, startOfDay, endOfDay } from 'date-fns';
 
 import { Component, OnInit } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { FormBuilder, FormGroup } from '@angular/forms';
-import { DateAdapter, MAT_DATE_FORMATS, MAT_DATE_LOCALE } from '@angular/material/core';
-import { MAT_MOMENT_DATE_FORMATS, MomentDateAdapter } from '@angular/material-moment-adapter';
 
 import { DestroyObservable } from '~/core/components/destroy-observable';
 import { TripStoreService } from '~/modules/trip/services/trip-store.service';
 import { ExportFilterUxInterface } from '~/core/interfaces/filter/exportFilterInterface';
 import { AuthenticationService } from '~/core/services/authentication/authentication.service';
 import { TripExportDialogComponent } from '../trip-export-dialog/trip-export-dialog.component';
+
 @Component({
   selector: 'app-trip-export',
   templateUrl: './trip-export.component.html',
   styleUrls: ['./trip-export.component.scss'],
-  providers: [
-    { provide: DateAdapter, useClass: MomentDateAdapter, deps: [MAT_DATE_LOCALE] },
-    { provide: MAT_DATE_FORMATS, useValue: MAT_MOMENT_DATE_FORMATS },
-  ],
 })
 export class TripExportComponent extends DestroyObservable implements OnInit {
-  isExporting = false;
-  minDate = moment().subtract(1, 'year').toDate();
+  public isExporting = false;
+  public minDate = sub(new Date(), { years: 1 });
 
-  exportFilterForm: FormGroup;
-  operatorFieldVisible: Observable<boolean>;
-  operatorFieldVisibleOperatorOnly: Observable<boolean>;
+  form: FormGroup;
 
   constructor(
     public tripService: TripStoreService,
-    public auth: AuthenticationService,
+    public user: AuthenticationService,
     private toastr: ToastrService,
     private fb: FormBuilder,
     private dialog: MatDialog,
@@ -42,29 +34,32 @@ export class TripExportComponent extends DestroyObservable implements OnInit {
   }
 
   ngOnInit(): void {
-    this.initForm();
-
-    // operator field is visible if user is not an operator
-    this.operatorFieldVisible = this.auth.user$.pipe(map((u) => u && !u.operator_id));
-
-    // territory / operatory flag is enabled only if user has a territory_id
-    this.operatorFieldVisibleOperatorOnly = this.auth.user$.pipe(map((u) => u && !!u.territory_id));
+    this.form = this.fb.group({
+      date: this.fb.group({
+        start: [startOfDay(sub(new Date(), { months: 1 }))],
+        end: [endOfDay(new Date())],
+      }),
+      operators: {
+        list: [],
+        count: 0,
+      },
+    });
   }
 
-  exportTrips(): void {
-    const filter: ExportFilterUxInterface = {
-      ...this.exportFilterForm.getRawValue(),
+  public export(): void {
+    const data: ExportFilterUxInterface = {
+      ...this.form.getRawValue(),
       tz: Intl.DateTimeFormat().resolvedOptions().timeZone,
     };
 
     this.dialog
-      .open(TripExportDialogComponent, { data: filter })
+      .open(TripExportDialogComponent, { data })
       .afterClosed()
       .pipe(takeUntil(this.destroy$))
       .subscribe((result) => {
         if (result) {
           this.isExporting = true;
-          this.tripService.exportTrips(filter).subscribe(
+          this.tripService.exportTrips(data).subscribe(
             () => {
               this.toastr.success('Export en cours');
               setTimeout(() => {
@@ -78,17 +73,5 @@ export class TripExportComponent extends DestroyObservable implements OnInit {
           );
         }
       });
-  }
-
-  private initForm(): void {
-    const start = moment().subtract(1, 'month').startOf('day').toDate();
-    const end = moment().endOf('day').toDate();
-    this.exportFilterForm = this.fb.group({
-      date: this.fb.group({
-        start: [start],
-        end: [end],
-      }),
-      operator_id: [null],
-    });
   }
 }

--- a/dashboard/src/app/modules/trip/services/trip-store.service.ts
+++ b/dashboard/src/app/modules/trip/services/trip-store.service.ts
@@ -43,8 +43,12 @@ export class TripStoreService extends GetListStore<LightTrip, LightTrip, TripApi
       },
     };
 
-    if (filter.operator_id) {
-      params.operator_id = filter.operator_id;
+    if (filter.operators && filter.operators.list && filter.operators.list.length) {
+      params.operator_id = filter.operators.list;
+    }
+
+    if (filter.territories && filter.territories.list && filter.territories.list.length) {
+      params.territory_id = filter.territories.list;
     }
 
     return this.rpcGetList.exportTrips(params);


### PR DESCRIPTION
#1169

- Amélioration des textes de la boite de confirmation.
- Remplacement de la méthode de sélection des opérateurs par une liste de checkboxes
- Filtrage de la liste des opérateurs en fonction de la config de visibilité opérateur pour les territoires
- Pas de choix de l'opérateur si l'utilisateur est un opérateur
- suppression de `moment` et remplacement par `date-fns`
- gestion de l'erreur sur le _DatePicker_ quand la date sélectionnée est antérieure à 1 an : **NON FAIT**