### PR TITLE
[hotfix] nb de trajets dans les attestations

### DIFF
--- a/api/services/certificate/src/providers/CarpoolPgRepositoryProvider.ts
+++ b/api/services/certificate/src/providers/CarpoolPgRepositoryProvider.ts
@@ -68,7 +68,7 @@ export class CarpoolPgRepositoryProvider implements CarpoolRepositoryProviderInt
           AND cc.identity_id = ANY($1::int[])
           ${where_positions.length ? `AND (${where_positions})` : ''}
       
-        UNION
+        UNION ALL
       
         SELECT
           cc.trip_id,


### PR DESCRIPTION
Utilisation de `UNION ALL` pour ne pas supprimer les résultats avec des données identiques (typiquement sur l'heure de départ).