### PR TITLE
fix: remove production env check for apdf cron process

### DIFF
--- a/api/services/trip/src/actions/ActiveCampaignExcelExportAction.spec.ts
+++ b/api/services/trip/src/actions/ActiveCampaignExcelExportAction.spec.ts
@@ -24,7 +24,6 @@ const test = anyTest as TestInterface<Partial<Context>>;
 test.beforeEach((t) => {
   t.context.fakeKernelInterfaceResolver = new (class extends KernelInterfaceResolver {})();
   t.context.activeCampaignExcelExportAction = new ActiveCampaignExcelExportAction(
-    null,
     t.context.fakeKernelInterfaceResolver,
   );
 

--- a/api/services/trip/src/actions/ActiveCampaignExcelExportAction.ts
+++ b/api/services/trip/src/actions/ActiveCampaignExcelExportAction.ts
@@ -1,57 +1,46 @@
-import {
-  ConfigInterfaceResolver,
-  ContextType,
-  handler,
-  InitHookInterface,
-  KernelInterfaceResolver,
-} from '@ilos/common';
+import { ContextType, handler, InitHookInterface, KernelInterfaceResolver } from '@ilos/common';
 import { Action } from '@ilos/core';
+import { internalOnlyMiddlewares } from '@pdc/provider-middleware/dist';
 import {
   ParamsInterface as ListCampaignsParamInterface,
   ResultInterface as ListCampaignsResultInterface,
   signature as listCampaignsSignature,
 } from '../shared/policy/list.contract';
+import { handlerConfig, ResultInterface, signature } from '../shared/trip/activeCampaignExcelExport.contract';
 import {
   ParamsInterface as BuildExcelExportParamInterface,
   ResultInterface as BuildExcelExportResultInterface,
   signature as buildExcelExportSignature,
 } from '../shared/trip/excelExport.contract';
-import { internalOnlyMiddlewares } from '@pdc/provider-middleware/dist';
-import { handlerConfig, ResultInterface, signature } from '../shared/trip/activeCampaignExcelExport.contract';
 
 @handler({
   ...handlerConfig,
   middlewares: [...internalOnlyMiddlewares(handlerConfig.service)],
 })
 export class ActiveCampaignExcelExportAction extends Action implements InitHookInterface {
-  constructor(private config: ConfigInterfaceResolver, private kernel: KernelInterfaceResolver) {
+  constructor(private kernel: KernelInterfaceResolver) {
     super();
   }
 
   async init(): Promise<void> {
-    /**
-     * Activate fund call exports in production only
-     */
-    if (this.config.get('app.environment') === 'production') {
-      await this.kernel.notify<{}>(
-        signature,
-        {},
-        {
-          call: {
-            user: {},
-          },
-          channel: {
-            service: handlerConfig.service,
-            metadata: {
-              repeat: {
-                cron: '0 5 6 * *',
-              },
-              jobId: 'trip.active_campaign_excel_export',
+    await this.kernel.notify<{}>(
+      signature,
+      {},
+      {
+        call: {
+          user: {},
+        },
+        channel: {
+          service: handlerConfig.service,
+          metadata: {
+            repeat: {
+              cron: '0 5 6 * *',
             },
+            jobId: 'trip.active_campaign_excel_export',
           },
         },
-      );
-    }
+      },
+    );
   }
 
   public async handle(params: {}, context: ContextType): Promise<ResultInterface> {


### PR DESCRIPTION
La cron qui se charge de déclencher la création des appels de fonds n'a pas run pour le mois d'Octobre.
Conditionner le run à l'environnement de prod n'est pas une bonne chose selon moi.