### PR TITLE
Rate limiter configurable

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -51,6 +51,9 @@ APP_APP_URL=http://localhost:4200
 APP_CERT_URL=http://localhost:4200
 APP_SHOWCASE_URL=http://localhost:1313
 
+# Multiply the max amount of requests. Pass 0 to disable, default is 1
+# APP_RATE_LIMIT_MAX_FACTOR=1
+
 # Sentry private DSN token for API error reporting (sentry.io)
 APP_SENTRY_DSN=
 


### PR DESCRIPTION
Pour palier à certaines limites lors des tests automatisés, la variable `APP_RATE_LIMITER_MAX_FACTOR` permet de multiplier le nombre max de requêtes acceptées par le _rate limiter_ du proxy.

Pour le désactiver complètement : `0`
Pour garder la configuration par défaut : `1` (valeur par défaut)

Il est possible d'utiliser un nombre à virgule (`0.1`, `1.2`...)