### PR TITLE
Ajouter un timeout sur les requêtes backend

### DIFF
--- a/api/ilos/common/src/exceptions/TimeoutException.ts
+++ b/api/ilos/common/src/exceptions/TimeoutException.ts
@@ -1,0 +1,12 @@
+import { RPCException } from './RPCException';
+
+export class TimeoutException extends RPCException {
+  constructor(data?: any) {
+    super('Timeout');
+    this.rpcError = {
+      data,
+      code: -32408,
+      message: this.message,
+    };
+  }
+}

--- a/api/ilos/common/src/exceptions/index.ts
+++ b/api/ilos/common/src/exceptions/index.ts
@@ -9,3 +9,4 @@ export { UnauthorizedException } from './UnauthorizedException';
 export { NotFoundException } from './NotFoundException';
 export { ConflictException } from './ConflictException';
 export { TooManyRequestsException } from './TooManyRequestsException';
+export { TimeoutException } from './TimeoutException';

--- a/api/ilos/core/src/foundation/Kernel.ts
+++ b/api/ilos/core/src/foundation/Kernel.ts
@@ -86,13 +86,12 @@ export abstract class Kernel extends ServiceProvider implements KernelInterface 
    */
   protected async getHandlerAndCall(config, call) {
     const cfg = this.container.get(ConfigInterfaceResolver);
-    const timeout: number = cfg.get('kernel.timeout');
-    let timer = null;
-    if (timeout) {
-      timer = new Promise((resolve, reject) => {
-        setTimeout(reject, timeout);
-      });
-    }
+    const timeout: number = cfg && cfg.get('kernel.timeout', 0);
+    const timer = timeout
+      ? new Promise((resolve, reject) => {
+          setTimeout(reject, timeout);
+        })
+      : undefined;
 
     const handler = this.getContainer().getHandler(config);
     if (!handler) {

--- a/api/ilos/core/src/foundation/Kernel.ts
+++ b/api/ilos/core/src/foundation/Kernel.ts
@@ -2,6 +2,7 @@ import {
   ContainerInterface,
   ParamsType,
   ContextType,
+  ConfigInterfaceResolver,
   ResultType,
   KernelInterface,
   KernelInterfaceResolver,
@@ -11,6 +12,7 @@ import {
   RPCSingleResponseType,
   MethodNotFoundException,
   InvalidRequestException,
+  TimeoutException,
 } from '@ilos/common';
 
 import { hasMultipleCall } from '../helpers/types/hasMultipleCall';
@@ -83,11 +85,25 @@ export abstract class Kernel extends ServiceProvider implements KernelInterface 
    * @memberof Kernel
    */
   protected async getHandlerAndCall(config, call) {
+    const cfg = this.container.get(ConfigInterfaceResolver);
+    const timeout: number = cfg.get('kernel.timeout');
+    let timer = null;
+    if (timeout) {
+      timer = new Promise((resolve, reject) => {
+        setTimeout(reject, timeout);
+      });
+    }
+
     const handler = this.getContainer().getHandler(config);
     if (!handler) {
       throw new MethodNotFoundException(`Unknown method or service ${config.signature}`);
     }
-    return handler(call);
+
+    return !timer
+      ? handler(call)
+      : Promise.race([timer, handler(call)]).catch(() => {
+          throw new TimeoutException(`Timeout Exception (${timeout}ms)`);
+        });
   }
 
   /**

--- a/api/ilos/transport-http/src/helpers/mapStatusCode.ts
+++ b/api/ilos/transport-http/src/helpers/mapStatusCode.ts
@@ -52,6 +52,10 @@ export function mapStatusCode(results: RPCResponseType): number {
       case -32509:
         return 409;
 
+      // Timeout
+      case -32408:
+        return 408;
+
       // Parse error --> Unprocessable entity
       case -32700:
         return 422;

--- a/api/providers/test/src/handlerMacro.ts
+++ b/api/providers/test/src/handlerMacro.ts
@@ -118,7 +118,7 @@ export function handlerMacro<ActionParams, ActionResult, ActionError extends Err
     const err = await t.throwsAsync<ActionError>(async () =>
       kernel.call<ActionParams>(`${handlerConfig.service}:${handlerConfig.method}`, finalParams, context),
     );
-    t.log(err);
+    t.log(err.message);
     if (typeof message === 'function') {
       await message(err, t);
     } else {

--- a/api/proxy/src/config/index.ts
+++ b/api/proxy/src/config/index.ts
@@ -1,10 +1,12 @@
 import * as jwt from './jwt';
+import * as kernel from './kernel';
 import * as proxy from './proxy';
 import * as redis from './redis';
 import * as sentry from './sentry';
 
 export const config = {
   jwt,
+  kernel,
   proxy,
   redis,
   sentry,

--- a/api/proxy/src/config/kernel.ts
+++ b/api/proxy/src/config/kernel.ts
@@ -1,0 +1,3 @@
+import { env } from '@ilos/core';
+
+export const timeout = env('APP_REQUEST_TIMEOUT', 5000);


### PR DESCRIPTION
- Ajout d'un timeout configurable par `APP_REQUEST_TIMEOUT` (default : 30000)
- Ajout d'une `TimeoutException`
- Mapping du code -32408 (non-officiel) vers 408 (officiel) pour les requêtes HTTP

ticket 1358