### PR TITLE
fix(policy): try catch on each trip to avoid computation abort

### DIFF
--- a/api/services/policy/src/actions/SimulateOnPastAction.ts
+++ b/api/services/policy/src/actions/SimulateOnPastAction.ts
@@ -72,14 +72,18 @@ export class SimulateOnPastAction extends AbstractAction {
       done = results.done;
       if (results.value) {
         for (const carpool of results.value) {
-          // 3. For each trip, process
-          const incentive = await policy.processStateless(carpool);
-          const finalIncentive = await policy.processStateful(store, incentive.export());
-          const finalAmount = finalIncentive.get();
-          if (finalAmount > 0) {
-            carpool_subsidized += 1;
+          // 3. For each trip, process stateless and stateful safely
+          try {
+            const incentive = await policy.processStateless(carpool);
+            const finalIncentive = await policy.processStateful(store, incentive.export());
+            const finalAmount = finalIncentive.get();
+            if (finalAmount > 0) {
+              carpool_subsidized += 1;
+            }
+            amount += finalAmount;
+          } catch (e) {
+            console.error(e);
           }
-          amount += finalAmount;
         }
       }
     } while (!done);

--- a/api/services/policy/src/actions/SimulateOnPastByGeoAction.ts
+++ b/api/services/policy/src/actions/SimulateOnPastByGeoAction.ts
@@ -77,14 +77,18 @@ export class SimulateOnPastByGeoAction extends AbstractAction {
       done = results.done;
       if (results.value) {
         for (const carpool of results.value) {
-          // 3. Process stateless and stateful for each trip
-          const incentive = await policy.processStateless(carpool);
-          const finalIncentive = await policy.processStateful(store, incentive.export());
-          const finalAmount = finalIncentive.get();
-          if (finalAmount > 0) {
-            carpool_subsidized += 1;
+          // 3. For each trip, process stateless and stateful safely
+          try {
+            const incentive = await policy.processStateless(carpool);
+            const finalIncentive = await policy.processStateful(store, incentive.export());
+            const finalAmount = finalIncentive.get();
+            if (finalAmount > 0) {
+              carpool_subsidized += 1;
+            }
+            amount += finalAmount;
+          } catch (e) {
+            console.error(e);
           }
-          amount += finalAmount;
         }
       }
     } while (!done);


### PR DESCRIPTION
Fix la simulation draft de Normandie. 
Si un trajet était en erreur à cause du référentiel geo, ça faisait crash la simulation entière et on est pas au trajet prêt.