### PR TITLE
Algo de consolidation des `trip_id`

### DIFF
--- a/api/ilos/core/src/foundation/Kernel.ts
+++ b/api/ilos/core/src/foundation/Kernel.ts
@@ -102,7 +102,7 @@ export abstract class Kernel extends ServiceProvider implements KernelInterface 
       throw new MethodNotFoundException(`Unknown method or service ${config.signature}`);
     }
 
-    console.debug(`[kernel] ${config.signature} ${timeout}ms`);
+    // console.debug(`[kernel] ${config.signature} ${timeout}ms`);
 
     if (timeout === 0) {
       return handler(call);

--- a/api/proxy/src/Kernel.ts
+++ b/api/proxy/src/Kernel.ts
@@ -19,6 +19,7 @@ import { bootstrap as tripcheckBootstrap } from '@pdc/service-trip';
 import { bootstrap as userBootstrap } from '@pdc/service-user';
 import { ProcessJourneyCommand } from './commands/ProcessJourneyCommand';
 import { StatsRefreshCommand } from './commands/StatsRefreshCommand';
+import { ProcessAcquisitionCommand } from './commands/ProcessAcquisitionCommand';
 import { SeedCommand } from './commands/SeedCommand';
 import { config } from './config';
 
@@ -41,6 +42,6 @@ import { config } from './config';
     ...honorBootstrap.serviceProviders,
   ],
   providers: [SentryProvider, TokenProvider],
-  commands: [ProcessJourneyCommand, SeedCommand, StatsRefreshCommand, Commands.CallCommand],
+  commands: [ProcessJourneyCommand, ProcessAcquisitionCommand, SeedCommand, StatsRefreshCommand, Commands.CallCommand],
 })
 export class Kernel extends BaseKernel {}

--- a/api/proxy/src/commands/ProcessAcquisitionCommand.ts
+++ b/api/proxy/src/commands/ProcessAcquisitionCommand.ts
@@ -1,0 +1,108 @@
+import { promisify } from 'util';
+import {
+  command,
+  CommandInterface,
+  CommandOptionType,
+  ResultType,
+  KernelInterfaceResolver,
+  ContextType,
+} from '@ilos/common';
+import { PostgresConnection, Cursor } from '@ilos/connection-postgres';
+
+@command()
+export class ProcessAcquisitionCommand implements CommandInterface {
+  static readonly signature: string = 'process:acquisition';
+  static readonly description: string = 'Push acquisition into the pipeline';
+  static readonly options: CommandOptionType[] = [
+    {
+      signature: '-u, --database-uri <uri>',
+      description: 'Connection string to the database',
+      default: process.env.APP_POSTGRES_URL,
+    },
+    {
+      signature: '-t, --table <table>',
+      description: 'Source table',
+      default: 'acquisition.acquisitions',
+    },
+    {
+      signature: '-s, --startdate <startdate>',
+      description: 'Select carpool with a created_at date after <startdate>',
+      default: '2022-01-01T00:00:00+0100',
+    },
+    {
+      signature: '-e, --enddate <enddate>',
+      description: 'Select carpool with a created_at date before <enddate>',
+      default: '2022-02-01T00:00:00+0100',
+    },
+    {
+      signature: '-l, --limit <limit>',
+      description: 'Limit to apply',
+      coerce: (s: string): number => Number(s),
+    },
+  ];
+
+  constructor(protected kernel: KernelInterfaceResolver) {}
+
+  public async call(options): Promise<ResultType> {
+    const readConnection = new PostgresConnection({ connectionString: options.databaseUri });
+    await readConnection.up();
+    const readClient = await readConnection.getClient().connect();
+
+    const handler = this.kernel.getContainer().getHandler({ signature: 'normalization:process' }) as any;
+
+    // select acquisition missing a carpool
+    const query = {
+      text: `
+        SELECT
+          aa._id,
+          aa.journey_id,
+          aa.operator_id,
+          aa.application_id,
+          aa.payload,
+          aa.created_at
+        FROM ${options.table} AS aa
+        LEFT JOIN carpool.carpools
+        ON aa._id = carpool.carpools.acquisition_id::integer
+        WHERE
+          carpool.carpools.acquisition_id IS NULL
+          AND payload#>>'{driver,start,datetime}' >= $2
+          AND payload#>>'{driver,start,datetime}' <  $3
+        LIMIT $1
+      `,
+      values: [options.limit, options.startdate, options.enddate],
+    };
+
+    const cursorCb = readClient.query(new Cursor(query.text, query.values));
+    const cursor = promisify(cursorCb.read.bind(cursorCb));
+    let count = 0;
+    const ROW_COUNT = 10000;
+
+    const context: ContextType = {
+      channel: {
+        // transport: 'cli',
+        service: 'acquisition', // this is necessary to have right permission on normalization service
+      },
+    };
+
+    do {
+      const result = await cursor(ROW_COUNT);
+      count = result.length;
+
+      for (const line of result) {
+        try {
+          const params = {
+            ...line,
+            created_at: line.created_at.toISOString(),
+          };
+          await handler({ params, context });
+          console.info(`> Operation done for ${line._id}`);
+        } catch (e) {
+          console.error(`> FAILED ${line._id}`);
+          console.error(e);
+        }
+      }
+    } while (count !== 0);
+
+    return 'Done!';
+  }
+}

