### PR TITLE
[hotfix] listing des APDF pour les territoires

### DIFF
--- a/api/services/apdf/src/providers/StorageRepositoryProvider.ts
+++ b/api/services/apdf/src/providers/StorageRepositoryProvider.ts
@@ -16,8 +16,14 @@ export class StorageRepositoryProvider implements StorageRepositoryProviderInter
   constructor(private s3StorageProvider: S3StorageProvider, private APDFNameProvider: APDFNameProvider) {}
 
   async findByCampaign(campaign: SerializedPolicyInterface): Promise<S3.ObjectList> {
-    const list = await this.s3StorageProvider.list(this.bucket, `${campaign._id}`);
-    return list.filter((obj: S3.Object) => obj.Size > 0);
+    try {
+      const list = await this.s3StorageProvider.list(this.bucket, `${campaign._id}`);
+      return list.filter((obj: S3.Object) => obj.Size > 0);
+    } catch (e) {
+      console.error(`[Apdf:StorageRepo:findByCampaign] ${e.message}`);
+      console.debug(e.stack);
+      throw e;
+    }
   }
 
   async enrich(list: S3.ObjectList): Promise<EnrichedApdfType[]> {

--- a/shared/apdf/list.contract.ts
+++ b/shared/apdf/list.contract.ts
@@ -1,6 +1,7 @@
 export interface ParamsInterface {
   campaign_id: number;
   operator_id?: number;
+  territory_id?: number;
 }
 
 export type EnrichedApdfType = {

--- a/shared/apdf/list.schema.ts
+++ b/shared/apdf/list.schema.ts
@@ -5,6 +5,7 @@ export const schema = {
   properties: {
     campaign_id: { macro: 'serial' },
     operator_id: { macro: 'serial' },
+    territory_id: { macro: 'serial' },
   },
 };
 


### PR DESCRIPTION
Ajout de `territory_id` dans le schema de `apdf:list` car le middleware l'injecte quand l'utilisateur est un territoire.