### PR TITLE
fix(TripRepositoryProvider): add missing colaesc for slices

### DIFF
--- a/api/services/trip/src/providers/TripRepositoryProvider.ts
+++ b/api/services/trip/src/providers/TripRepositoryProvider.ts
@@ -406,7 +406,7 @@ export class TripRepositoryProvider implements TripRepositoryInterface {
 
     const lateralString: string = slices
       .map((s, i) => {
-        return `(data.tranche_${i}_count, coalesce(data.tranche_${i}_sum_1)+ coalesce(data.tranche_${i}_sum_2, 0))`;
+        return `(data.tranche_${i}_count, coalesce(data.tranche_${i}_sum_1, 0)+ coalesce(data.tranche_${i}_sum_2, 0))`;
       })
       .join(',');
 


### PR DESCRIPTION
L'argument par défaut coalesce 0 n'étant présent pour la somme du 2ème éléments du tableau d'incentive produisait un null + 0 => un Nan dans les APDF 