### PR TITLE
Timeout sur les stats

### DIFF
--- a/api/proxy/src/HttpTransport.ts
+++ b/api/proxy/src/HttpTransport.ts
@@ -667,10 +667,12 @@ export class HttpTransport implements TransportInterface {
     );
   }
 
-  private start(port = 8080): void {
+  private start(port = 8080, timeout = 60000): void {
     this.server = this.app.listen(port, () =>
       console.info(`Listening on port ${port}. Version ${this.config.get('sentry.version')}`),
     );
+
+    this.server.timeout = timeout;
   }
 
   /**

--- a/api/proxy/src/HttpTransport.ts
+++ b/api/proxy/src/HttpTransport.ts
@@ -667,12 +667,12 @@ export class HttpTransport implements TransportInterface {
     );
   }
 
-  private start(port = 8080, timeout = 60000): void {
+  private start(port = 8080, timeout = 30000): void {
     this.server = this.app.listen(port, () =>
       console.info(`Listening on port ${port}. Version ${this.config.get('sentry.version')}`),
     );
 
-    this.server.timeout = timeout;
+    this.server.setTimeout(timeout);
   }
 
   /**

--- a/dashboard/src/app/core/const/tooltips.const.ts
+++ b/dashboard/src/app/core/const/tooltips.const.ts
@@ -3,6 +3,7 @@ export const TOOLTIPS = {
     A: 'Classe A : l’opérateur certifie la mise en relation avec intention de covoiturer',
     B: 'Classe B : l’opérateur certifie la mise en relation et le trajet d’un occupant du véhicule',
     C:
-      'Classe C : l’opérateur certifie la mise en relation, les trajets des occupants du véhicule et une identité distincte des occupants',
+      'Classe C : l’opérateur certifie la mise en relation, les trajets des occupants du véhicule ' +
+      'et une identité distincte des occupants',
   },
 };

--- a/dashboard/src/app/core/interceptor/http.interceptor.ts
+++ b/dashboard/src/app/core/interceptor/http.interceptor.ts
@@ -14,6 +14,8 @@ export class HttpApiInterceptor implements HttpInterceptor {
   private api = this.config.get('apiUrl');
   private router: Router;
 
+  private readonly canSkip503 = ['trip:stats', 'trip:searchcount'];
+
   constructor(private config: ConfigService, private injector: Injector, public toastr: ToastrService) {
     this.router = this.injector.get(Router);
   }
@@ -52,7 +54,7 @@ export class HttpApiInterceptor implements HttpInterceptor {
 
           case 0: // Unknown error
           case 503: // Maintenance mode
-            this.router.navigate(['/503']);
+            if (this.can503(req)) this.router.navigate(['/503']);
             break;
 
           default:
@@ -64,5 +66,9 @@ export class HttpApiInterceptor implements HttpInterceptor {
         return throwError(err);
       }),
     );
+  }
+
+  private can503(req: HttpRequest<any>): boolean {
+    return this.canSkip503.reduce((p, c) => p && !req.url.includes(c), true);
   }
 }


### PR DESCRIPTION
#1344 

Bypass du renvoi sur la page 503 pour les appels à `trip:stats` et `trip:searchcount` qui peuvent un peu trainer.