### PR TITLE
fix Redis warnings

### DIFF
--- a/api/ilos/connection-redis/src/RedisConnection.ts
+++ b/api/ilos/connection-redis/src/RedisConnection.ts
@@ -32,16 +32,22 @@ export class RedisConnection implements ConnectionInterface<RedisInterface> {
   }
 
   protected buildClient(): RedisInterface {
+    const defaultConfig = {
+      maxRetriesPerRequest: null,
+      enableReadyCheck: false,
+      // lazyConnect: true,
+    };
+
     if (this.config.connectionString) {
       const { connectionString, ...other } = this.config;
       return new Redis(connectionString, {
+        ...defaultConfig,
         ...other,
-        // lazyConnect: true,
       });
     }
     return new Redis({
+      ...defaultConfig,
       ...this.config,
-      // lazyConnect: true,
     });
   }
 }

--- a/api/ilos/connection-redis/src/RedisConnection.ts
+++ b/api/ilos/connection-redis/src/RedisConnection.ts
@@ -19,7 +19,7 @@ export class RedisConnection implements ConnectionInterface<RedisInterface> {
 
   async down() {
     if (this.connected) {
-      await this.getClient().disconnect();
+      this.getClient().disconnect();
       this.connected = false;
     }
   }


### PR DESCRIPTION
- [x] fix #1550 
- [x] fix du nb d'eventListeners max par connexion

Une nouvelle connexion est créée par queue comme indiqué ici : https://github.com/OptimalBits/bull/issues/1192