### PR TITLE
Amélioration du parsing JSON de ilos call

### DIFF
--- a/api/ilos/cli/src/commands/CallCommand.ts
+++ b/api/ilos/cli/src/commands/CallCommand.ts
@@ -2,6 +2,17 @@ import { command, KernelInterfaceResolver, ResultType, CommandOptionType } from 
 
 import { Command } from '../parents/Command';
 
+function coerceToJson(s: string): object {
+  try {
+    if ('string' !== typeof s) return {};
+    if (!s.length) return {};
+    return JSON.parse(s);
+  } catch (e) {
+    console.error(e.message);
+    return {};
+  }
+}
+
 /**
  * Command that make an RPC call
  * @export
@@ -16,12 +27,14 @@ export class CallCommand extends Command {
     {
       signature: '-p, --params <params>',
       description: 'Set call parameters',
-      coerce: (val) => JSON.parse(val),
+      default: {},
+      coerce: coerceToJson,
     },
     {
       signature: '-c, --context <context>',
       description: 'Set call context',
-      coerce: (val) => JSON.parse(val),
+      default: {},
+      coerce: coerceToJson,
     },
   ];
 


### PR DESCRIPTION
Amélioration du parsing JSON de ilos call pour ne pas crasher quand on passe une chaine vide ou que le param `-p` ou `-c` n'est pas passé.

les erreurs sont remontées par l'action appelée si les params ou le contexte ne sont pas bons.