### PR TITLE
Affichage conditionnel des APDF

### DIFF
--- a/api/ilos/framework/package.json
+++ b/api/ilos/framework/package.json
@@ -28,6 +28,7 @@
     "@ilos/common": "^0.4.1",
     "@ilos/connection-manager": "^0.4.1",
     "@ilos/core": "^0.4.1",
+    "@ilos/handler-http": "0.4.1",
     "@ilos/queue": "^0.4.1",
     "@ilos/tools": "^0.4.1",
     "@ilos/transport-http": "^0.4.1",

--- a/api/services/policy/src/config/apdf.ts
+++ b/api/services/policy/src/config/apdf.ts
@@ -1,0 +1,8 @@
+import { env } from '@ilos/core';
+
+/**
+ * APDF of the current month can be hidden.
+ * Other months will display
+ * Super admins are not affected
+ */
+export const showLastMonth = env('APP_APDF_SHOW_LAST_MONTH', true);

--- a/api/services/policy/src/config/index.ts
+++ b/api/services/policy/src/config/index.ts
@@ -1,7 +1,9 @@
 import * as ajv from './ajv';
+import * as apdf from './apdf';
 import * as connections from './connections';
 
 export const config = {
   ajv,
+  apdf,
   connections,
 };

--- a/api/services/policy/src/interfaces/providers/FundingRequestsRepositoryProviderInterface.ts
+++ b/api/services/policy/src/interfaces/providers/FundingRequestsRepositoryProviderInterface.ts
@@ -6,5 +6,6 @@ export abstract class FundingRequestsRepositoryProviderInterfaceResolver {
   abstract findByCampaign(campaign: SerializedPolicyInterface): Promise<S3.ObjectList>;
   abstract campaignsFilter(campaigns: number[]): (obj: EnrichedFundingRequestType) => boolean;
   abstract operatorsFilter(operators: number[]): (obj: EnrichedFundingRequestType) => boolean;
+  abstract showCurrentMonthFilter(permissions: string[], show: boolean): (obj: EnrichedFundingRequestType) => boolean;
   abstract enrich(list: S3.ObjectList): Promise<EnrichedFundingRequestType[]>;
 }

--- a/api/services/policy/src/providers/FundingRequestsRepositoryProvider.ts
+++ b/api/services/policy/src/providers/FundingRequestsRepositoryProvider.ts
@@ -1,6 +1,7 @@
 import S3 from 'aws-sdk/clients/s3';
 import { provider } from '@ilos/common';
 import { S3StorageProvider, BucketName, APDFNameProvider } from '@pdc/provider-file';
+import { subMonths } from 'date-fns';
 import { SerializedPolicyInterface } from '../interfaces';
 import { FundingRequestsRepositoryProviderInterfaceResolver } from '../interfaces';
 import { EnrichedFundingRequestType } from '../shared/policy/fundingRequestsList.contract';
@@ -40,6 +41,25 @@ export class FundingRequestsRepositoryProvider implements FundingRequestsReposit
   operatorsFilter(operators: number[]) {
     return (obj: EnrichedFundingRequestType): boolean => {
       return operators.length ? operators.indexOf(obj.operator_id) > -1 : true;
+    };
+  }
+
+  // use in a [].filter
+  showCurrentMonthFilter(permissions: string[], show: boolean) {
+    return (obj: EnrichedFundingRequestType): boolean => {
+      // from config
+      if (show) return true;
+
+      // from permissions
+      if (permissions.indexOf('registry.policy.fundingRequestsListCurrentMonth') > -1) {
+        return true;
+      }
+
+      // show all but last month
+      const fileMonth = obj.datetime.toISOString().substring(0, 7);
+      const lastMonth = subMonths(new Date(), 1).toISOString().substring(0, 7);
+
+      return fileMonth !== lastMonth;
     };
   }
 }

--- a/shared/user/permissions.config.ts
+++ b/shared/user/permissions.config.ts
@@ -73,6 +73,7 @@ const permissions = {
     'registry.admin',
   ],
   'policy.fundingRequestsList': ['operator.admin', 'territory.admin', 'registry.admin'],
+  'policy.fundingRequestsListCurrentMonth': ['registry.admin'],
   'policy.fundingRequestsExport': ['registry.admin'],
   'trip.list': [
     'operator.user',


### PR DESCRIPTION
#1951 

Possibilité de masquer les APDF du mois dernier aux opérateurs et territoires en attendant la validation du RPC.

Passer la variable d'environnement `APP_APDF_SHOW_LAST_MONTH` à `false` pour les masquer.