### PR TITLE
fix: avoid double free

### DIFF
--- a/api/services/fraud/src/providers/FraudCheckRepositoryProvider.integration.spec.ts
+++ b/api/services/fraud/src/providers/FraudCheckRepositoryProvider.integration.spec.ts
@@ -197,10 +197,12 @@ test.serial('Should rollback if update error', async (t) => {
   );
   t.deepEqual(result1, [1]);
 
-  await t.throwsAsync(async () => {
+  await t.notThrowsAsync(async () => {
     const data = createFraudCheck({ acquisition_id: result1[0] });
     await fn1({ ...data, status: 'status_not_existing' as FraudCheckStatusEnum });
   });
+
+  await fn1();
   const [result2, fn2] = await t.context.repository.findThenUpdate({
     limit: 1,
     status: FraudCheckStatusEnum.Pending,


### PR DESCRIPTION
Fix de l'erreur

```json
{
  "level": 50,
  "time": 1675859163850,
  "pid": 63,
  "hostname": "pdc-prod-worker-1",
  "err": {
    "type": "Error",
    "message": "Release called on client which has already been released to the pool.",
    "stack": "Error: Release called on client which has already been released to the pool.
                    at throwOnDoubleRelease (/app/node_modules/pg-pool/index.js:27:9)
                    at Client.release (/app/node_modules/pg-pool/index.js:318:9)
                    at /app/services/fraud/dist/providers/FraudCheckRepositoryProvider.js:96:34
                    at runMicrotasks (<anonymous>)
                    at processTicksAndRejections (node:internal/process/task_queues:96:5)"
  },
  "msg": "unhandled promise rejection"
}
```