### PR TITLE
[fix] résolution des INSEE des pays voisins

### DIFF
--- a/api/providers/geo/src/providers/LocalGeoProvider.ts
+++ b/api/providers/geo/src/providers/LocalGeoProvider.ts
@@ -5,7 +5,7 @@ import { PointInterface, InseeCoderInterface } from '../interfaces';
 
 @provider()
 export class LocalGeoProvider implements InseeCoderInterface {
-  protected fn = 'geo.get_latest_by_point';
+  protected fn = 'geo.get_closest_country';
 
   constructor(protected connection: PostgresConnection) {}
 

--- a/api/providers/geo/src/providers/LocalGeoProvider.ts
+++ b/api/providers/geo/src/providers/LocalGeoProvider.ts
@@ -5,7 +5,8 @@ import { PointInterface, InseeCoderInterface } from '../interfaces';
 
 @provider()
 export class LocalGeoProvider implements InseeCoderInterface {
-  protected fn = 'geo.get_closest_country';
+  protected fn = 'geo.get_latest_by_point';
+  protected fb = 'geo.get_closest_country';
 
   constructor(protected connection: PostgresConnection) {}
 
@@ -14,9 +15,15 @@ export class LocalGeoProvider implements InseeCoderInterface {
 
     const comResult = await this.connection.getClient().query({
       text: `
-        SELECT
-          com, arr
+        SELECT com, arr
         FROM ${this.fn}($1::float, $2::float)
+        WHERE com IS NOT NULL
+
+        UNION
+
+        SELECT com, arr
+        FROM ${this.fb}($1::float, $2::float)
+        WHERE country <> 'XXXXX' AND com IS NULL
       `,
       values: [lon, lat],
     });

--- a/api/proxy/load/acquisition_create.js
+++ b/api/proxy/load/acquisition_create.js
@@ -11,7 +11,7 @@ const o = {
   base_url: __ENV.LOAD_BASE_URL || 'http://localhost:8080',
   user: {
     email: 'operator@example.com',
-    password: 'admin1234',
+    password: 'password',
   },
 };
 
@@ -111,13 +111,13 @@ export default function (store) {
         },
         start: {
           datetime: new Date(start).toISOString(),
-          lat: 48.77826,
-          lon: 2.21223,
+          lat: 49.45218,
+          lon: 6.02627,
         },
         end: {
           datetime: new Date(end).toISOString(),
-          lat: 48.82338,
-          lon: 1.78668,
+          lat: 49.45218,
+          lon: 6.02627,
         },
       },
       driver: {
@@ -131,8 +131,8 @@ export default function (store) {
         },
         start: {
           datetime: new Date(start).toISOString(),
-          lat: 48.77826,
-          lon: 2.21223,
+          lat: 49.45218,
+          lon: 6.02627,
         },
         end: {
           datetime: new Date(end).toISOString(),


### PR DESCRIPTION
Suite à l'évolution en 1.2.1 du paquet geo, il est possible d'utiliser `geo.get_closest_country` à la place de `geo.get_latest_by_point` pour résoudre le code INSEE d'un point géographique.

Les contours des pays limitrophes étant volontairement imprécis pour des raisons de performances, il est nécessaire d'utiliser cette fonction de résolution.

**POST DEPLOY**

- [ ] lister les trajets en erreur à cause du code INSEE et les repasser

```sql
-- copie des preuves concernées
create table tmp_replay_errors as (select * from acquisition.acquisitions where error_stage = 'normalization');

-- reset du statut des preuves
update acquisition.acquisitions set status = 'pending' where _id in (select _id from tmp_replay_errors);

-- update des trajets passés en carpool quand c'est terminé
-- TODO

-- cleanup
DROP TABLE tmp_replay_errors;
```

