### PR TITLE
Fix/1247 migration

### DIFF
--- a/api/db/migrations/trip/20210107000000-update_trip_view_financial_sum.up.sql
+++ b/api/db/migrations/trip/20210107000000-update_trip_view_financial_sum.up.sql
@@ -517,7 +517,7 @@ BEGIN
       driver_incentive_rpc_sum,
       driver_incentive_rpc_financial_sum,
       status
-    ) SELECT (
+    ) SELECT
       tv.operator_id,
       tv.start_territory_id,
       tv.end_territory_id,
@@ -568,7 +568,7 @@ BEGIN
       tv.driver_incentive_rpc_sum,
       tv.driver_incentive_rpc_financial_sum,
       tv.status
-    ) FROM carpool.carpools AS cc
+    FROM carpool.carpools AS cc
     LEFT JOIN trip.list_view AS tv ON tv.journey_id = cc.acquisition_id
     WHERE cc._id = NEW.carpool_id
     ON CONFLICT (journey_id)
@@ -671,6 +671,7 @@ BEGIN
       excluded.driver_revenue,
       excluded.driver_incentive_raw,
       excluded.driver_incentive_rpc_raw,
+      excluded.driver_incentive_rpc_sum,
       excluded.driver_incentive_rpc_financial_sum,
       excluded.status
     );

