### PR TITLE
Ajout d'un cron pour le refresh des vues de stats

### DIFF
--- a/api/cron.json
+++ b/api/cron.json
@@ -1,0 +1,8 @@
+{
+  "jobs": [
+    {
+      "command": "0 3 * * 1 yarn workspace @pdc/proxy ilos stats:refresh",
+      "size": "M"
+    }
+  ]
+}

--- a/api/proxy/src/Kernel.ts
+++ b/api/proxy/src/Kernel.ts
@@ -18,6 +18,7 @@ import { bootstrap as territoryBootstrap } from '@pdc/service-territory';
 import { bootstrap as tripcheckBootstrap } from '@pdc/service-trip';
 import { bootstrap as userBootstrap } from '@pdc/service-user';
 import { ProcessJourneyCommand } from './commands/ProcessJourneyCommand';
+import { StatsRefreshCommand } from './commands/StatsRefreshCommand';
 import { SeedCommand } from './commands/SeedCommand';
 import { config } from './config';
 
@@ -40,6 +41,6 @@ import { config } from './config';
     ...honorBootstrap.serviceProviders,
   ],
   providers: [SentryProvider, TokenProvider],
-  commands: [ProcessJourneyCommand, SeedCommand, Commands.CallCommand],
+  commands: [ProcessJourneyCommand, SeedCommand, StatsRefreshCommand, Commands.CallCommand],
 })
 export class Kernel extends BaseKernel {}

--- a/api/proxy/src/commands/StatsRefreshCommand.ts
+++ b/api/proxy/src/commands/StatsRefreshCommand.ts
@@ -1,0 +1,39 @@
+import { command, CommandInterface, CommandOptionType, ResultType, KernelInterfaceResolver } from '@ilos/common';
+import { PostgresConnection } from '@ilos/connection-postgres';
+
+@command()
+export class StatsRefreshCommand implements CommandInterface {
+  static readonly signature: string = 'stats:refresh';
+  static readonly description: string = 'Refresh stats materialized views';
+  static readonly options: CommandOptionType[] = [
+    {
+      signature: '-u, --database-uri <uri>',
+      description: 'Connection string to the database',
+      default: process.env.APP_POSTGRES_URL,
+    },
+  ];
+
+  constructor(protected kernel: KernelInterfaceResolver) {}
+
+  public async call({ databaseUri }): Promise<ResultType> {
+    const connection = new PostgresConnection({ connectionString: databaseUri });
+    await connection.up();
+    const client = await connection.getClient().connect();
+
+    // create metadata table
+    const response = await client.query(`SELECT matviewname FROM pg_matviews WHERE schemaname = 'stats'`);
+    if (!response.rowCount) {
+      console.info('No materialized views to refresh');
+      return 0;
+    }
+
+    for (const { matviewname: table } of response.rows) {
+      const bench = new Date().getTime();
+      await client.query(`REFRESH MATERIALIZED VIEW stats.${table}`);
+      const ms = (new Date().getTime() - bench) / 1000;
+      console.info(`[stats:refresh] Refreshed stats.${table} in ${ms} seconds`);
+    }
+
+    return 'Done!';
+  }
+}


### PR DESCRIPTION
Lancé tous les lundis à 3h du matin.
- liste les vues matérialisées du schéma `stats` et rafraîchi les données
- utilise la fonctionnalité de Scalingo `cron.json` pour lancer la commande de refresh