### PR TITLE
Personnalisation de l'adresse de support des attestations opérateur

### DIFF
--- a/api/db/migrations/20221207163054-operators-add-support-column.js
+++ b/api/db/migrations/20221207163054-operators-add-support-column.js
@@ -1,0 +1,10 @@
+'use strict';
+
+var { createMigration } = require('../helpers/createMigration');
+var { setup, up, down } = createMigration([
+  'operator/20221207163054-operators-add-support-column',
+], __dirname);
+
+exports.setup = setup;
+exports.up = up;
+exports.down = down;

--- a/api/db/migrations/operator/20221207163054-operators-add-support-column.down.sql
+++ b/api/db/migrations/operator/20221207163054-operators-add-support-column.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE operator.operators DROP COLUMN support;

--- a/api/db/migrations/operator/20221207163054-operators-add-support-column.up.sql
+++ b/api/db/migrations/operator/20221207163054-operators-add-support-column.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE operator.operators ADD COLUMN support VARCHAR(256);

--- a/api/providers/pdfcert/src/PdfCertProvider.ts
+++ b/api/providers/pdfcert/src/PdfCertProvider.ts
@@ -120,8 +120,8 @@ export class PdfCertProvider implements PdfCertProviderInterface {
 
     // Some help?
     this.text(page, `Un problème, une question ?`, { x: 46, y: 190 });
-    this.text(page, 'Contactez nous par email à', { x: 46, y: 176 });
-    this.text(page, 'attestation@covoiturage.beta.gouv.fr', { x: 172, y: 176, color: rgb(0, 0, 0.8) });
+    this.text(page, 'Contactez nous :', { x: 46, y: 176 });
+    this.text(page, data.support, { x: 124, y: 176, color: rgb(0, 0, 0.8) });
 
     // Notes
     if ('notes' in data.header && data.header.notes !== '') {

--- a/api/providers/pdfcert/src/interfaces/PdfTemplateData.ts
+++ b/api/providers/pdfcert/src/interfaces/PdfTemplateData.ts
@@ -5,6 +5,7 @@ export interface PdfTemplateData {
   data: CertificateMetaInterface;
   identity: string;
   operator: string;
+  support: string;
   certificate: {
     uuid: string;
     created_at: string;

--- a/api/services/certificate/src/actions/DownloadCertificateAction.ts
+++ b/api/services/certificate/src/actions/DownloadCertificateAction.ts
@@ -49,6 +49,7 @@ export class DownloadCertificateAction extends AbstractAction {
       data: certificate.meta,
       identity: certificate.meta.identity.uuid.toUpperCase(),
       operator: certificate.meta.operator.uuid.toUpperCase(),
+      support: certificate.meta.operator.support || this.config.get('templates.certificate.support'),
       certificate: {
         uuid: certificate.uuid.toUpperCase(),
         created_at: `${this.dateProvider.format(certificate.created_at, 'd MMMM yyyy à kk:mm', {

--- a/api/services/certificate/src/config/templates.ts
+++ b/api/services/certificate/src/config/templates.ts
@@ -11,6 +11,7 @@ export const certificate = {
     url: 'https://covoiturage.beta.gouv.fr',
     email: 'contact@covoiturage.beta.gouv.fr',
   },
+  support: 'attestation@covoiturage.beta.gouv.fr',
   validation: {
     url: `${appUrl}/attestation`,
   },

--- a/api/services/certificate/src/helpers/findOperatorHelper.ts
+++ b/api/services/certificate/src/helpers/findOperatorHelper.ts
@@ -9,6 +9,8 @@ export interface ResultsInterface {
   _id: number;
   uuid: string;
   name: string;
+  support: string;
+  thumbnail?: string;
 }
 
 export interface FindOperatorInterface {

--- a/api/services/certificate/src/helpers/mapFromCarpools.ts
+++ b/api/services/certificate/src/helpers/mapFromCarpools.ts
@@ -7,7 +7,7 @@ import { PointInterface } from '../shared/common/interfaces/PointInterface';
 
 export interface ParamsInterface {
   person: { uuid: string };
-  operator: { _id: number; uuid: string; name: string };
+  operator: { _id: number; uuid: string; name: string; support: string };
   carpools: CarpoolInterface[];
   params: Partial<{
     tz: string;
@@ -29,7 +29,7 @@ export const mapFromCarpools = (params: ParamsInterface): CertificateBaseInterfa
     tz,
     positions,
     identity: { uuid: person.uuid },
-    operator: { uuid: operator.uuid, name: operator.name },
+    operator: { uuid: operator.uuid, name: operator.name, support: operator.support },
     driver: agg(CarpoolTypeEnum.DRIVER, carpools),
     passenger: agg(CarpoolTypeEnum.PASSENGER, carpools),
   };

--- a/api/services/operator/src/interfaces/OperatorRepositoryProviderInterface.ts
+++ b/api/services/operator/src/interfaces/OperatorRepositoryProviderInterface.ts
@@ -4,7 +4,10 @@ import { OperatorListInterface } from '../shared/operator/common/interfaces/Oper
 
 export interface OperatorRepositoryProviderInterface {
   find(id: number): Promise<OperatorDbInterface>;
-  quickFind(_id: number, withThumbnail: boolean): Promise<{ uuid: string; name: string; thumbnail?: string }>;
+  quickFind(
+    _id: number,
+    withThumbnail: boolean,
+  ): Promise<{ uuid: string; name: string; support: string; thumbnail?: string }>;
   all(): Promise<OperatorListInterface[]>;
   create(data: OperatorInterface): Promise<OperatorDbInterface>;
   delete(_id: number): Promise<void>;
@@ -22,7 +25,10 @@ export abstract class OperatorRepositoryProviderInterfaceResolver implements Ope
     throw new Error('Not implemented');
   }
 
-  async quickFind(_id: number, withThumbnail: boolean): Promise<{ uuid: string; name: string; thumbnail?: string }> {
+  async quickFind(
+    _id: number,
+    withThumbnail: boolean,
+  ): Promise<{ uuid: string; name: string; support: string; thumbnail?: string }> {
     throw new Error('Not implemented');
   }
   async all(): Promise<OperatorListInterface[]> {

--- a/api/services/operator/src/providers/OperatorPgRepositoryProvider.ts
+++ b/api/services/operator/src/providers/OperatorPgRepositoryProvider.ts
@@ -61,13 +61,17 @@ export class OperatorPgRepositoryProvider implements OperatorRepositoryProviderI
     return operator;
   }
 
-  async quickFind(_id: number, withThumbnail = false): Promise<{ uuid: string; name: string; thumbnail?: string }> {
+  async quickFind(
+    _id: number,
+    withThumbnail = false,
+  ): Promise<{ uuid: string; name: string; support: string; thumbnail?: string }> {
     const selectThumbnail = withThumbnail ? ", encode(ot.data, 'hex')::text AS thumbnail" : '';
     const joinThumbnail = withThumbnail ? ' LEFT JOIN operator.thumbnails ot ON oo._id = ot.operator_id' : '';
 
     const result = await this.connection.getClient().query({
       text: `
-        SELECT uuid, name ${selectThumbnail} FROM ${this.table} oo
+        SELECT uuid, name ${selectThumbnail}, support
+        FROM ${this.table} oo
         ${joinThumbnail}
         WHERE oo._id = $1
         AND oo.deleted_at IS NULL

--- a/shared/certificate/common/interfaces/CertificateMetaInterface.ts
+++ b/shared/certificate/common/interfaces/CertificateMetaInterface.ts
@@ -23,7 +23,7 @@ export interface CertificateMetaInterface {
   tz: string;
   positions: PointInterface[];
   identity: { uuid: string };
-  operator: { uuid: string; name: string };
+  operator: { uuid: string; name: string; support?: string };
   driver: MetaPersonInterface;
   passenger: MetaPersonInterface;
 }

--- a/shared/operator/quickfind.contract.ts
+++ b/shared/operator/quickfind.contract.ts
@@ -6,6 +6,8 @@ export interface ParamsInterface {
 export interface ResultInterface {
   uuid: string;
   name: string;
+  support: string;
+  thumbnail?: string;
 }
 
 export const handlerConfig = {


### PR DESCRIPTION
- ajout de la colonne `support` dans la table des opérateurs
- utilisation de la valeur dans les meta données de l'attestation
- utilisation lors du print du PDF
- fallback configurable sur un email RPC