### PR TITLE
Fix de la liste de trajets dans le fichier APDF

### DIFF
--- a/api/services/trip/src/actions/excel/BuildExcel.ts
+++ b/api/services/trip/src/actions/excel/BuildExcel.ts
@@ -4,7 +4,6 @@ import { stream } from 'exceljs';
 import { CampaignSearchParamsInterface } from '~/interfaces';
 import { SliceStatInterface } from '~/interfaces/PolicySliceStatInterface';
 import { ResultInterface as Campaign } from '~/shared/policy/find.contract';
-import { PgCursorHandler } from '../../interfaces/PromisifiedPgCursor';
 import { TripRepositoryProvider } from '../../providers/TripRepositoryProvider';
 import { DataWorkBookWriter } from './writer/DataWorkbookWriter';
 import { SlicesWorkbookWriter } from './writer/SlicesWorkbookWriter';
@@ -62,7 +61,7 @@ export class BuildExcel {
 
   private async writeTrips(wkw: stream.xlsx.WorkbookWriter, params: CampaignSearchParamsInterface): Promise<void> {
     try {
-      const tripCursor: PgCursorHandler = await this.getTripsCursor(params);
+      const tripCursor = await this.tripRepoProvider.getPolicyCursor(params, 'territory');
       await this.dataWorkbookWriter.call(tripCursor, wkw);
     } catch (e) {
       console.error('Error while writing trips');
@@ -76,19 +75,5 @@ export class BuildExcel {
     } catch (e) {
       console.error('Error while computing slices');
     }
-  }
-
-  private getTripsCursor(params: CampaignSearchParamsInterface): Promise<PgCursorHandler> {
-    return this.tripRepoProvider.searchWithCursor(
-      {
-        date: {
-          start: params.start_date,
-          end: params.end_date,
-        },
-        campaign_id: [params.campaign_id],
-        operator_id: [params.operator_id],
-      },
-      'territory',
-    );
   }
 }

--- a/api/services/trip/src/actions/excel/BuildExcel.ts
+++ b/api/services/trip/src/actions/excel/BuildExcel.ts
@@ -65,6 +65,7 @@ export class BuildExcel {
       await this.dataWorkbookWriter.call(tripCursor, wkw);
     } catch (e) {
       console.error('Error while writing trips');
+      console.error(e.message);
     }
   }
 
@@ -74,6 +75,7 @@ export class BuildExcel {
       await this.slicesWorkbookWriter.call(wkw, slices);
     } catch (e) {
       console.error('Error while computing slices');
+      console.error(e.message);
     }
   }
 }

--- a/api/services/trip/src/actions/excel/CheckCampaign.spec.ts
+++ b/api/services/trip/src/actions/excel/CheckCampaign.spec.ts
@@ -50,7 +50,7 @@ const successStubArrange = (ctx: Context, operator_ids: number[]): GetCampaignRe
 };
 
 // eslint-disable-next-line max-len
