### PR TITLE
fix(github): force node 16 install to avoid node 17 build error

### DIFF
--- a/.github/workflows/deploy-doc-production.yml
+++ b/.github/workflows/deploy-doc-production.yml
@@ -1,7 +1,7 @@
 name: Deploy documentation - production
 on:
   push:
-    branches: [dev, fix/deploy_doc_production]
+    branches: [dev]
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-doc-production.yml
+++ b/.github/workflows/deploy-doc-production.yml
@@ -1,7 +1,7 @@
 name: Deploy documentation - production
 on:
   push:
-    branches: [dev]
+    branches: [dev, fix/deploy_doc_production]
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-doc-production.yml
+++ b/.github/workflows/deploy-doc-production.yml
@@ -10,6 +10,13 @@ jobs:
         uses: actions/checkout@v3
         with:
           persist-credentials: false
+      
+      - name: Install NodeJS 16
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+          cache: 'yarn'
+          cache-dependency-path: doc/yarn.lock
 
       - name: Install and Build 🔧
         run: |


### PR DESCRIPTION
Force nodeJS 16.
Working build => https://github.com/betagouv/preuve-covoiturage/actions/runs/4512630793/jobs/7946350939?pr=2084