### PR TITLE
Update stat-graph-trip.component.html

### DIFF
--- a/dashboard/src/app/modules/stat/modules/stat-ui/components/stat-graph/stat-graph-trip/stat-graph-trip.component.html
+++ b/dashboard/src/app/modules/stat/modules/stat-ui/components/stat-graph/stat-graph-trip/stat-graph-trip.component.html
@@ -7,7 +7,7 @@
       <div class="graph-trips-legend">
         <div class="legend-square legend-square-secondary-color"></div>
         <div class="graph-trips-legend-label">
-          <span>Tous les trajets réalisés (incit</span>
+          <span>Tous les trajets réalisés (incités et non incités)</span>
         </div>
       </div>
       <div class="graph-trips-legend">


### PR DESCRIPTION
Fix du label pour les trajets. Le contenu a été tronqué lors de la dernière PR.