-test('GetCampaignAndCallBuildExcel: should campaign be valid if proveded dates are in date range and one operator', async (t) => {
+test('GetCampaignAndCallBuildExcel: should campaign be valid if provided dates are in date range and one operator', async (t) => {
   // Arrange
   const campaign: GetCampaignResultInterface = successStubArrange(t.context, [5]);
 
@@ -139,7 +139,7 @@ test('GetCampaignAndCallBuildExcel: should throw NotFoundException if no campaig
   sinon.assert.calledOnce(t.context.kernelInterfaceResolverStub);
 });
 
-test('GetCampaignAndCallBuildExcel: should throw InvalidRequestException if draft campaign', async (t) => {
+test('GetCampaignAndCallBuildExcel: should throw Error if draft campaign', async (t) => {
   // Arrange
   t.context.kernelInterfaceResolverStub.resolves(createGetCampaignResultInterface('draft', t.context.CAMPAIGN_NAME));
 
@@ -152,7 +152,7 @@ test('GetCampaignAndCallBuildExcel: should throw InvalidRequestException if draf
   sinon.assert.calledOnce(t.context.kernelInterfaceResolverStub);
 });
 
-test('GetCampaignAndCallBuildExcel: should throw InvalidRequest if campaign dates are not in date range', async (t) => {
+test('GetCampaignAndCallBuildExcel: should throw Error if campaign dates are not in date range', async (t) => {
   // Arrange
   t.context.kernelInterfaceResolverStub.resolves(
     createGetCampaignResultInterface(
@@ -175,5 +175,159 @@ test('GetCampaignAndCallBuildExcel: should throw InvalidRequest if campaign date
   });
 
   // Assert
+  sinon.assert.calledOnce(t.context.kernelInterfaceResolverStub);
+});
+
+test('isValidDateRange: lower = start. end = upper', async (t) => {
+  // Arrange
+  const campaign = createGetCampaignResultInterface(
+    'active',
+    t.context.CAMPAIGN_NAME,
+    new Date('2022-01-01T00:00:00+0100'),
+    new Date('2023-01-01T00:00:00+0100'),
+  );
+  t.context.kernelInterfaceResolverStub.resolves(campaign);
+
+  // Act
+  await t.context.checkCampaign.call(
+    campaign._id,
+    new Date('2022-01-01T00:00:00+0100'),
+    new Date('2023-01-01T00:00:00+0100'),
+  );
+
+  // Assert
+  t.pass();
+  sinon.assert.calledOnce(t.context.kernelInterfaceResolverStub);
+});
+
+test('isValidDateRange: lower = start. end < upper', async (t) => {
+  // Arrange
+  const campaign = createGetCampaignResultInterface(
+    'active',
+    t.context.CAMPAIGN_NAME,
+    new Date('2022-01-01T00:00:00+0100'),
+    new Date('2023-01-01T00:00:00+0100'),
+  );
+  t.context.kernelInterfaceResolverStub.resolves(campaign);
+
+  // Act
+  await t.context.checkCampaign.call(
+    campaign._id,
+    new Date('2022-01-01T00:00:00+0100'),
+    new Date('2022-02-01T00:00:00+0100'),
+  );
+
+  // Assert
+  t.pass();
+  sinon.assert.calledOnce(t.context.kernelInterfaceResolverStub);
+});
+
+test('isValidDateRange: lower < start. end = upper', async (t) => {
+  // Arrange
+  const campaign = createGetCampaignResultInterface(
+    'active',
+    t.context.CAMPAIGN_NAME,
+    new Date('2022-01-01T00:00:00+0100'),
+    new Date('2023-01-01T00:00:00+0100'),
+  );
+  t.context.kernelInterfaceResolverStub.resolves(campaign);
+
+  // Act
+  await t.context.checkCampaign.call(
+    campaign._id,
+    new Date('2022-02-01T00:00:00+0100'),
+    new Date('2023-01-01T00:00:00+0100'),
+  );
+
+  // Assert
+  t.pass();
+  sinon.assert.calledOnce(t.context.kernelInterfaceResolverStub);
+});
+
+test('isValidDateRange: lower > start. end < upper', async (t) => {
+  // Arrange
+  const campaign = createGetCampaignResultInterface(
+    'active',
+    t.context.CAMPAIGN_NAME,
+    new Date('2022-01-01T00:00:00+0100'),
+    new Date('2023-01-01T00:00:00+0100'),
+  );
+  t.context.kernelInterfaceResolverStub.resolves(campaign);
+
+  // Act
+  await t.context.checkCampaign.call(
+    campaign._id,
+    new Date('2021-12-01T00:00:00+0100'),
+    new Date('2022-02-01T00:00:00+0100'),
+  );
+
+  // Assert
+  t.pass();
+  sinon.assert.calledOnce(t.context.kernelInterfaceResolverStub);
+});
+
+test('isValidDateRange: lower < start. end > upper', async (t) => {
+  // Arrange
+  const campaign = createGetCampaignResultInterface(
+    'active',
+    t.context.CAMPAIGN_NAME,
+    new Date('2022-01-01T00:00:00+0100'),
+    new Date('2023-01-01T00:00:00+0100'),
+  );
+  t.context.kernelInterfaceResolverStub.resolves(campaign);
+
+  // Act
+  await t.context.checkCampaign.call(
+    campaign._id,
+    new Date('2022-12-01T00:00:00+0100'),
+    new Date('2023-02-01T00:00:00+0100'),
+  );
+
+  // Assert
+  t.pass();
+  sinon.assert.calledOnce(t.context.kernelInterfaceResolverStub);
+});
+
+test('isValidDateRange: lower < start. end < upper', async (t) => {
+  // Arrange
+  const campaign = createGetCampaignResultInterface(
+    'active',
+    t.context.CAMPAIGN_NAME,
+    new Date('2022-01-01T00:00:00+0100'),
+    new Date('2023-01-01T00:00:00+0100'),
+  );
+  t.context.kernelInterfaceResolverStub.resolves(campaign);
+
+  // Act
+  await t.context.checkCampaign.call(
+    campaign._id,
+    new Date('2022-12-01T00:00:00+0100'),
+    new Date('2023-02-01T00:00:00+0100'),
+  );
+
+  // Assert
+  t.pass();
+  sinon.assert.calledOnce(t.context.kernelInterfaceResolverStub);
+});
+
+test('isValidDateRange: lower > start. end > upper', async (t) => {
+  // Arrange
+  const campaign = createGetCampaignResultInterface(
+    'active',
+    t.context.CAMPAIGN_NAME,
+    new Date('2022-01-01T00:00:00+0100'),
+    new Date('2023-01-01T00:00:00+0100'),
+  );
+  t.context.kernelInterfaceResolverStub.resolves(campaign);
+
+  // Act
+  await t.context.checkCampaign.call(
+    campaign._id,
+    new Date('2021-12-01T00:00:00+0100'),
+    new Date('2023-02-01T00:00:00+0100'),
+  );
+
+  // Assert
+  t.pass();
   sinon.assert.calledOnce(t.context.kernelInterfaceResolverStub);
 });

--- a/api/services/trip/src/interfaces/TripRepositoryProviderInterface.ts
+++ b/api/services/trip/src/interfaces/TripRepositoryProviderInterface.ts
@@ -39,6 +39,7 @@ export interface TripRepositoryInterface {
   validateTz(tz?: string): Promise<TzResultInterface>;
   getPolicyActiveOperators(campaign_id: number, start_date: Date, end_date: Date): Promise<number[]>;
   getPolicyStats(params: CampaignSearchParamsInterface, slices: SliceInterface[]): Promise<PolicyStatsInterface>;
+  getPolicyCursor(params: CampaignSearchParamsInterface): Promise<PgCursorHandler>;
 }
 export abstract class TripRepositoryProviderInterfaceResolver implements TripRepositoryInterface {
   public async stats(params: Partial<TripSearchInterface>): Promise<StatInterface[]> {
@@ -88,6 +89,10 @@ export abstract class TripRepositoryProviderInterfaceResolver implements TripRep
     params: CampaignSearchParamsInterface,
     slices: SliceInterface[],
   ): Promise<PolicyStatsInterface> {
+    throw new Error('Not implemented');
+  }
+
+  public async getPolicyCursor(params: CampaignSearchParamsInterface, type = 'opendata'): Promise<PgCursorHandler> {
     throw new Error('Not implemented');
   }
 }


### PR DESCRIPTION
- use the same selector as getPolicyStats in getPolicyCursor

Il reste un soucis sur la somme des incitations qui n'est pas égale à celle des stats. C'est probablement dû au fait que ça utilise `driver_incentives_rpc_sum` alors que les stats font la somme des `policy.incentives.amount`.