--- a/api/providers/test/src/httpMacro.ts
+++ b/api/providers/test/src/httpMacro.ts
@@ -22,16 +22,10 @@ export function httpMacro<TestContext = unknown>(
   test.before(async (t) => {
     t.context.transport = await transportCtor('http', '0');
     t.context.supertest = supertest(t.context.transport.getInstance());
-    t.context.request = async <P = ParamsType, R = ResultType>(method: string, params: P, context: Partial<ContextType>) => {
+    t.context.request = async <P = ParamsType>(method: string, params: P, context: Partial<ContextType>) => {
       const mergedContext: ContextType = {
-        call: {
-          user: {},
-          ...context.call,
-        },
-        channel: {
-          service: '',
-          ...context.channel,
-        },
+        call: { user: {}, ...context.call },
+        channel: { service: '', ...context.channel },
       };
 
       const result = await t.context.supertest

--- a/api/services/company/src/providers/CompanyDataSourceProvider.spec.ts
+++ b/api/services/company/src/providers/CompanyDataSourceProvider.spec.ts
@@ -6,27 +6,30 @@ import { CompanyDataSourceProvider } from './CompanyDataSourceProvider';
 test('should fetch from data source with a siret id', async (t) => {
   const provider: CompanyDataSourceProvider = new CompanyDataSourceProvider();
   const data = await provider.find('12000101100010');
-  t.deepEqual(Reflect.ownKeys(data).sort(), [
-    'siret',
-    'siren',
-    'nic',
-    'legal_name',
-    'company_naf_code',
-    'establishment_naf_code',
-    'legal_nature_code',
-    'legal_nature_label',
-    'intra_vat',
-    'headquarter',
-    'updated_at',
-    'nonprofit_code',
-    'address',
-    'address_street',
-    'address_postcode',
-    'address_cedex',
-    'address_city',
-    'lat',
-    'lon',
-  ].sort());
+  t.deepEqual(
+    Reflect.ownKeys(data).sort(),
+    [
+      'siret',
+      'siren',
+      'nic',
+      'legal_name',
+      'company_naf_code',
+      'establishment_naf_code',
+      'legal_nature_code',
+      'legal_nature_label',
+      'intra_vat',
+      'headquarter',
+      'updated_at',
+      'nonprofit_code',
+      'address',
+      'address_street',
+      'address_postcode',
+      'address_cedex',
+      'address_city',
+      'lat',
+      'lon',
+    ].sort(),
+  );
 
   t.is(data.siret, '12000101100010');
   t.is(data.siren, '120001011');

--- a/api/services/normalization/src/actions/NormalizationProcessAction.ts
+++ b/api/services/normalization/src/actions/NormalizationProcessAction.ts
@@ -1,5 +1,3 @@
-import { get } from 'lodash';
-
 import { Action as AbstractAction } from '@ilos/core';
 import { handler, KernelInterfaceResolver, ContextType } from '@ilos/common';
 
@@ -119,7 +117,7 @@ export class NormalizationProcessAction extends AbstractAction {
     const driverDuration = Math.floor(
       ((driverEnd.getTime ? driverEnd.getTime() : new Date(driverEnd).getTime()) -
         (driverStart.getTime ? driverStart.getTime() : new Date(driverStart).getTime())) /
-      1000,
+        1000,
     );
 
     return {

--- a/api/services/normalization/src/providers/territoryProvider.spec.ts
+++ b/api/services/normalization/src/providers/territoryProvider.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-len */
 import anyTest, { TestInterface } from 'ava';
 import { PostgresConnection } from '@ilos/connection-postgres';
 import { TerritoryProvider } from './TerritoryProvider';
@@ -9,7 +10,7 @@ interface TestContext {
 
 const test = anyTest as TestInterface<TestContext>;
 
-test('TerritoryProvider', t => {
+test('TerritoryProvider', (t) => {
   // NOTE : Disabling this test cause of id inconsistency.
   t.pass();
 });

--- a/api/services/policy/src/providers/TripRepositoryProvider.spec.ts
+++ b/api/services/policy/src/providers/TripRepositoryProvider.spec.ts
@@ -2,7 +2,6 @@ import anyTest, { TestInterface } from 'ava';
 import { PostgresConnection } from '@ilos/connection-postgres';
 
 import { TripRepositoryProvider } from './TripRepositoryProvider';
-import { ProcessableCampaign } from '../engine/ProcessableCampaign';
 
 interface TestContext {
   connection: PostgresConnection;

--- a/api/services/territory/src/providers/TerritoryOperatorRepositoryProvider.spec.ts
+++ b/api/services/territory/src/providers/TerritoryOperatorRepositoryProvider.spec.ts
@@ -36,22 +36,21 @@ test.after.always(async (t) => {
   await t.context.connection.down();
 });
 
+test.serial('should update by operator', async (t) => {
+  const result = await t.context.repository.updateByOperator(t.context.operatorId, t.context.territoryIds);
+  t.is(result, undefined);
+});
 
-  test.serial('should update by operator', async (t) => {
-    const result = await t.context.repository.updateByOperator(t.context.operatorId, t.context.territoryIds);
-    t.is(result, undefined);
-  });
+test.serial('should list by operator', async (t) => {
+  const resultFromRepository = await t.context.repository.findByOperator(t.context.operatorId);
+  t.true(Array.isArray(resultFromRepository));
+  for (const territoryId of t.context.territoryIds) {
+    t.true(resultFromRepository.indexOf(territoryId) > -1);
+  }
+});
 
-  test.serial('should list by operator', async (t) => {
-    const resultFromRepository = await t.context.repository.findByOperator(t.context.operatorId);
-    t.true(Array.isArray(resultFromRepository));
-    for(const territoryId of t.context.territoryIds) {
-      t.true(resultFromRepository.indexOf(territoryId) > -1);
-    }
-  });
-
-  test.serial('should list by territory', async (t) => {
-    const resultFromRepository = await t.context.repository.findByTerritory(t.context.territoryIds[0]);
-    t.true(Array.isArray(resultFromRepository));
-    t.true(resultFromRepository.indexOf(t.context.operatorId) > -1);
-  });
+test.serial('should list by territory', async (t) => {
+  const resultFromRepository = await t.context.repository.findByTerritory(t.context.territoryIds[0]);
+  t.true(Array.isArray(resultFromRepository));
+  t.true(resultFromRepository.indexOf(t.context.operatorId) > -1);
+});


### PR DESCRIPTION
Résolution de problèmes de syntax dans la requête de migration `trip/20210107000000-update_trip_view_financial_sum.up.sql`

A faire avant merge :

- [x] suppression de la migration sur `dev`
- [x] suppression de la migration sur `staging`