### PR TITLE
conf: use sym link to use single tsconf

### DIFF
--- a/api/services/acquisition/tsconfig.json
+++ b/api/services/acquisition/tsconfig.json
@@ -1,12 +1,1 @@
-{
-  "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "outDir": "dist",
-    "baseUrl": ".",
-    "paths": {
-      "*": ["node_modules/*"]
-    }
-  },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules"]
-}
+../../tsconfig.json

--- a/api/services/application/tsconfig.json
+++ b/api/services/application/tsconfig.json
@@ -1,12 +1,1 @@
-{
-  "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "outDir": "dist",
-    "baseUrl": ".",
-    "paths": {
-      "*": ["node_modules/*"]
-    }
-  },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules"]
-}
+../../tsconfig.json

--- a/api/services/carpool/tsconfig.json
+++ b/api/services/carpool/tsconfig.json
@@ -1,12 +1,1 @@
-{
-  "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "outDir": "dist",
-    "baseUrl": ".",
-    "paths": {
-      "*": ["node_modules/*"]
-    }
-  },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules"]
-}
+../../tsconfig.json

--- a/api/services/certificate/tsconfig.json
+++ b/api/services/certificate/tsconfig.json
@@ -1,12 +1,1 @@
-{
-  "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "outDir": "dist",
-    "baseUrl": ".",
-    "paths": {
-      "*": ["node_modules/*"]
-    }
-  },
-  "include": ["src"],
-  "exclude": ["node_modules"]
-}
+../../tsconfig.json

--- a/api/services/company/tsconfig.json
+++ b/api/services/company/tsconfig.json
@@ -1,12 +1,1 @@
-{
-  "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "outDir": "dist",
-    "baseUrl": ".",
-    "paths": {
-      "*": ["node_modules/*"]
-    }
-  },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules"]
-}
+../../tsconfig.json

--- a/api/services/fraud/tsconfig.json
+++ b/api/services/fraud/tsconfig.json
@@ -1,12 +1,1 @@
-{
-  "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "outDir": "dist",
-    "baseUrl": ".",
-    "paths": {
-      "*": ["node_modules/*"]
-    }
-  },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules"]
-}
+../../tsconfig.json

--- a/api/services/honor/tsconfig.json
+++ b/api/services/honor/tsconfig.json
@@ -1,12 +1,1 @@
-{
-  "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "outDir": "dist",
-    "baseUrl": ".",
-    "paths": {
-      "*": ["node_modules/*"]
-    }
-  },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules"]
-}
+../../tsconfig.json

--- a/api/services/monitoring/tsconfig.json
+++ b/api/services/monitoring/tsconfig.json
@@ -1,12 +1,1 @@
-{
-  "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "outDir": "dist",
-    "baseUrl": ".",
-    "paths": {
-      "*": ["node_modules/*"]
-    }
-  },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules"]
-}
+../../tsconfig.json

--- a/api/services/normalization/tsconfig.json
+++ b/api/services/normalization/tsconfig.json
@@ -1,12 +1,1 @@
-{
-  "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "outDir": "dist",
-    "baseUrl": ".",
-    "paths": {
-      "*": ["node_modules/*"]
-    }
-  },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules"]
-}
+../../tsconfig.json

--- a/api/services/operator/tsconfig.json
+++ b/api/services/operator/tsconfig.json
@@ -1,12 +1,1 @@
-{
-  "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "outDir": "dist",
-    "baseUrl": ".",
-    "paths": {
-      "*": ["node_modules/*"]
-    }
-  },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules"]
-}
+../../tsconfig.json

--- a/api/services/policy/tsconfig.json
+++ b/api/services/policy/tsconfig.json
@@ -1,12 +1,1 @@
-{
-  "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "outDir": "dist",
-    "baseUrl": ".",
-    "paths": {
-      "*": ["node_modules/*"]
-    }
-  },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules"]
-}
+../../tsconfig.json

--- a/api/services/territory/tsconfig.json
+++ b/api/services/territory/tsconfig.json
@@ -1,12 +1,1 @@
-{
-  "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "outDir": "dist",
-    "baseUrl": ".",
-    "paths": {
-      "*": ["node_modules/*"]
-    }
-  },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules"]
-}
+../../tsconfig.json

--- a/api/services/trip/tsconfig.json
+++ b/api/services/trip/tsconfig.json
@@ -1,12 +1,1 @@
-{
-  "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "outDir": "dist",
-    "baseUrl": ".",
-    "paths": {
-      "*": ["node_modules/*"]
-    }
-  },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules"]
-}
+../../tsconfig.json


### PR DESCRIPTION
Lien symbolique sur le tsconfig de api pour tous les sous modules:
- Exclusion des tests pour la phase de build (la partie perf ... même si c'est pas énorme)
- Même tsconfig pour tout les sous modules d'api