### PR TITLE
bump @betagouvpdc/evolution-geo to 1.2.4

### DIFF
--- a/api/db/package.json
+++ b/api/db/package.json
@@ -16,10 +16,9 @@
     "coverage": "exit 0"
   },
   "dependencies": {
-    "@betagouvpdc/evolution-geo": "^1.2.3",
-    "@types/node": "^17.0.8",
-    "@types/sinon": "^10.0.6",
+    "@betagouvpdc/evolution-geo": "^1.2.4",
     "db-migrate": "^0.11.13",
     "db-migrate-pg": "^1.2.2"
-  }
+  },
+  "devDependencies": {}
 }

--- a/api/yarn.lock
+++ b/api/yarn.lock
@@ -205,10 +205,10 @@
     "@babel/helper-validator-identifier" "^7.19.1"
     to-fast-properties "^2.0.0"
 
-"@betagouvpdc/evolution-geo@^1.2.3":
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/@betagouvpdc/evolution-geo/-/evolution-geo-1.2.3.tgz#5f7fbc51cfd2324520d2242181519b806ffdb9e0"
-  integrity sha512-1jeAyvNuUsabkkzdIqqtbwATBDi0r77Q2YU3tjACOMjFMO5gyYUUX+2k8zimdetqYJ1zyommpJIVSXAZSoNx0A==
+"@betagouvpdc/evolution-geo@^1.2.4":
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/@betagouvpdc/evolution-geo/-/evolution-geo-1.2.4.tgz#c7692a417a8617a0ee1c9c1a6ef312d2a2cd8fba"
+  integrity sha512-BpJbQuU8f5ciF88nXSL6E0+UiMMYiEhLaIG6mZQe+NlwXNHBeQjnL2ypgkenjQkcQ/F1S7pr1ZTzSO7DGpL4ZA==
   dependencies:
     axios "^1.1.3"
     commander "^9.4.1"
@@ -1724,7 +1724,7 @@
     "@types/mime" "*"
     "@types/node" "*"
 
-"@types/sinon@^10.0.3", "@types/sinon@^10.0.6":
+"@types/sinon@^10.0.3":
   version "10.0.13"
   resolved "https://registry.yarnpkg.com/@types/sinon/-/sinon-10.0.13.tgz#60a7a87a70d9372d0b7b38cc03e825f46981fb83"
   integrity sha512-UVjDqJblVNQYvVNUsj0PuYYw0ELRmgt1Nt5Vk0pT5f16ROGfcKJY8o1HVuMOJOpD727RrGB9EGvoaTQE5tgxZQ==
@@ -1763,7 +1763,7 @@
   dependencies:
     "@types/node" "*"
 
-"@xmldom/xmldom@^0.8.6":
+"@xmldom/xmldom@0.8", "@xmldom/xmldom@^0.8.6":
   version "0.8.6"
   resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.8.6.tgz#8a1524eb5bd5e965c1e3735476f0262469f71440"
   integrity sha512-uRjjusqpoqfmRkTaNuLJ2VohVr67Q5YwDATW3VU7PfzTj6IRaihGrYI7zckGZjxQPBIp63nfvJbM+Yu5ICh0Bg==
@@ -2079,19 +2079,7 @@ asn1@^0.2.4:
   dependencies:
     safer-buffer "~2.1.0"
 
-async@3.2.3:
-  version "3.2.3"
-  resolved "https://registry.yarnpkg.com/async/-/async-3.2.3.tgz#ac53dafd3f4720ee9e8a160628f18ea91df196c9"
-  integrity sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g==
-
-async@^2.6.4:
-  version "2.6.4"
-  resolved "https://registry.yarnpkg.com/async/-/async-2.6.4.tgz#706b7ff6084664cd7eae713f6f965433b5504221"
-  integrity sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==
-  dependencies:
-    lodash "^4.17.14"
-
-async@^3.2.3:
+async@3.2.3, async@^2.6.4, async@^3.2.3:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/async/-/async-3.2.4.tgz#2d22e00f8cddeb5fde5dd33522b56d1cf569a81c"
   integrity sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==
@@ -5495,7 +5483,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==
 
-lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.21:
+lodash@^4.17.15, lodash@^4.17.21:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==


### PR DESCRIPTION
Bump de la lib evolution-geo et nettoyage des dépendances.

La v1.2.4 ne migre pas les centroids à chaque déploiement !