### PR TITLE
remove LOG_LEVEL setting on worker

### DIFF
--- a/api/Procfile
+++ b/api/Procfile
@@ -1,3 +1,3 @@
 web: yarn start:http
-worker: LOG_LEVEL=info APP_POSTGRES_TIMEOUT=0 APP_REQUEST_TIMEOUT=0 yarn start:queue
+worker: APP_POSTGRES_TIMEOUT=0 APP_REQUEST_TIMEOUT=0 yarn start:queue
 postdeploy: yarn migrate && yarn seed:templates


### PR DESCRIPTION
Suppression de `LOG_LEVEL=info` dans le `Procfile` pour éviter d'écraser la config passée dans les variables d'environnement.

```
scalingo -a pdc-prod env-set LOG_LEVEL=info
scalingo -a pdc-prod restart
```