--- a/api/proxy/src/commands/ProcessAcquisitionCommand.ts
+++ b/api/proxy/src/commands/ProcessAcquisitionCommand.ts
@@ -27,12 +27,12 @@ export class ProcessAcquisitionCommand implements CommandInterface {
     {
       signature: '-s, --startdate <startdate>',
       description: 'Select carpool with a created_at date after <startdate>',
-      default: '2022-01-01T00:00:00+0100',
+      default: '2022-06-01T00:00:00+0200',
     },
     {
       signature: '-e, --enddate <enddate>',
       description: 'Select carpool with a created_at date before <enddate>',
-      default: '2022-02-01T00:00:00+0100',
+      default: '2022-07-01T00:00:00+0200',
     },
     {
       signature: '-l, --limit <limit>',
@@ -63,8 +63,9 @@ export class ProcessAcquisitionCommand implements CommandInterface {
         ON aa._id = carpool.carpools.acquisition_id::integer
         WHERE
           carpool.carpools.acquisition_id IS NULL
-          AND payload#>>'{driver,start,datetime}' >= $2
-          AND payload#>>'{driver,start,datetime}' <  $3
+          AND aa.created_at >= $2
+          AND (payload#>>'{driver,start,datetime}')::timestamp with time zone >= $2
+          AND (payload#>>'{driver,start,datetime}')::timestamp with time zone <  $3
         LIMIT $1
       `,
       values: [options.limit, options.startdate, options.enddate],

--- a/api/services/carpool/src/providers/CrosscheckRepositoryProvider.ts
+++ b/api/services/carpool/src/providers/CrosscheckRepositoryProvider.ts
@@ -67,8 +67,8 @@ export class CrosscheckRepositoryProvider implements CrosscheckRepositoryProvide
           JOIN ${this.identityTable} as identity
           ON carpool.identity_id = identity._id
           WHERE identity.uuid = $1
-          AND carpool.datetime >= timestamptz '${startDateString}'::timestamptz - interval '2 hour'
-          AND carpool.datetime <= timestamptz '${startDateString}'::timestamptz + interval '2 hour'
+          AND carpool.datetime >= timestamptz '${startDateString}'::timestamptz - interval '10 minutes'
+          AND carpool.datetime <= timestamptz '${startDateString}'::timestamptz + interval '10 minutes'
           LIMIT 1
       `,
       values: [identity_uuid],

--- a/api/services/normalization/src/actions/NormalizationProcessAction.ts
+++ b/api/services/normalization/src/actions/NormalizationProcessAction.ts
@@ -96,9 +96,9 @@ export class NormalizationProcessAction extends AbstractAction {
         { channel: { service: 'acquisition' } },
       );
 
-      console.debug('[normalization]:call carpool:crosscheck', {
-        operator_journey_id: normalizedData.operator_journey_id,
-      });
+      // console.debug('[normalization]:call carpool:crosscheck', {
+      //   operator_journey_id: normalizedData.operator_journey_id,
+      // });
 
       await this.kernel.call<CrossCheckParamsInterface, CrossCheckResultInterface>(
         crossCheckSignature,
@@ -176,7 +176,7 @@ export class NormalizationProcessAction extends AbstractAction {
     // Cost ------------------------------------------------------------------------------------
 
     try {
-      console.debug('[normalization]:cost start');
+      // console.debug('[normalization]:cost start');
       const { cost, payments } = await this.kernel.call<CostParamsInterface, CostResultInterface>(
         costSignature,
         {
@@ -201,7 +201,7 @@ export class NormalizationProcessAction extends AbstractAction {
     // Identity ------------------------------------------------------------------------------------
 
     try {
-      console.debug('[normalization]:identity start');
+      // console.debug('[normalization]:identity start');
       finalPerson.identity = await this.kernel.call<IdentityParamsInterface, IdentityResultInterface>(
         identitySignature,
         finalPerson.identity,
@@ -216,7 +216,7 @@ export class NormalizationProcessAction extends AbstractAction {
     // Geo ------------------------------------------------------------------------------------
     let isSubGeoError = false;
     try {
-      console.debug('[normalization]:geo start');
+      // console.debug('[normalization]:geo start');
       const { start, end } = await this.kernel.call<GeoParamsInterface, GeoResultInterface>(
         geoSignature,
         {
@@ -231,7 +231,7 @@ export class NormalizationProcessAction extends AbstractAction {
 
       // Route ------------------------------------------------------------------------------------
       try {
-        console.debug('[normalization]:geo:route start');
+        // console.debug('[normalization]:geo:route start');
         const { calc_distance, calc_duration } = await this.kernel.call<RouteParamsInterface, RouteResultInterface>(
           routeSignature,
           {


### PR DESCRIPTION
Passage de +/- 2h à +/- 10 minutes pour le recollement de trajets.

- ajout de la commande `process:acquisition`
- nettoyage de quelques console.debug trop verbeux