### PR TITLE
Message d'erreur quand les enfants manquent

### DIFF
--- a/dashboard/src/app/modules/territory/modules/territory-ui/components/territory-form/territory-form.component.html
+++ b/dashboard/src/app/modules/territory/modules/territory-ui/components/territory-form/territory-form.component.html
@@ -37,6 +37,10 @@
         (hasTerritories)="hasTerritoriesChanged($event)"
       ></app-territory-children>
 
+      <mat-error class="no-children-error" *ngIf="!hasTerritories && relationDisplayMode === 'parent'">
+        Ajoutez au moins 1 territoire pour valider le formulaire
+      </mat-error>
+
       <div *ngIf="relationDisplayMode === 'insee'">
         <h4>Codes INSEE (séparés par des virgules)</h4>
         <mat-form-field class="relation-textarea" appearance="outline">
@@ -130,7 +134,7 @@
           class="large"
           mat-flat-button
           (click)="onSubmit()"
-          [disabled]="!territoryForm.valid || (!hasTerritories && relationDisplayMode === 'parent')"
+          [disabled]="territoryForm.invalid || (!hasTerritories && relationDisplayMode === 'parent')"
           color="primary"
         >
           {{ !!editedId ? 'Mettre à jour' : 'Créer' }}

--- a/dashboard/src/app/modules/territory/modules/territory-ui/components/territory-form/territory-form.component.scss
+++ b/dashboard/src/app/modules/territory/modules/territory-ui/components/territory-form/territory-form.component.scss
@@ -48,3 +48,13 @@ form {
 .format-radio .mat-radio-button {
   margin: 2px 0;
 }
+
+.no-children-error {
+  padding: 0 0.5em;
+  margin: -3em 0 2em;
+  font-size: 75%;
+  font-weight: 400;
+  line-height: 1.125;
+  font-family: Roboto, 'Helvetica Neue', sans-serif;
+  letter-spacing: normal;
+}


### PR DESCRIPTION
#1348 
Le formulaire de création / édition de territoire est invalide si aucun enfant n'est défini pour un territoire parent.

Ajout d'un message d'erreur pour expliquer ce cas.