### PR TITLE
Town filter

### DIFF
--- a/api/providers/middleware/src/HasPermissionByScope/HasPermissionByScopeMiddleware.spec.ts
+++ b/api/providers/middleware/src/HasPermissionByScope/HasPermissionByScopeMiddleware.spec.ts
@@ -182,7 +182,7 @@ test('Middleware Scopetoself: territory-admin can trip.stats', async (t) => {
 
 test('Middleware Scopetoself: territory-admin can trip.stats w/ town filter', async (t) => {
   // mock territory_id being added by copy.from_context middleware
-  const params = { ...t.context.mockAllStatsParams, territory_id: t.context.mockTerritoryAdmin.territory_id };
+  const params = t.context.mockTownStatsParams;
   const context = t.context.contextFactory(t.context.mockTerritoryAdmin);
 
   const result = await t.context.middleware.process(

--- a/api/providers/middleware/src/HasPermissionByScope/HasPermissionByScopeMiddleware.spec.ts
+++ b/api/providers/middleware/src/HasPermissionByScope/HasPermissionByScopeMiddleware.spec.ts
@@ -4,10 +4,14 @@ import { ContextType, ForbiddenException } from '@ilos/common';
 import { HasPermissionByScopeMiddleware } from './HasPermissionByScopeMiddleware';
 
 const test = anyTest as TestInterface<{
-  mockConnectedUser: any;
+  mockSuperAdmin: any;
+  mockTerritoryAdmin: any;
   mockCreateUserParameters: any;
+  mockAllStatsParams: any;
+  mockTownStatsParams: any;
   contextFactory: Function;
-  middlewareConfig: any;
+  middlewareConfigUserCreate: any;
+  middlewareConfigTripStats: any;
   middleware: HasPermissionByScopeMiddleware;
 }>;
 
@@ -16,7 +20,7 @@ test.before((t) => {
     return {
       call: {
         user: {
-          ...t.context.mockConnectedUser,
+          ...t.context.mockSuperAdmin,
           ...params,
         },
       },
@@ -26,7 +30,7 @@ test.before((t) => {
     };
   };
 
-  t.context.mockConnectedUser = {
+  t.context.mockSuperAdmin = {
     _id: '1ab',
     email: 'john.schmidt@example.com',
     firstname: 'john',
@@ -34,7 +38,20 @@ test.before((t) => {
     phone: '0624857425',
     group: 'registry',
     role: 'admin',
-    permissions: ['user.create'],
+    permissions: ['registry.user.create'],
+  };
+
+  t.context.mockTerritoryAdmin = {
+    _id: 2,
+    email: 'territory.admin@example.com',
+    firstname: 'john',
+    lastname: 'schmidt',
+    phone: '0624857425',
+    group: 'territories',
+    role: 'admin',
+    territory_id: 42,
+    permissions: ['territory.trip.stats'],
+    authorizedTerritories: [42, 43, 44, 45],
   };
 
   t.context.mockCreateUserParameters = {
@@ -43,16 +60,35 @@ test.before((t) => {
     lastname: 'nelson',
     phone: '+33622222233',
     role: 'admin',
-    territory: 42,
+    territory_id: 42,
   };
 
-  t.context.middlewareConfig = [
-    'user.create',
+  t.context.middlewareConfigUserCreate = [
+    'registry.user.create',
     [
-      ['territory.users.add', 'call.user.territory', 'territory'],
-      ['operator.users.add', 'call.user.operator', 'operator'],
+      ['territory.users.add', 'call.user.territory_id', 'territory_id'],
+      ['operator.users.add', 'call.user.operator_id', 'operator_id'],
     ],
   ];
+
+  t.context.middlewareConfigTripStats = [
+    'registry.trip.stats',
+    [
+      ['territory.trip.stats', 'call.user.authorizedTerritories', 'territory_id'],
+      ['operator.trip.stats', 'call.user.operator_id', 'operator_id'],
+    ],
+  ];
+
+  t.context.mockAllStatsParams = {
+    date: { start: new Date('2020-01-01T00:00:00+0100') },
+    tz: 'Europe/Paris',
+  };
+
+  t.context.mockTownStatsParams = {
+    date: { start: new Date('2020-01-01T00:00:00+0100') },
+    territory_id: [43],
+    tz: 'Europe/Paris',
+  };
 
   t.context.middleware = new HasPermissionByScopeMiddleware();
 });
@@ -60,9 +96,9 @@ test.before((t) => {
 test('Middleware Scopetoself: has permission to create user', async (t) => {
   const result = await t.context.middleware.process(
     t.context.mockCreateUserParameters,
-    t.context.contextFactory({ permissions: ['user.create'] }),
+    t.context.contextFactory({ permissions: ['registry.user.create'] }),
     () => 'next() called',
-    t.context.middlewareConfig,
+    t.context.middlewareConfigUserCreate,
   );
 
   t.is(result, 'next() called');
@@ -73,10 +109,10 @@ test('Middleware Scopetoself: has permission to create territory user', async (t
     t.context.mockCreateUserParameters,
     t.context.contextFactory({
       permissions: ['territory.users.add'],
-      territory: t.context.mockCreateUserParameters.territory,
+      territory_id: t.context.mockCreateUserParameters.territory_id,
     }),
     () => 'next() called',
-    t.context.middlewareConfig,
+    t.context.middlewareConfigUserCreate,
   );
 
   t.is(result, 'next() called');
@@ -88,7 +124,7 @@ test('Middleware Scopetoself: territory admin - has no permission to create terr
       t.context.mockCreateUserParameters,
       t.context.contextFactory({ permissions: [], territory: t.context.mockCreateUserParameters.territory }),
       () => {},
-      t.context.middlewareConfig,
+      t.context.middlewareConfigUserCreate,
     ),
     { instanceOf: ForbiddenException },
   );
@@ -100,8 +136,61 @@ test('Middleware Scopetoself: registry admin - wrong territory', async (t) => {
       t.context.mockCreateUserParameters,
       t.context.contextFactory({ permissions: ['territory.users.add'], territory: 0 }),
       () => {},
-      t.context.middlewareConfig,
+      t.context.middlewareConfigUserCreate,
     ),
     { instanceOf: ForbiddenException },
   );
+});
+
+test('Middleware Scopetoself: super-admin can trip.stats', async (t) => {
+  const result = await t.context.middleware.process(
+    t.context.mockAllStatsParams,
+    t.context.contextFactory({ permissions: ['registry.trip.stats'] }),
+    () => 'next() called',
+    t.context.middlewareConfigTripStats,
+  );
+
+  t.is(result, 'next() called');
+});
+
+test('Middleware Scopetoself: super-admin can trip.stats with town filter', async (t) => {
+  const result = await t.context.middleware.process(
+    t.context.mockTownStatsParams,
+    t.context.contextFactory({ permissions: ['registry.trip.stats'] }),
+    () => 'next() called',
+    t.context.middlewareConfigTripStats,
+  );
+
+  t.is(result, 'next() called');
+});
+
+test('Middleware Scopetoself: territory-admin can trip.stats', async (t) => {
+  // mock territory_id being added by copy.from_context middleware
+  const params = { ...t.context.mockAllStatsParams, territory_id: t.context.mockTerritoryAdmin.territory_id };
+
+  const context = t.context.contextFactory(t.context.mockTerritoryAdmin);
+
+  const result = await t.context.middleware.process(
+    params,
+    context,
+    () => 'next() called',
+    t.context.middlewareConfigTripStats,
+  );
+
+  t.is(result, 'next() called');
+});
+
+test('Middleware Scopetoself: territory-admin can trip.stats w/ town filter', async (t) => {
+  // mock territory_id being added by copy.from_context middleware
+  const params = { ...t.context.mockAllStatsParams, territory_id: t.context.mockTerritoryAdmin.territory_id };
+  const context = t.context.contextFactory(t.context.mockTerritoryAdmin);
+
+  const result = await t.context.middleware.process(
+    params,
+    context,
+    () => 'next() called',
+    t.context.middlewareConfigTripStats,
+  );
+
+  t.is(result, 'next() called');
 });

--- a/api/providers/middleware/src/HasPermissionByScope/HasPermissionByScopeMiddleware.ts
+++ b/api/providers/middleware/src/HasPermissionByScope/HasPermissionByScopeMiddleware.ts
@@ -7,7 +7,7 @@ import {
   InvalidParamsException,
   ForbiddenException,
 } from '@ilos/common';
-import { get } from 'lodash';
+import { get, includes } from 'lodash';
 import { ConfiguredMiddleware } from '../interfaces';
 
 /**
@@ -43,7 +43,7 @@ export class HasPermissionByScopeMiddleware implements MiddlewareInterface<HasPe
     }
     for (const [scopedPermission, contextPath, paramsPath] of permissionScopes) {
       if (
-        get(context, contextPath, Symbol()) === get(params, paramsPath, Symbol()) &&
+        this.belongsTo(get(params, paramsPath, Symbol()), get(context, contextPath, Symbol())) &&
         permissions.indexOf(scopedPermission) > -1
       ) {
         return next(params, context);
@@ -51,6 +51,12 @@ export class HasPermissionByScopeMiddleware implements MiddlewareInterface<HasPe
     }
 
     throw new ForbiddenException('Invalid permissions');
+  }
+
+  private belongsTo(value: any | any[], list: any | any[]): boolean {
+    const val = Array.isArray(value) ? value : [value];
+    const lst = Array.isArray(list) ? list : [list];
+    return val.reduce((p, c) => p && includes(lst, c), true);
   }
 }
 

--- a/api/providers/middleware/src/helpers.ts
+++ b/api/providers/middleware/src/helpers.ts
@@ -51,7 +51,7 @@ export function groupPermissionMiddlewares(
   if (territoryPermission) {
     middlewareParameters.push([
       territoryPermission,
-      'call.user.authorizedTerritories',
+      'call.user.territory_id',
       buildPathWithPrefix('territory_id', targetPathPrefix),
     ]);
   }

--- a/api/providers/middleware/src/helpers.ts
+++ b/api/providers/middleware/src/helpers.ts
@@ -51,7 +51,7 @@ export function groupPermissionMiddlewares(
   if (territoryPermission) {
     middlewareParameters.push([
       territoryPermission,
-      'call.user.territory_id',
+      'call.user.authorizedTerritories',
       buildPathWithPrefix('territory_id', targetPathPrefix),
     ]);
   }

--- a/api/services/trip/src/actions/ExportAction.ts
+++ b/api/services/trip/src/actions/ExportAction.ts
@@ -2,7 +2,7 @@ import { get } from 'lodash';
 
 import { Action } from '@ilos/core';
 import { handler, ContextType, KernelInterfaceResolver, InvalidParamsException } from '@ilos/common';
-import { copyGroupIdAndApplyGroupPermissionMiddlewares, validateDateMiddleware } from '@pdc/provider-middleware';
+import { copyGroupIdFromContextMiddlewares, validateDateMiddleware } from '@pdc/provider-middleware';
 
 import { TripRepositoryProviderInterfaceResolver } from '../interfaces';
 import { handlerConfig, ParamsInterface, ResultInterface } from '../shared/trip/export.contract';
@@ -12,14 +12,16 @@ import {
   ParamsInterface as BuildParamsInterface,
 } from '../shared/trip/buildExport.contract';
 import * as middlewareConfig from '../config/middlewares';
+import { groupPermissionMiddlewaresHelper } from '../middleware/groupPermissionMiddlewaresHelper';
 
 @handler({
   ...handlerConfig,
   middlewares: [
-    ...copyGroupIdAndApplyGroupPermissionMiddlewares({
-      territory: 'territory.trip.export',
-      operator: 'operator.trip.export',
-      registry: 'registry.trip.export',
+    ...copyGroupIdFromContextMiddlewares(['territory_id', 'operator_id'], null, true),
+    ...groupPermissionMiddlewaresHelper({
+      territory: 'territory.trip.stats',
+      operator: 'operator.trip.stats',
+      registry: 'registry.trip.stats',
     }),
     ['validate', alias],
     validateDateMiddleware({

--- a/api/services/trip/src/actions/FinancialStatsAction.ts
+++ b/api/services/trip/src/actions/FinancialStatsAction.ts
@@ -1,17 +1,19 @@
 import { Action } from '@ilos/core';
 import { handler, ContextType } from '@ilos/common';
-import { copyGroupIdAndApplyGroupPermissionMiddlewares, validateDateMiddleware } from '@pdc/provider-middleware';
+import { copyGroupIdFromContextMiddlewares, validateDateMiddleware } from '@pdc/provider-middleware';
 
 import { handlerConfig, ParamsInterface, ResultInterface } from '../shared/trip/financialStats.contract';
 import { TripRepositoryProvider } from '../providers/TripRepositoryProvider';
 import { alias } from '../shared/trip/stats.schema';
 import { StatCacheRepositoryProviderInterfaceResolver } from '../interfaces/StatCacheRepositoryProviderInterface';
 import * as middlewareConfig from '../config/middlewares';
+import { groupPermissionMiddlewaresHelper } from '../middleware/groupPermissionMiddlewaresHelper';
 
 @handler({
   ...handlerConfig,
   middlewares: [
-    ...copyGroupIdAndApplyGroupPermissionMiddlewares({
+    ...copyGroupIdFromContextMiddlewares(['territory_id', 'operator_id'], null, true),
+    ...groupPermissionMiddlewaresHelper({
       territory: 'territory.trip.stats',
       operator: 'operator.trip.stats',
       registry: 'registry.trip.stats',

--- a/api/services/trip/src/actions/ListAction.ts
+++ b/api/services/trip/src/actions/ListAction.ts
@@ -1,21 +1,23 @@
 import { Action } from '@ilos/core';
 import { handler, ContextType } from '@ilos/common';
 import { get } from 'lodash';
-import { copyGroupIdAndApplyGroupPermissionMiddlewares, validateDateMiddleware } from '@pdc/provider-middleware';
+import { copyGroupIdFromContextMiddlewares, validateDateMiddleware } from '@pdc/provider-middleware';
 
-import { handlerConfig, ParamsInterface, ResultInterface } from '../shared/trip/list.contract';
-import { TripRepositoryProvider } from '../providers/TripRepositoryProvider';
 import { alias } from '../shared/trip/list.schema';
 import * as middlewareConfig from '../config/middlewares';
+import { TripRepositoryProvider } from '../providers/TripRepositoryProvider';
+import { handlerConfig, ParamsInterface, ResultInterface } from '../shared/trip/list.contract';
+import { groupPermissionMiddlewaresHelper } from '../middleware/groupPermissionMiddlewaresHelper';
 
 // TODO
 @handler({
   ...handlerConfig,
   middlewares: [
-    ...copyGroupIdAndApplyGroupPermissionMiddlewares({
-      territory: 'territory.trip.list',
-      operator: 'operator.trip.list',
-      registry: 'registry.trip.list',
+    ...copyGroupIdFromContextMiddlewares(['territory_id', 'operator_id'], null, true),
+    ...groupPermissionMiddlewaresHelper({
+      territory: 'territory.trip.stats',
+      operator: 'operator.trip.stats',
+      registry: 'registry.trip.stats',
     }),
     ['validate', alias],
     validateDateMiddleware({

--- a/api/services/trip/src/actions/SearchCountAction.ts
+++ b/api/services/trip/src/actions/SearchCountAction.ts
@@ -1,19 +1,21 @@
 import { Action } from '@ilos/core';
 import { handler, ContextType, KernelInterfaceResolver } from '@ilos/common';
-import { copyGroupIdAndApplyGroupPermissionMiddlewares, validateDateMiddleware } from '@pdc/provider-middleware';
+import { copyGroupIdFromContextMiddlewares, validateDateMiddleware } from '@pdc/provider-middleware';
 
-import { handlerConfig, ParamsInterface, ResultInterface } from '../shared/trip/searchcount.contract';
-import { TripRepositoryProvider } from '../providers/TripRepositoryProvider';
 import { alias } from '../shared/trip/searchcount.schema';
 import * as middlewareConfig from '../config/middlewares';
+import { TripRepositoryProvider } from '../providers/TripRepositoryProvider';
+import { handlerConfig, ParamsInterface, ResultInterface } from '../shared/trip/searchcount.contract';
+import { groupPermissionMiddlewaresHelper } from '../middleware/groupPermissionMiddlewaresHelper';
 
 @handler({
   ...handlerConfig,
   middlewares: [
-    ...copyGroupIdAndApplyGroupPermissionMiddlewares({
-      territory: 'territory.trip.list',
-      operator: 'operator.trip.list',
-      registry: 'registry.trip.list',
+    ...copyGroupIdFromContextMiddlewares(['territory_id', 'operator_id'], null, true),
+    ...groupPermissionMiddlewaresHelper({
+      territory: 'territory.trip.stats',
+      operator: 'operator.trip.stats',
+      registry: 'registry.trip.stats',
     }),
     ['validate', alias],
     validateDateMiddleware({

--- a/api/services/trip/src/actions/StatsAction.ts
+++ b/api/services/trip/src/actions/StatsAction.ts
@@ -1,17 +1,19 @@
 import { Action } from '@ilos/core';
 import { handler, ContextType } from '@ilos/common';
-import { copyGroupIdAndApplyGroupPermissionMiddlewares, validateDateMiddleware } from '@pdc/provider-middleware';
+import { copyGroupIdFromContextMiddlewares, validateDateMiddleware } from '@pdc/provider-middleware';
 
-import { handlerConfig, ParamsInterface, ResultInterface } from '../shared/trip/stats.contract';
-import { TripRepositoryProvider } from '../providers/TripRepositoryProvider';
 import { alias } from '../shared/trip/stats.schema';
-import { StatCacheRepositoryProviderInterfaceResolver } from '../interfaces/StatCacheRepositoryProviderInterface';
 import * as middlewareConfig from '../config/middlewares';
+import { TripRepositoryProvider } from '../providers/TripRepositoryProvider';
+import { handlerConfig, ParamsInterface, ResultInterface } from '../shared/trip/stats.contract';
+import { groupPermissionMiddlewaresHelper } from '../middleware/groupPermissionMiddlewaresHelper';
+import { StatCacheRepositoryProviderInterfaceResolver } from '../interfaces/StatCacheRepositoryProviderInterface';
 
 @handler({
   ...handlerConfig,
   middlewares: [
-    ...copyGroupIdAndApplyGroupPermissionMiddlewares({
+    ...copyGroupIdFromContextMiddlewares(['territory_id', 'operator_id'], null, true),
+    ...groupPermissionMiddlewaresHelper({
       territory: 'territory.trip.stats',
       operator: 'operator.trip.stats',
       registry: 'registry.trip.stats',

--- a/api/services/trip/src/middleware/groupPermissionMiddlewaresHelper.ts
+++ b/api/services/trip/src/middleware/groupPermissionMiddlewaresHelper.ts
@@ -1,0 +1,22 @@
+import {
+  hasPermissionByScopeMiddleware,
+  HasPermissionByScopeMiddlewareParams,
+  ListOfConfiguredMiddlewares,
+} from '@pdc/provider-middleware';
+
+//
+// Custom groupPermissionMiddlewares() using authorizedTerritories in place of territory_id
+//
+export function groupPermissionMiddlewaresHelper(groups: {
+  territory: string;
+  operator: string;
+  registry: string;
+}): ListOfConfiguredMiddlewares<HasPermissionByScopeMiddlewareParams> {
+  const middlewareParameters = [];
+  const { territory: territoryPermission, operator: operatorPermission, registry: registryPermission } = groups;
+
+  middlewareParameters.push([territoryPermission, 'call.user.authorizedTerritories', 'territory_id']);
+  middlewareParameters.push([operatorPermission, 'call.user.operator_id', 'operator_id']);
+
+  return [hasPermissionByScopeMiddleware(registryPermission, ...middlewareParameters)];
+}


### PR DESCRIPTION
fix du bug #1326 lié à la gestion des permissions des territoires dans le middleware.

- utilisation de `authorizedTerritories` à la place de `territory_id` pour comparer l'appartenance au territoire
- ajout d'une fonction de comparaison utilisant 2 tableaux à la place de 2 entiers dans `HasPermissionByScope`.

**HOTFIX** à mettre en prod rapidement !