### PR TITLE
Namespace du docker-compose de test

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,21 +56,19 @@ docker-compose run api yarn migrate
 ### End-to-end testing
 
 ```
-TODO
+# standalone e2e (running in CI)
+docker-compose -f docker-compose.e2e.yml build
+bash e2e.sh e2e
 ```
 
-##### Requirements
-
-- a working DB with `admin@example.com` active user
-
 ```
-#term 1 : cd api && docker-compose compose up api
-#term 2 : cd api && docker-compose compose up worker
-#term 3 : cd dashboard && yarn start
-#term 4 :
-$ cd tests
-$ yarn
-$ CYPRESS_BASE_URL=http://localhost:4200 yarn cy:open
+# local e2e
+docker-compose up api (worker is started too)
+docker-compose up dashboard
+vi .env (set your database to 'test')
+docker-compose run api yarn workspace ilos seed
+cd tests
+CYPRESS_BASE_URL=http://localhost:4200 yarn cy:open
 ```
 
 ##### Notes

--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ You will need `docker` and `docker-compose`.
 | Mailhog     | `mailer`   | APP_MAIL_SMTP_URL | http://localhost:8025      | -          |
 | S3          | `s3`       | AWS\_\*           | http://localhost:9000      | -          |
 
-> \* The Frontend doesn't run in Docker. Install NodeJS locally and run it with `yarn start` from the `dashboard` folder.  
 > ⚠️ `docker-compose.yml` is used in `local` environment only
 
 ### Installation
@@ -37,14 +36,15 @@ You will need `docker` and `docker-compose`.
 5. `./rebuild.sh`
 6. `docker-compose run api yarn migrate`
 
-```
-docker-compose up api
-docker-compose up worker
+```shell
+terminal 1: docker-compose up api
+terminal 2: docker-compose up dashboard
+# nav to http://localhost:4200
 ```
 
 ### Migrations
 
-```
+```shell
 // use SKIP_MIGRATIONS=true to skip migrations in an automated deployment process
 
 cd api
@@ -55,12 +55,12 @@ docker-compose run api yarn migrate
 
 ### End-to-end testing
 
-```
+```shell
 # standalone e2e (running in CI)
 bash e2e.sh
 ```
 
-```
+```shell
 # local e2e
 docker-compose up api (worker is started too)
 docker-compose up dashboard

--- a/README.md
+++ b/README.md
@@ -57,8 +57,7 @@ docker-compose run api yarn migrate
 
 ```
 # standalone e2e (running in CI)
-docker-compose -f docker-compose.e2e.yml build
-bash e2e.sh e2e
+bash e2e.sh
 ```
 
 ```
@@ -68,6 +67,7 @@ docker-compose up dashboard
 vi .env (set your database to 'test')
 docker-compose run api yarn workspace ilos seed
 cd tests
+yarn
 CYPRESS_BASE_URL=http://localhost:4200 yarn cy:open
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -101,6 +101,20 @@ services:
       - mailer
       # - s3
 
+  dashboard:
+    build:
+      dockerfile: ./docker/dashboard/Dockerfile
+      context: .
+    volumes:
+      - ./dashboard:/app/dashboard
+      - ./docker/dashboard/dev.env.js:/app/dashboard/src/assets/env.js
+      - ./shared:/app/shared
+    tty: true
+    ports:
+      - 4200:4200
+    depends_on:
+      - api
+
   lint:
     build: './docker/lint'
     tty: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,8 +60,8 @@ services:
       context: .
     volumes:
       - ./api:/app/api
-      - ./shared:/app/shared
-    command: 'bash -c "pm2-runtime start ../pm2-api.json | pino-pretty"'
+      - ./shared:/app/shared:ro
+    command: 'sh -c "pm2-runtime start ../pm2-api.json | pino-pretty"'
     tty: true
     env_file: ./api/.env
     environment:
@@ -82,8 +82,8 @@ services:
       context: .
     volumes:
       - ./api:/app/api
-      - ./shared:/app/shared
-    command: 'bash -c "pm2-runtime start ../pm2-worker.json | pino-pretty"'
+      - ./shared:/app/shared:ro
+    command: 'sh -c "pm2-runtime start ../pm2-worker.json | pino-pretty"'
     tty: true
     env_file: ./api/.env
     environment:
@@ -107,8 +107,8 @@ services:
       context: .
     volumes:
       - ./dashboard:/app/dashboard
-      - ./docker/dashboard/dev.env.js:/app/dashboard/src/assets/env.js
-      - ./shared:/app/shared
+      - ./docker/dashboard/dev.env.js:/app/dashboard/src/assets/env.js:ro
+      - ./shared:/app/shared:ro
     tty: true
     ports:
       - 4200:4200

--- a/docker/api/Dockerfile
+++ b/docker/api/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14.16.0
+FROM node:14.16.0-alpine
 
 RUN yarn global add pm2 pino-pretty
 RUN mkdir -p /app/shared

--- a/docker/dashboard/Dockerfile
+++ b/docker/dashboard/Dockerfile
@@ -3,11 +3,8 @@ FROM node:14.16.0
 RUN mkdir -p /app/shared
 RUN mkdir -p /app/dashboard
 
-COPY ./shared /app/shared
-COPY ./dashboard /app/dashboard
-
 WORKDIR /app/dashboard
 RUN yarn install
 
-EXPOSE 8080
-CMD ["yarn", "start", "--port=8080", "--disable-host-check", "--host=0.0.0.0"]
+EXPOSE 4200
+CMD ["yarn", "start", "--port=4200", "--disable-host-check", "--host=0.0.0.0"]

--- a/docker/dashboard/Dockerfile
+++ b/docker/dashboard/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14.16.0
+FROM node:14.16.0-alpine
 
 RUN mkdir -p /app/shared
 RUN mkdir -p /app/dashboard

--- a/docker/dashboard/dev.env.js
+++ b/docker/dashboard/dev.env.js
@@ -1,0 +1,6 @@
+window.environment = {
+  production: false,
+  name: 'local',
+  apiUrl: 'http://localhost:8080/',
+  sentryDSN: '',
+};

--- a/docker/lint/Dockerfile
+++ b/docker/lint/Dockerfile
@@ -1,5 +1,4 @@
-FROM node:14
-RUN curl -s --compressed -o- -L https://yarnpkg.com/install.sh | bash
+FROM node:14-alpine
 RUN mkdir -p /code
 WORKDIR /code
 COPY .eslint* ./

--- a/e2e.sh
+++ b/e2e.sh
@@ -1,4 +1,4 @@
-DC="$(which docker-compose) -f docker-compose.e2e.yml"
+DC="$(which docker-compose) -p pdce2e -f docker-compose.e2e.yml"
 CERT_DIR="$(pwd)/docker/traefik/certs"
 
 generate_certs() {


### PR DESCRIPTION
- ajout d'un namespace (_project_) sur les images docker de e2e pour éviter les conflits avec les images de dev.
- utilisation des version `alpine` des images node pour limiter le tps de téléchargement :deciduous_tree: 
 