### PR TITLE
fix: remove duplicate city response that could lead to wrong insee

### DIFF
--- a/api/services/territory/src/providers/GeoRepositoryProvider.ts
+++ b/api/services/territory/src/providers/GeoRepositoryProvider.ts
@@ -57,6 +57,9 @@ export class GeoRepositoryProvider implements GeoRepositoryProviderInterface {
 
     const total = parseFloat(totalResult.rows[0].count || '0');
 
+    values.push(limit);
+    values.push(offset);
+
     const results = await this.connection.getClient().query({
       values,
       text: `
@@ -65,8 +68,8 @@ export class GeoRepositoryProvider implements GeoRepositoryProviderInterface {
         } as tt LEFT OUTER JOIN territory.territory_codes as tc ON tt._id = tc.territory_id
         WHERE (tc.type = 'insee' OR tc.type = 'codedep' OR tc.type IS NULL) AND ${where.join(' AND ')}
         ORDER BY name ASC
-        LIMIT ${limit}
-        OFFSET ${offset}
+        LIMIT $${where.length + 1}
+        OFFSET $${where.length + 2}
       `,
     });
 

--- a/shared/territory/common/geo/GeoCodeTypeEnum.ts
+++ b/shared/territory/common/geo/GeoCodeTypeEnum.ts
@@ -1,4 +1,5 @@
 export enum GeoCodeTypeEnum {
   City = 'city',
   Region = 'region',
+  District = 'district',
 }


### PR DESCRIPTION
Actuellement il  y a plusieurs lignes de retour pour la recherche d'une ville (code postale et code insee).
![image](https://user-images.githubusercontent.com/6213517/147114405-c1033844-88ae-4057-bb6b-654f28aadafc.png)

Afin de fix ça, je fais une jointure avec `territory.territory_codes`

Cela peu poser problème lors du paramétrage d'une campagne avec des exclusions