### PR TITLE
FIX node-gyp build

### DIFF
--- a/api/.buildpacks
+++ b/api/.buildpacks
@@ -1,2 +1,2 @@
-https://github.com/Scalingo/nodejs-buildpack.git
 https://github.com/Scalingo/apt-buildpack.git
+https://github.com/Scalingo/nodejs-buildpack.git

--- a/api/Aptfile
+++ b/api/Aptfile
@@ -1,1 +1,4 @@
+build-essential
+gcc
+cmake
 p7zip-full

--- a/api/Aptfile
+++ b/api/Aptfile
@@ -1,4 +1,3 @@
-build-essential
-gcc
+g++
 cmake
 p7zip-full

--- a/api/yarn.lock
+++ b/api/yarn.lock
@@ -4389,7 +4389,7 @@ globby@^13.1.1:
     merge2 "^1.4.1"
     slash "^4.0.0"
 
-google-libphonenumber@^3.2.30:
+google-libphonenumber@^3.2.31:
   version "3.2.31"
   resolved "https://registry.yarnpkg.com/google-libphonenumber/-/google-libphonenumber-3.2.31.tgz#d2c4d4c8d7385be70b515086e4d28dd20da50600"
   integrity sha512-l3bzAkfN4ITICKvuqEiY7JN06RxDAviOoKMtD2KfGYjGK3btPO8Xav7k0fgmf1Ud/pEm523yBh1/s/xDtKEvnw==

--- a/docker/api/Dockerfile
+++ b/docker/api/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:16.13-alpine
 
-RUN apk add p7zip
+RUN apk add p7zip python3 make g++ cmake
 
 RUN yarn global add pm2 pino-pretty db-migrate db-migrate-pg
 RUN mkdir -p /app/shared


### PR DESCRIPTION
Ajout de cmake g++ python3 dans l'image Docker et dépendances Scalingo pour que le build de `node-gyp` fonctionne.