### PR TITLE
Fix/cert identities

### DIFF
--- a/api/providers/geo/src/providers/EtalabGeoAdressProvider.ts
+++ b/api/providers/geo/src/providers/EtalabGeoAdressProvider.ts
@@ -15,7 +15,7 @@ export class EtalabGeoAdressProvider implements GeoCoderInterface, InseeCoderInt
       limit: '1',
       autocomplete: '0',
     });
-  
+
     const res = await axios.get(`${this.domain}/search`, { params });
 
     if (!get(res, 'data.features', []).length) {
@@ -33,13 +33,14 @@ export class EtalabGeoAdressProvider implements GeoCoderInterface, InseeCoderInt
       lat,
     };
   }
+
   async positionToInsee(geo: PointInterface): Promise<string> {
     const { lat, lon } = geo;
     const params = new URLSearchParams({
       lat: lat.toString(),
       lon: lon.toString(),
     });
-  
+
     const res = await axios.get(`${this.domain}/reverse`, { params });
 
     if (!get(res, 'data.features', []).length) {

--- a/api/providers/geo/src/providers/OSMNominatimProvider.ts
+++ b/api/providers/geo/src/providers/OSMNominatimProvider.ts
@@ -15,7 +15,7 @@ export class OSMNominatimProvider implements GeoCoderInterface {
       'accept-language': 'fr-fr',
       limit: '1',
     });
-  
+
     let { data } = await axios.get(`${this.domain}/search.php`, { params });
 
     if (data.error || (Array.isArray(data) && data.length === 0)) {

--- a/api/services/carpool/src/ServiceProvider.ts
+++ b/api/services/carpool/src/ServiceProvider.ts
@@ -8,23 +8,25 @@ import { defaultMiddlewareBindings } from '@pdc/provider-middleware';
 import { config } from './config';
 import { binding as crosscheckBinding } from './shared/carpool/crosscheck.schema';
 import { binding as findUuidBinding } from './shared/carpool/finduuid.schema';
+import { binding as findIdentitiesBinding } from './shared/carpool/findidentities.schema';
 import { CarpoolRepositoryProvider } from './providers/CarpoolRepositoryProvider';
 import { CrosscheckAction } from './actions/CrosscheckAction';
 import { FindUuidAction } from './actions/FindUuidAction';
 import { CrosscheckRepositoryProvider } from './providers/CrosscheckRepositoryProvider';
 import { IdentityRepositoryProvider } from './providers/IdentityRepositoryProvider';
 import { UpdateStatusAction } from './actions/UpdateStatusAction';
+import { FindIdentitiesAction } from './actions/FindIdentitiesAction';
 
 @serviceProvider({
   config,
   providers: [CarpoolRepositoryProvider, CrosscheckRepositoryProvider, IdentityRepositoryProvider],
-  validator: [crosscheckBinding, findUuidBinding],
+  validator: [crosscheckBinding, findUuidBinding, findIdentitiesBinding],
   middlewares: [...defaultMiddlewareBindings, ['validate', ValidatorMiddleware]],
   connections: [
     [RedisConnection, 'connections.redis'],
     [PostgresConnection, 'connections.postgres'],
   ],
-  handlers: [CrosscheckAction, FindUuidAction, UpdateStatusAction],
+  handlers: [CrosscheckAction, FindUuidAction, FindIdentitiesAction, UpdateStatusAction],
   queues: ['carpool'],
 })
 export class ServiceProvider extends AbstractServiceProvider {

--- a/api/services/carpool/src/actions/FindIdentitiesAction.ts
+++ b/api/services/carpool/src/actions/FindIdentitiesAction.ts
@@ -1,0 +1,29 @@
+import { Action } from '@ilos/core';
+import { handler } from '@ilos/common';
+import { copyFromContextMiddleware, internalOnlyMiddlewares } from '@pdc/provider-middleware';
+
+import { alias } from '../shared/carpool/findidentities.schema';
+import { IdentityRepositoryProviderInterfaceResolver } from '../interfaces/IdentityRepositoryProviderInterface';
+import { handlerConfig, ParamsInterface, ResultInterface } from '../shared/carpool/findidentities.contract';
+
+/*
+ * Dispatch carpool to other service when ready
+ */
+@handler({
+  ...handlerConfig,
+  middlewares: [
+    ...internalOnlyMiddlewares('certificate'),
+    copyFromContextMiddleware('call.user.operator_id', 'operator_id'),
+    ['validate', alias],
+  ],
+})
+export class FindIdentitiesAction extends Action {
+  constructor(private repository: IdentityRepositoryProviderInterfaceResolver) {
+    super();
+  }
+
+  public async handle(params: ParamsInterface): Promise<ResultInterface> {
+    const { identity, operator_id } = params;
+    return this.repository.findIdentities(identity, { operator_id });
+  }
+}

--- a/api/services/carpool/src/interfaces/IdentityRepositoryProviderInterface.ts
+++ b/api/services/carpool/src/interfaces/IdentityRepositoryProviderInterface.ts
@@ -13,6 +13,7 @@ export interface IdentityRepositoryProviderInterface {
   create(identity: IdentityInterface, meta: IdentityMetaInterface): Promise<{ _id: number; uuid: string }>;
   delete(_id: number): Promise<void>;
   findUuid(identity: IdentityInterface, meta: IdentityMetaInterface, options?: findUuidOptions): Promise<string>;
+  findIdentities(identity: IdentityInterface, meta: IdentityMetaInterface): Promise<string[]>;
 }
 
 export abstract class IdentityRepositoryProviderInterfaceResolver implements IdentityRepositoryProviderInterface {
@@ -32,6 +33,10 @@ export abstract class IdentityRepositoryProviderInterfaceResolver implements Ide
     meta: IdentityMetaInterface,
     options?: findUuidOptions,
   ): Promise<string> {
+    throw new Error('Not implemented');
+  }
+
+  public async findIdentities(identity: IdentityInterface, meta: IdentityMetaInterface): Promise<string[]> {
     throw new Error('Not implemented');
   }
 }

--- a/api/services/certificate/src/actions/CreateCertificateAction.spec.ts
+++ b/api/services/certificate/src/actions/CreateCertificateAction.spec.ts
@@ -30,7 +30,7 @@ interface Context {
   // Constants
   OPERATOR_UUID: string;
   OPERATOR_NAME: string;
-  USER_RPC_UUID: string;
+  USER_RPC_UUID_LIST: string[];
   CERTIFICATE_UUID: string;
 
   // Tested token
@@ -72,7 +72,7 @@ test.beforeEach((t) => {
 
   t.context = {
     OPERATOR_UUID: faker.datatype.uuid(),
-    USER_RPC_UUID: faker.datatype.uuid(),
+    USER_RPC_UUID_LIST: [faker.datatype.uuid(), faker.datatype.uuid()],
     CERTIFICATE_UUID: faker.datatype.uuid(),
     OPERATOR_NAME: faker.random.alpha(),
     fakeKernelInterfaceResolver,
@@ -86,7 +86,7 @@ test.beforeEach((t) => {
   t.context.carpoolRepositoryFindStub = sinon.stub(t.context.carpoolRepositoryProviderInterfaceResolver, 'find');
   t.context.kernelCallStub = sinon.stub(t.context.fakeKernelInterfaceResolver, 'call');
 
-  t.context.kernelCallStub.onCall(0).resolves(t.context.USER_RPC_UUID);
+  t.context.kernelCallStub.onCall(0).resolves(t.context.USER_RPC_UUID_LIST);
   t.context.kernelCallStub.onCall(1).resolves({ uuid: t.context.OPERATOR_UUID, name: t.context.OPERATOR_NAME });
 });
 
@@ -107,7 +107,7 @@ test('CreateCertificateAction: should generate certificate payload', async (t) =
   // Assert
   const expected = {
     tz: 'Europe/Paris',
-    identity: { uuid: t.context.USER_RPC_UUID },
+    identity: { uuid: t.context.USER_RPC_UUID_LIST[0] },
     operator: { uuid: t.context.OPERATOR_UUID, name: t.context.OPERATOR_NAME },
     positions: [],
     carpools: carpoolData,
@@ -133,7 +133,7 @@ test('CreateCertificateAction: should return empty cert if no trips', async (t) 
   // Assert
   const expected = {
     tz: 'Europe/Paris',
-    identity: { uuid: t.context.USER_RPC_UUID },
+    identity: { uuid: t.context.USER_RPC_UUID_LIST[0] },
     operator: { uuid: t.context.OPERATOR_UUID, name: t.context.OPERATOR_NAME },
     positions: [],
     carpools: [],
@@ -171,19 +171,21 @@ function stubCertificateCreateAndGetParams(t) {
   t.context.certificateRepositoryCreateStub.resolves({
     _id: 1,
     uuid: t.context.CERTIFICATE_UUID,
-    identity_uuid: t.context.USER_RPC_UUID,
+    identity_uuid: t.context.USER_RPC_UUID_LIST[0],
     operator_id: 4,
     meta: {
-      identity: { uuid: t.context.USER_RPC_UUID },
+      identity: { uuid: t.context.USER_RPC_UUID_LIST[0] },
     },
   } as CertificateInterface);
+
   const params: ParamsInterface = {
     tz: 'Europe/Paris',
     operator_id: 4,
     identity: {
       phone_trunc: '+33696989598',
-      uuid: t.context.USER_RPC_UUID,
+      uuid: t.context.USER_RPC_UUID_LIST[0],
     },
   };
+
   return params;
 }

--- a/api/services/certificate/src/actions/CreateCertificateAction.ts
+++ b/api/services/certificate/src/actions/CreateCertificateAction.ts
@@ -48,15 +48,15 @@ export class CreateCertificateAction extends AbstractAction {
     const { identity, tz, operator_id, start_at, end_at, positions } = this.castParams(params);
 
     // fetch the data for this identity and operator and map to template object
-    const personUUID = await this.findPerson({ identity, operator_id });
+    const uuidList = await this.findPerson({ identity, operator_id });
     const operator = await this.findOperator({ operator_id, context });
 
     // fetch the data for this identity and operator and store the compiled data
-    const findParams: FindParamsInterface = { personUUID, operator_id, tz, start_at, end_at, positions };
+    const findParams: FindParamsInterface = { uuidList, operator_id, tz, start_at, end_at, positions };
     const carpools: CarpoolInterface[] = await this.carpoolRepository.find(findParams);
     const certificate: CertificateInterface = await this.certRepository.create(
       mapFromCarpools({
-        person: { uuid: personUUID },
+        person: { uuid: uuidList[0] },
         operator,
         carpools,
         params: { tz, start_at, end_at, positions },

--- a/api/services/certificate/src/helpers/findPersonHelper.ts
+++ b/api/services/certificate/src/helpers/findPersonHelper.ts
@@ -7,7 +7,7 @@ export interface ParamsInterface {
   context?: ContextType;
 }
 
-export type ResultsInterface = string;
+export type ResultsInterface = string[];
 
 export interface FindPersonInterface {
   (params: ParamsInterface): Promise<ResultsInterface>;
@@ -18,7 +18,7 @@ export const findPerson = (kernel: KernelInterface): FindPersonInterface =>
     const { identity, operator_id } = params;
 
     return kernel.call(
-      'carpool:finduuid',
+      'carpool:findidentities',
       { identity, operator_id },
       {
         channel: { service: 'certificate' },

--- a/api/services/certificate/src/interfaces/CarpoolRepositoryProviderInterface.ts
+++ b/api/services/certificate/src/interfaces/CarpoolRepositoryProviderInterface.ts
@@ -1,7 +1,7 @@
 import { PointInterface } from '../shared/common/interfaces/PointInterface';
 import { CarpoolInterface } from '../shared/certificate/common/interfaces/CarpoolInterface';
 export interface FindParamsInterface {
-  personUUID: string;
+  uuidList: string[];
   operator_id: number;
   tz: string;
   start_at: Date;

--- a/api/services/certificate/src/providers/CarpoolPgRepositoryProvider.ts
+++ b/api/services/certificate/src/providers/CarpoolPgRepositoryProvider.ts
@@ -18,9 +18,9 @@ export class CarpoolPgRepositoryProvider implements CarpoolRepositoryProviderInt
    * Find all carpools for an identity on a given period of time
    */
   async find(params: FindParamsInterface): Promise<CarpoolInterface[]> {
-    const { personUUID, operator_id, tz, start_at, end_at, positions = [], radius = 1000 } = params;
+    const { uuidList, operator_id, tz, start_at, end_at, positions = [], radius = 1000 } = params;
 
-    const values: any[] = [personUUID, operator_id, start_at, end_at];
+    const values: any[] = [uuidList, operator_id, start_at, end_at];
 
     const where_positions = positions
       .reduce((prev: string[], pos: PointInterface): string[] => {
@@ -62,7 +62,7 @@ export class CarpoolPgRepositoryProvider implements CarpoolRepositoryProviderInt
           WHERE tl.operator_id = $2::int
             AND cc.is_driver = true
             AND cc.status = 'ok'
-            AND tl.driver_id = $1::uuid
+            AND tl.driver_id = ANY($1::uuid[])
             AND tl.journey_start_datetime >= $3
             AND tl.journey_start_datetime < $4
             ${where_positions.length ? `AND (${where_positions})` : ''}
@@ -79,7 +79,7 @@ export class CarpoolPgRepositoryProvider implements CarpoolRepositoryProviderInt
           WHERE tl.operator_id = $2::int
             AND cc.is_driver = false
             AND cc.status = 'ok'
-            AND tl.passenger_id = $1::uuid
+            AND tl.passenger_id = ANY($1::uuid[])
             AND tl.journey_start_datetime >= $3
             AND tl.journey_start_datetime < $4
             ${where_positions.length ? `AND (${where_positions})` : ''}

--- a/api/services/trip/src/actions/opendata/GetRessourceIdIfExists.spec.ts
+++ b/api/services/trip/src/actions/opendata/GetRessourceIdIfExists.spec.ts
@@ -1,5 +1,4 @@
 /* eslint-disable max-len */
-import { ConfigInterfaceResolver } from '@ilos/common';
 import anyTest, { TestFn } from 'ava';
 import sinon, { SinonStub } from 'sinon';
 import { DataGouvProvider } from '../../providers/DataGouvProvider';
@@ -40,9 +39,7 @@ test.before((t) => {
 
 test.beforeEach((t) => {
   t.context.dataGouvProvider = new DataGouvProvider(null);
-  t.context.getRessourceIdIfExists = new GetRessourceIdIfExists(
-    t.context.dataGouvProvider,
-  );
+  t.context.getRessourceIdIfExists = new GetRessourceIdIfExists(t.context.dataGouvProvider);
   t.context.dataGouvProviderStub = sinon.stub(t.context.dataGouvProvider, 'getDataset');
 });
 

--- a/dashboard/src/app/modules/territory/services/territory-api.service.ts
+++ b/dashboard/src/app/modules/territory/services/territory-api.service.ts
@@ -18,10 +18,10 @@ import { JsonRPCParam } from '~/core/entities/api/jsonRPCParam';
 import { JsonRPCResult } from '~/core/entities/api/jsonRPCResult';
 import { CrudActions } from '~/core/services/api/json-rpc.crud';
 import { TerritoryInterface } from '~/shared/territory/common/interfaces/TerritoryInterface';
-import { JsonRPCError } from '../../../core/entities/api/jsonRPCError';
-import { JsonRPCOptions } from '../../../core/entities/api/jsonRPCOptions';
-import { JsonRPCResponse } from '../../../core/entities/api/jsonRPCResponse';
-import { TerritoryBaseInterface } from '../../../core/entities/api/shared/territory/common/interfaces/TerritoryInterface';
+import { JsonRPCError } from '~/core/entities/api/jsonRPCError';
+import { JsonRPCOptions } from '~/core/entities/api/jsonRPCOptions';
+import { JsonRPCResponse } from '~/core/entities/api/jsonRPCResponse';
+import { TerritoryBaseInterface } from '~/core/entities/api/shared/territory/common/interfaces/TerritoryInterface';
 
 @Injectable({
   providedIn: 'root',

--- a/dashboard/src/app/modules/trip/modules/ui-trip/components/trip-table/trip-table.component.ts
+++ b/dashboard/src/app/modules/trip/modules/ui-trip/components/trip-table/trip-table.component.ts
@@ -7,7 +7,7 @@ import { CommonDataService } from '~/core/services/common-data.service';
 import { Campaign } from '~/core/entities/campaign/api-format/campaign';
 import { Operator } from '~/core/entities/operator/operator';
 import { TOOLTIPS } from '~/core/const/tooltips.const';
-import { LightTripInterface } from '../../../../../../core/entities/api/shared/trip/common/interfaces/LightTripInterface';
+import { LightTripInterface } from '~/core/entities/api/shared/trip/common/interfaces/LightTripInterface';
 
 @Component({
   selector: 'app-trip-table',

--- a/dashboard/src/app/modules/trip/pages/trip-export/trip-export.component.ts
+++ b/dashboard/src/app/modules/trip/pages/trip-export/trip-export.component.ts
@@ -10,6 +10,7 @@ import { takeUntil } from 'rxjs/operators';
 import { BaseParamsInterface as TripExportParamsInterface } from '~/shared/trip/export.contract';
 import { DestroyObservable } from '~/core/components/destroy-observable';
 import { AuthenticationService } from '~/core/services/authentication/authentication.service';
+// eslint-disable-next-line max-len
 import { OperatorsCheckboxesComponent } from '../../../operator/modules/operator-ui/components/operators-checkboxes/operators-checkboxes.component';
 import { TripApiService } from '../../services/trip-api.service';
 import { TripExportDialogComponent } from '../trip-export-dialog/trip-export-dialog.component';

--- a/shared/carpool/findidentities.contract.ts
+++ b/shared/carpool/findidentities.contract.ts
@@ -1,0 +1,15 @@
+import { IdentityInterface } from '../common/interfaces/IdentityInterface';
+
+export interface ParamsInterface {
+  identity: IdentityInterface;
+  operator_id?: number;
+}
+
+export type ResultInterface = string[];
+
+export const handlerConfig = {
+  service: 'carpool',
+  method: 'findidentities',
+};
+
+export const signature = `${handlerConfig.service}:${handlerConfig.method}`;

--- a/shared/carpool/findidentities.schema.ts
+++ b/shared/carpool/findidentities.schema.ts
@@ -1,0 +1,15 @@
+import { findIdentity } from '../common/schemas/findIdentity';
+
+export const alias = 'carpool.findidentities';
+export const schema = {
+  $id: alias,
+  type: 'object',
+  required: ['identity', 'operator_id'],
+  additionalProperties: false,
+  properties: {
+    identity: findIdentity,
+    operator_id: { macro: 'dbid' },
+  },
+};
+
+export const binding = [alias, schema];


### PR DESCRIPTION
Ajout de l'action `carpool:findidentities` pour récupérer une liste d'UUID contrairement à `carpool:finduuid` qui retourne le plus récent.

Split de la méthode pour éviter d'impacter le service fraude qui utilise `carpool:uuid`.

Quelques corrections de _lint_ dans un commit séparé qui impacte des fichiers non liés à la modification :thinking: :smile: 