### PR TITLE
Fix du calcul de incentive_sum

### DIFF
--- a/api/services/policy/src/providers/IncentiveRepositoryProvider.ts
+++ b/api/services/policy/src/providers/IncentiveRepositoryProvider.ts
@@ -271,14 +271,14 @@ export class IncentiveRepositoryProvider implements IncentiveRepositoryProviderI
 
   async updateIncentiveSum(): Promise<void> {
     await this.connection.getClient().query(`
-      UPDATE POLICY.POLICIES P
-      SET INCENTIVE_SUM = POLICY_INCENTIVE_SUM.AMOUNT
+      UPDATE policy.policies p
+      SET incentive_sum = policy_incentive_sum.amount
       FROM
-        (SELECT POLICY_ID, COALESCE(SUM(RESULT),0)::int AS AMOUNT
-          FROM POLICY.INCENTIVES
-          WHERE STATUS = 'validated'
-          GROUP BY POLICY_ID) AS POLICY_INCENTIVE_SUM
-      WHERE P._ID = POLICY_INCENTIVE_SUM.POLICY_ID
+        (SELECT policy_id, coalesce(sum(amount),0)::int AS amount
+          FROM policy.incentives
+          WHERE status = 'validated'
+          GROUP BY policy_id) AS policy_incentive_sum
+      WHERE p._id = policy_incentive_sum.policy_id
     `);
   }
 }


### PR DESCRIPTION
Utilisation de `amount` à la place de `result` pour le calcul de `incentive_sum` dans la table policies.

`amount` est le montant corrigé par l'action `campaign:finalize` après application des règles stateful.
`result` est le montant calculé par `campaign:apply`