### PR TITLE
Fix/create territory group

### DIFF
--- a/api/services/territory/src/providers/TerritoryRepositoryProvider.ts
+++ b/api/services/territory/src/providers/TerritoryRepositoryProvider.ts
@@ -59,7 +59,7 @@ export class TerritoryRepositoryProvider implements TerritoryRepositoryProviderI
           tg.address,
           tgs.selector
         FROM ${this.table} AS tg
-        JOIN selector AS tgs
+        LEFT JOIN selector AS tgs
           ON tgs.territory_group_id = tg._id
         WHERE 
           tg._id = $1 AND
@@ -143,7 +143,9 @@ export class TerritoryRepositoryProvider implements TerritoryRepositoryProviderI
 
       const resultData = result.rows[0];
 
-      await this.syncSelector(connection, resultData._id, data.selector);
+      if (data.selector) {
+        await this.syncSelector(connection, resultData._id, data.selector);
+      }
 
       await connection.query('COMMIT');
       return { ...resultData, selector: data.selector };
@@ -240,7 +242,9 @@ export class TerritoryRepositoryProvider implements TerritoryRepositoryProviderI
 
       const resultData = result.rows[0];
 
-      await this.syncSelector(connection, resultData._id, data.selector);
+      if (data.selector) {
+        await this.syncSelector(connection, resultData._id, data.selector);
+      }
 
       await connection.query('COMMIT');
       return { ...resultData, selector: data.selector };

--- a/dashboard/src/app/core/entities/territory/territory.ts
+++ b/dashboard/src/app/core/entities/territory/territory.ts
@@ -1,3 +1,4 @@
+import { TerritorySelectorsInterface } from '~/shared/territory/common/interfaces/TerritoryCodeInterface';
 /* tslint:disable:variable-name*/
 import { AbstractControl } from '@angular/forms';
 import { removeNullsProperties } from '~/core/entities/utils';
@@ -15,14 +16,18 @@ export class TerritoryMapper {
     aomSiren: string,
     aomName: string,
   ): CreateTerritoryGroupInterface {
+    let selector: TerritorySelectorsInterface;
+    if (aomSiren) {
+      selector = {
+        aom: [aomSiren],
+      };
+    }
     const territory: CreateTerritoryGroupInterface = {
       name: aomName,
       company_id: company_id,
       contacts: ContactsMapper.toModel(territoryForm.get('contacts')),
       address: removeNullsProperties(territoryForm.get('address').value),
-      selector: {
-        aom: [aomSiren],
-      },
+      selector,
     };
     return territory;
   }

--- a/dashboard/src/app/modules/territory/modules/territory-ui/components/territory-form/territory-form.component.html
+++ b/dashboard/src/app/modules/territory/modules/territory-ui/components/territory-form/territory-form.component.html
@@ -23,7 +23,7 @@
             {{ com.name }}   ({{ com.insee }})
           </div>
         </div>
-        <mat-hint *ngIf="!(comComs && comComs.length > 0)">Aucun référentiel géographique associé à ce numéro de SIRET dans la base Banatic</mat-hint>
+        <mat-hint *ngIf="!(comComs && comComs.length > 0)">Aucun référentiel géographique associé à ce numéro de SIRET</mat-hint>
       </div>  
     </div>
 

--- a/dashboard/src/app/modules/territory/modules/territory-ui/components/territory-form/territory-form.component.html
+++ b/dashboard/src/app/modules/territory/modules/territory-ui/components/territory-form/territory-form.component.html
@@ -6,6 +6,8 @@
   <form class="territoryForm" [formGroup]="territoryForm">
     <h2>Informations générales</h2>
 
+    <mat-error *ngIf="!!territory && hasNoGeoReferential()">Aucun référentiel géographique configuré pour ce territoire</mat-error>
+
     <div class="line">
       <div *ngIf="isRegistryGroup" style="margin-right: 50px;">
         <h3>Structure</h3>
