### PR TITLE
Mentionne le niveau d'accessibilité dans le footer

### DIFF
--- a/dashboard/src/app/shared/components/footer/footer.component.html
+++ b/dashboard/src/app/shared/components/footer/footer.component.html
@@ -13,6 +13,9 @@
       <li class="Footer-link">
         <a class="link" target="_blank" rel="noopener noreferrer" [href]="URLS.legalMentions">Mentions légales</a>
       </li>
+      <li class="Footer-link">
+        Accessibilité : non conforme
+      </li>
     </ul>
   </div>
   <div>


### PR DESCRIPTION
Cette PR ajoute la mention "Accessibilité : non conforme" à votre footer.

La mention "Accessibilité : non conforme" est obligatoire pour les sites du service public et réellement utile pour les personnes en situation de handicap.


## Première étape : mention du niveau d'accessibilité dans le footer

En tant que site faisant partie du service public, nous avons un certain nombre d'obligation. 

L'une d'elle est la [**transparence du niveau d'accessibilité de votre site**](https://www.numerique.gouv.fr/publications/rgaa-accessibilite/obligations/#mention-obligatoire-sur-la-page-daccueil). 


Pour cela, il faut afficher le niveau de conformité dans le footer :

![](https://storage.gra.cloud.ovh.net/v1/AUTH_0f20d409cb2a4c9786c769e2edec0e06/imagespadincubateurnet/uploads/upload_0b915dfac42811371f8e93b6b4941d5b.png)
 
Tant que le niveau de conformité est inconnu, il est considéré comme **non conforme**.

Après avoir effectué un audit, on peut afficher : 
- Accessibilité : non conforme : score inférieur à 50 %.
- Accessibilité : partiellement conforme : score de 50% ou plus
- Accessibilité : totalement conforme : score est de 100%.

Pour connaître son score, il est donc nécessaire d'effectuer un audit auprès d'un cabinet d'expert qui mesurera le taux de conformité. Rejoignez le [**programme ACCESS**](https://doc.incubateur.net/communaute/gerer-sa-startup-detat-ou-de-territoires-au-quotidien/jameliore-le-design-et-lexperience-utilisateur/accessibilite-et-rgaa/acces) pour bénéficier d'un audit.

### Prochaine étape : création de la page "Déclaration d'accessibilité"

Cette mention obligatoire doit ensuite être un lien vers une **déclaration d'accessibilité**. 

Voici quelques exemples :

- La [page Accessibilité de signal.conso.gouv.fr](https://signal.conso.gouv.fr/accessibilite) qui affiche le score de l'audit.
- La [page Accessibilité du site des Designers Transverses](https://design.incubateur.net/accessibility/) qui indique que le site n'a pas encore été audité, mais rassure les utilisateurs concernés sur les mesures qui ont été prises.
- Le [générateur de déclaration d'accessibilité](https://betagouv.github.io/a11y-generateur-declaration/#create) pour obtenir un exemple de déclaration conforme en quelques clics.

### De l'aide en plus

En attendant, vous trouverez aussi plus d'infos :
- sur le [Kit Accessibilité](https://doc.incubateur.net/design/ressources-design/kit-accessibilite) de la documentation design
- sur [#domaine-accessibilité](https://app.slack.com/client/T04C2PSNY/C015LNMTTJ9/thread/C0135ELJ6TV-1616511717.002400) sur le Slack
- sur le [programme ACCESS](https://doc.incubateur.net/communaute/gerer-sa-startup-detat-ou-de-territoires-au-quotidien/jameliore-le-design-et-lexperience-utilisateur/accessibilite-et-rgaa/acces) d'accompagnement des Startups d'Etat pour vous aider à accélérer votre accessibilité. On peut financer un audit et un accompagnement pour vous !

Je reste à dispo si vous avez des questions :)