### PR TITLE
Fix stats

### DIFF
--- a/api/providers/middleware/src/ValidateDate/ValidateDateMiddleware.ts
+++ b/api/providers/middleware/src/ValidateDate/ValidateDateMiddleware.ts
@@ -1,5 +1,13 @@
 import { get, set } from 'lodash';
-import { MiddlewareInterface, ContextType, ResultType, InvalidParamsException, middleware } from '@ilos/common';
+import { startOfDay, endOfDay } from 'date-fns';
+import {
+  MiddlewareInterface,
+  ContextType,
+  ParamsType,
+  ResultType,
+  InvalidParamsException,
+  middleware,
+} from '@ilos/common';
 
 export type ValidateDateMiddlewareOptionsType = {
   startPath: string;
@@ -12,7 +20,7 @@ export type ValidateDateMiddlewareOptionsType = {
 @middleware()
 export class ValidateDateMiddleware implements MiddlewareInterface {
   async process(
-    params: any,
+    params: ParamsType,
     context: ContextType,
     next: Function,
     options: ValidateDateMiddlewareOptionsType,
@@ -22,8 +30,8 @@ export class ValidateDateMiddleware implements MiddlewareInterface {
     }
 
     const { startPath, endPath, minStart: minStartFn, maxEnd: maxEndFn, applyDefault: applyDefaultOpt } = options;
-    const minStart: Date | undefined = minStartFn ? minStartFn() : undefined;
-    const maxEnd: Date | undefined = maxEndFn ? maxEndFn() : undefined;
+    const minStart: Date | undefined = minStartFn ? startOfDay(minStartFn()) : undefined;
+    const maxEnd: Date | undefined = maxEndFn ? endOfDay(maxEndFn()) : undefined;
     const applyDefault = applyDefaultOpt ?? false;
     const startDate: Date | undefined = get(params, startPath, undefined);
     const endDate: Date | undefined = get(params, endPath, undefined);

--- a/api/services/trip/src/actions/StatsAction.ts
+++ b/api/services/trip/src/actions/StatsAction.ts
@@ -26,7 +26,7 @@ import * as middlewareConfig from '../config/middlewares';
         startPath: 'date.start',
         endPath: 'date.end',
         minStart: () => new Date(new Date().getTime() - middlewareConfig.date.minStartDefault),
-        maxEnd: () => new Date(),
+        maxEnd: () => new Date(new Date().getTime() - middlewareConfig.date.maxEndDefault),
         applyDefault: true,
       },
     ],


### PR DESCRIPTION
fix des `minDate` et `endDate` pour simplifier la date à la journée et permettre l'utilisation de la cache sur les stats.

:warning: **pas de cherry-pick sur ce fix, il est déjà sur la branche de `dev`**
La modif appliquée permet uniquement de régler ce problème. La structure du fichier a un peu changé sur la branche `dev`.