@@ -14,17 +16,16 @@
         <h3>Adresse</h3>
         <app-form-address [parentForm]="territoryForm.get('address')"></app-form-address>
       </div>
-      <div style="flex: 1;" *ngIf="comComs && comComs.length > 0">
+      <div style="flex: 1;" >
         <h3>Communes membres</h3>
-        <div class="comcoms">
+        <div class="comcoms" *ngIf="comComs && comComs.length > 0">
           <div style="width: 50%;" *ngFor="let com of comComs; let idx = index">
             {{ com.name }}   ({{ com.insee }})
           </div>
         </div>
-      </div>
-      <mat-error *ngIf="!(comComs && comComs.length > 0)">Aucune commune associée à ce numéro de SIRET</mat-error>
+        <mat-hint *ngIf="!(comComs && comComs.length > 0)">Aucun référentiel géographique associé à ce numéro de SIRET dans la base Banatic</mat-hint>
+      </div>  
     </div>
-
 
 
     <h2>Contacts et responsables</h2>

--- a/dashboard/src/app/modules/territory/modules/territory-ui/components/territory-form/territory-form.component.ts
+++ b/dashboard/src/app/modules/territory/modules/territory-ui/components/territory-form/territory-form.component.ts
@@ -115,10 +115,6 @@ export class TerritoryFormComponent extends DestroyObservable implements OnInit,
     }
 
     const aomSiren: string = this.getAOMSiren();
-    if (!aomSiren) {
-      // TODO should be toasted when enterring siret
-      this.toastr.error(`Aucune EPCI ou AOM correspondant à ce numéro de SIREN`);
-    }
     const aomName: string = this.getTerritoryName();
 
     const createTerritory: CreateTerritoryGroupInterface = TerritoryMapper.toModel(
@@ -235,11 +231,14 @@ export class TerritoryFormComponent extends DestroyObservable implements OnInit,
             tap((company) => this.updateCompanyForm(company)),
             mergeMap((company) => this.territoryApi.findGeoBySiren({ siren: company.siren })),
           )
-          .subscribe((geoBySirenResponse) => this.updateTerritoryGeoList(geoBySirenResponse));
+          .subscribe((geoBySirenResponse) => this.updateTerritoryGeoListOrToastError(geoBySirenResponse));
       });
   }
 
-  private updateTerritoryGeoList(geoBySirenResponse: FindGeoBySirenResultInterface): void {
+  private updateTerritoryGeoListOrToastError(geoBySirenResponse: FindGeoBySirenResultInterface): void {
+    if (!!!geoBySirenResponse.coms.length) {
+      this.toastr.info(`Aucune EPCI ou AOM correspondant à ce numéro de SIREN`);
+    }
     this.findGeoBySiretResponse = geoBySirenResponse;
     this.comComs = geoBySirenResponse.coms.sort((g1, g2) => g1.name.localeCompare(g2.name));
   }

--- a/shared/territory/common/interfaces/TerritoryInterface.ts
+++ b/shared/territory/common/interfaces/TerritoryInterface.ts
@@ -11,7 +11,7 @@ export interface TerritoryGroupInterface {
   created_at: Date;
   updated_at: Date;
   deleted_at?: Date;
-  selector: TerritorySelectorsInterface;
+  selector?: TerritorySelectorsInterface;
 }
 
 export type CreateTerritoryGroupInterface = Omit<

--- a/shared/territory/common/schema.ts
+++ b/shared/territory/common/schema.ts
@@ -24,7 +24,7 @@ export function schema(alias: string, update = false) {
   return {
     $id: alias,
     type: 'object',
-    required: ['address', 'contacts', 'selector', 'company_id', ...(update ? ['_id'] : [])],
+    required: ['address', 'contacts', 'company_id', ...(update ? ['_id'] : [])],
     additionalProperties: true,
     properties: {
       contacts: { contacts },


### PR DESCRIPTION
On permet le create / update / find d'un `territory_group` sans selecteur pour les bisdev afin de permettre de les ajouter manuellement, à posteriori, par les devs