### PR TITLE
fix(BuildResourceDescription): add 6 days to fix issue with timezone

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -74,5 +74,8 @@
     "ts-node": "^10.4.0",
     "tsconfig-paths": "^3.11.0",
     "typescript": "^4.4.3"
+  },
+  "resolutions": {
+    "**/async": "^3.2.3"
   }
 }

--- a/api/services/trip/src/actions/opendata/BuildResourceDescription.ts
+++ b/api/services/trip/src/actions/opendata/BuildResourceDescription.ts
@@ -51,9 +51,11 @@ export class BuildResourceDescription {
     intersection: number,
     start_date: Date,
   ): string {
-    return `# Spécificités jeu de données ${start_date.toLocaleString('fr-FR', {
+    const startDatePlus6Days: Date = new Date(start_date.valueOf());
+    startDatePlus6Days.setDate(startDatePlus6Days.getDate() + 6);
+    return `# Spécificités jeu de données ${startDatePlus6Days.toLocaleString('fr-FR', {
       month: 'long',
-    })} ${start_date.getFullYear()}
+    })} ${startDatePlus6Days.getFullYear()}
 Les données concernent également les trajets dont le point de départ OU d'arrivée est situé en dehors du territoire français.
 
 * Nombre trajets collectés et validés par le registre de preuve de covoiturage **${total}**

--- a/api/yarn.lock
+++ b/api/yarn.lock
@@ -1838,20 +1838,10 @@ assert-plus@1.0.0, assert-plus@^1.0.0:
   resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-1.0.0.tgz#f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525"
   integrity sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=
 
-async@^3.2.0:
-  version "3.2.2"
-  resolved "https://registry.yarnpkg.com/async/-/async-3.2.2.tgz#2eb7671034bb2194d45d30e31e24ec7e7f9670cd"
-  integrity sha512-H0E+qZaDEfx/FY4t7iLRv1W2fFI6+pyCeTw1uN20AQPiwqwM6ojPxHxdLv4z8hi2DtnW9BOckSspLucW7pIE5g==
-
-async@~0.9.0:
-  version "0.9.2"
-  resolved "https://registry.yarnpkg.com/async/-/async-0.9.2.tgz#aea74d5e61c1f899613bf64bda66d4c78f2fd17d"
-  integrity sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=
-
-async@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/async/-/async-1.0.0.tgz#f8fc04ca3a13784ade9e1641af98578cfbd647a9"
-  integrity sha1-+PwEyjoTeErenhZBr5hXjPvWR6k=
+async@^3.2.0, async@^3.2.3, async@~0.9.0, async@~1.0.0:
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/async/-/async-3.2.3.tgz#ac53dafd3f4720ee9e8a160628f18ea91df196c9"
+  integrity sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g==
 
 asynckit@^0.4.0:
   version "0.4.0"


### PR DESCRIPTION
Même erreur que pour les APDF [ici](https://github.com/betagouv/preuve-covoiturage/pull/1714) ...
Provoque un décalage de -1 mois sur la description des datasets
![image](https://user-images.githubusercontent.com/6213517/162739530-57999841-6a42-4ce5-a745-b8bcc90584da.png)
