### PR TITLE
Fix du timeout de `stats:refresh`

### DIFF
--- a/api/proxy/src/commands/StatsRefreshCommand.ts
+++ b/api/proxy/src/commands/StatsRefreshCommand.ts
@@ -11,11 +11,21 @@ export class StatsRefreshCommand implements CommandInterface {
       description: 'Connection string to the database',
       default: process.env.APP_POSTGRES_URL,
     },
+    {
+      signature: '-t, --timeout',
+      description: 'pg query timeout',
+      default: 2 * 86_400_000, // 2 hours
+    },
   ];
 
   constructor(protected kernel: KernelInterfaceResolver) {}
 
-  public async call({ databaseUri }): Promise<ResultType> {
+  public async call({ databaseUri, timeout }): Promise<ResultType> {
+    // override the environment variable.
+    // the command is run once and this config override will not
+    // affect the global postgresql timeout
+    process.env.APP_POSTGRES_TIMEOUT = `${timeout}`;
+
     const connection = new PostgresConnection({ connectionString: databaseUri });
     await connection.up();
     const client = await connection.getClient().connect();


### PR DESCRIPTION
Le CRON `stats:refresh` lancé chaque semaine utilise le timeout Postgresql par défaut et ne termine pas son execution.

- [x] ajout d'un argument pour la commande `stats:refresh --timeout {number}`
- [x] valeur par défaut de 2 heures (on peut passer `--timeout 0` pour que ça tourne _ad vitam eternam_.

J'ai écrasé `APP_POSTGRES_TIMEOUT` directement en amont de la création de la connexion Postgresql :
1. pour simplifier l'implémentation et coller aux pratiques utilisées ailleurs
2. parce que c'est une commande exécutée dans son propre environnement et que ça ne va pas polluer les autres containers.