### PR TITLE
fix(proxy): update timeout for stats endpoint only

### DIFF
--- a/api/proxy/src/HttpTransport.ts
+++ b/api/proxy/src/HttpTransport.ts
@@ -613,6 +613,9 @@ export class HttpTransport implements TransportInterface {
       endpoint,
       apiRateLimiter(),
       asyncHandler(async (req: express.Request, res: express.Response, next: express.NextFunction): Promise<void> => {
+        if (req.originalUrl === '/rpc?methods=trip:stats') {
+          res.setTimeout(120000);
+        }
         // inject the req.session.user to context in the body
         const isBatch = Array.isArray(req.body);
         let user = get(req, 'session.user', null);


### PR DESCRIPTION
Y'a un autre timeout à 45 secondes mais ça sera toujours 15 secondes de plus actuellement