### PR TITLE
fix: avoid using incentive result if carpool status not ok

### DIFF
--- a/api/services/policy/src/providers/IncentiveRepositoryProvider.ts
+++ b/api/services/policy/src/providers/IncentiveRepositoryProvider.ts
@@ -26,13 +26,14 @@ export class IncentiveRepositoryProvider implements IncentiveRepositoryProviderI
       text: `
         UPDATE ${this.table} AS pi
         SET
-          state = $1::policy.incentive_state_enum
+          state = 'disabled'::policy.incentive_state_enum,
+          status = 'error'::policy.incentive_status_enum
         FROM ${this.tripTable} AS pt
         WHERE
           pt.carpool_id = pi.carpool_id AND
-          pt.carpool_status = $2::carpool.carpool_status_enum
+          pt.carpool_status <> 'ok'::carpool.carpool_status_enum
       `,
-      values: ['disabled', 'canceled'],
+      values: [],
     };
 
     await this.connection.getClient().query(query);


### PR DESCRIPTION
Avant, les trajets non 'ok' n'étaient pas du tout calculé. Maintenant ils arrivent dans le moteur de calcul. Il faut donc : 
- flagger les trajets qui sont non seulement canceled mais aussi en fraudcheck_error (avec le state = disabled)
- exclure ces incitations des export en passant le statut de l'incitation à error