### PR TITLE
Attestation sans `phone_trunc`

### DIFF
--- a/shared/certificate/common/interfaces/IdentityIdentifiersInterface.ts
+++ b/shared/certificate/common/interfaces/IdentityIdentifiersInterface.ts
@@ -2,4 +2,5 @@ export type IdentityIdentifiersInterface =
   | { _id: number }
   | { uuid: string }
   | { phone: string }
-  | { phone_trunc: string; operator_user_id: string };
+  | { phone_trunc: string; operator_user_id: string }
+  | { operator_user_id: string };


### PR DESCRIPTION
#1945 

Ajout de la possibilité de créer un attestation uniquement avec l'`operator_user_id`.