### PR TITLE
Feat/atmb

### DIFF
--- a/api/services/policy/src/engine/helpers/startAndEndAtOrThrow.spec.ts
+++ b/api/services/policy/src/engine/helpers/startAndEndAtOrThrow.spec.ts
@@ -1,0 +1,33 @@
+import test from 'ava';
+
+import { StatelessContext } from '../entities/Context';
+import { generateCarpool } from '../tests/helpers';
+import { TerritoryCodeInterface } from '../../interfaces';
+import { startAndEndAtOrThrow } from './startAndEndAtOrThrow';
+import { NotEligibleTargetException } from '../exceptions/NotEligibleTargetException';
+
+function setup(start: TerritoryCodeInterface, end: TerritoryCodeInterface) {
+  return StatelessContext.fromCarpool(1, generateCarpool({ start, end }));
+}
+
+test('should throw if start and end not in perimeter', async (t) => {
+  const ctx = setup(
+    { aom: '217500016', com: '91471', reg: '11', epci: '200056232' },
+    { aom: '217500016', com: '91471', reg: '11', epci: '200056232' },
+  );
+  t.throws(
+    () => {
+      startAndEndAtOrThrow(ctx, { reg: ['84'] });
+    },
+    { instanceOf: NotEligibleTargetException },
+  );
+});
+
+test('should pass if start and end is in perimeter', async (t) => {
+  const ctx = setup(
+    { aom: '217500016', com: '91471', reg: '11', epci: '200056232' },
+    { aom: '217500016', com: '91471', reg: '11', epci: '200056232' },
+  );
+  const res = startAndEndAtOrThrow(ctx, { aom: ['217500016'] });
+  t.is(res, true);
+});

--- a/api/services/policy/src/engine/helpers/startAndEndAtOrThrow.ts
+++ b/api/services/policy/src/engine/helpers/startAndEndAtOrThrow.ts
@@ -1,0 +1,13 @@
+import { StatelessContextInterface, StatelessRuleHelper, TerritorySelectorsInterface } from '../../interfaces';
+import { NotEligibleTargetException } from '../exceptions/NotEligibleTargetException';
+import { startsAndEndsAt } from './position';
+
+export const startAndEndAtOrThrow: StatelessRuleHelper<TerritorySelectorsInterface> = (
+  ctx: StatelessContextInterface,
+  selector: TerritorySelectorsInterface,
+): boolean => {
+  if (!startsAndEndsAt(ctx, selector)) {
+    throw new NotEligibleTargetException('Journey start & end not in region');
+  }
+  return true;
+};

--- a/api/services/policy/src/engine/policies/Atmb.html.ts
+++ b/api/services/policy/src/engine/policies/Atmb.html.ts
@@ -1,0 +1,30 @@
+export const description = `<p _ngcontent-pmm-c231="" id="summary" class="campaignSummaryText-content-text">
+<p>Campagne d’incitation au covoiturage du <b> 2 mai 2023 au 31 décembre 2023</b>, toute la semaine
+</p>
+<p>Cette campagne est limitée à
+  <b>24 400 euros </b>.
+</p>
+<p>
+Le périmètre géographique de la campagne comprend les zones suivantes
+</p>
+<ul>
+  <li>Communauté de communes Cluses Arve et Montagnes</li>
+  <li>Communauté de communes Pays du Mont Blanc</li>
+  <li>Communauté de communes Vallée de Chamonix</li>
+  <li>Communauté de communes des Montagnes du Giffre</li>
+  <li>Communauté de communes des 4 rivières</li>
+  <li>Communauté de communes de Vallée Verte</li>
+</ul>
+<p>Les <b> conducteurs </b> effectuant un trajet d'au moins 2 km, avec pour origine et destination le périmètre ci-dessus,
+sont incités selon les règles suivantes : </p>
+<ul>
+  <li><b>De 4 à 20 km : 2 euros par trajet par passager transporté.</b></li>
+  <li><b>De 20 à 40 km : 0.1 euros (10 centimes d'euro) par km par passager</b></li>
+</ul>
+<p>Les restrictions suivantes seront appliquées :</p>
+<ul>
+  <li><b>120 € maximum pour le conducteur par mois.</b></li>
+</ul>
+<p>La campagne est limitée à l'opérateur <b>Klaxit, Karos et BlablaCar Daily</b> proposant des preuves de classe <b>B ou C</b>.</p>
+<p></p>
+</p>`;

--- a/api/services/policy/src/engine/policies/Atmb.html.ts
+++ b/api/services/policy/src/engine/policies/Atmb.html.ts
@@ -25,6 +25,6 @@ sont incités selon les règles suivantes : </p>
 <ul>
   <li><b>120 € maximum pour le conducteur par mois.</b></li>
 </ul>
-<p>La campagne est limitée à l'opérateur <b>Klaxit, Karos et BlablaCar Daily</b> proposant des preuves de classe <b>B ou C</b>.</p>
+<p>La campagne est limitée aux opérateurs <b>Klaxit, Karos et BlablaCar Daily</b> proposant des preuves de classe <b>B ou C</b>.</p>
 <p></p>
 </p>`;

--- a/api/services/policy/src/engine/policies/Atmb.spec.ts
+++ b/api/services/policy/src/engine/policies/Atmb.spec.ts
@@ -1,0 +1,117 @@
+import test from 'ava';
+import { v4 } from 'uuid';
+import { OperatorsEnum } from '../../interfaces';
+import { makeProcessHelper } from '../tests/macro';
+import { Atmb as Handler } from './Atmb';
+
+const defaultPosition = {
+  arr: '74278',
+  com: '74278',
+  aom: '200033116',
+  epci: '200033116',
+  dep: '74',
+  reg: '84',
+  country: 'XXXXX',
+  reseau: '142',
+};
+
+const defaultCarpool = {
+  _id: 1,
+  trip_id: v4(),
+  passenger_identity_uuid: v4(),
+  driver_identity_uuid: v4(),
+  operator_siret: OperatorsEnum.Klaxit,
+  operator_class: 'C',
+  passenger_is_over_18: true,
+  passenger_has_travel_pass: true,
+  driver_has_travel_pass: true,
+  datetime: new Date('2023-04-15'),
+  seats: 1,
+  duration: 600,
+  distance: 5_000,
+  cost: 20,
+  driver_payment: 20,
+  passenger_payment: 20,
+  start: { ...defaultPosition },
+  end: { ...defaultPosition },
+};
+
+const process = makeProcessHelper(defaultCarpool);
+
+test(
+  'should work with exclusion',
+  process,
+  {
+    policy: { handler: Handler.id },
+    carpool: [
+      { operator_siret: 'not in list' },
+      { distance: 100 },
+      { operator_class: 'A' },
+      { start: { ...defaultPosition, aom: '11' } },
+      { end: { ...defaultPosition, aom: '11' } },
+    ],
+    meta: [],
+  },
+  { incentive: [0, 0, 0, 0, 0], meta: [] },
+);
+
+test(
+  'should work basic',
+  process,
+  {
+    policy: { handler: Handler.id },
+    carpool: [
+      { distance: 5_000, driver_identity_uuid: 'one' },
+      { distance: 5_000, seats: 2, driver_identity_uuid: 'one' },
+      { distance: 25_000, driver_identity_uuid: 'one', passenger_identity_uuid: 'two' },
+      { distance: 40_000, driver_identity_uuid: 'one', passenger_identity_uuid: 'three' },
+      { distance: 40_000, seats: 2, driver_identity_uuid: 'one', passenger_identity_uuid: 'three' },
+      { distance: 60_000, driver_identity_uuid: 'one' },
+    ],
+    meta: [],
+  },
+  {
+    incentive: [200, 400, 250, 400, 800, 400],
+    meta: [
+      {
+        key: 'max_amount_restriction.0-one.month.3-2023',
+        value: 2450,
+      },
+      {
+        key: 'max_amount_restriction.global.campaign.global',
+        value: 2450,
+      },
+    ],
+  },
+);
+
+test(
+  'should work with driver month limits',
+  process,
+  {
+    policy: { handler: Handler.id },
+    carpool: [
+      { distance: 5_000, driver_identity_uuid: 'one' },
+      { distance: 5_000, driver_identity_uuid: 'one' },
+    ],
+    meta: [
+      {
+        key: 'max_amount_restriction.0-one.month.3-2023',
+        value: 118_00,
+      },
+    ],
+  },
+  {
+    incentive: [200, 0],
+    meta: [
+      {
+        key: 'max_amount_restriction.0-one.month.3-2023',
+        value: 120_00,
+      },
+      {
+        key: 'max_amount_restriction.global.campaign.global',
+        value: 200,
+      },
+    ],
+  },
+);

--- a/api/services/policy/src/engine/policies/Atmb.ts
+++ b/api/services/policy/src/engine/policies/Atmb.ts
@@ -1,0 +1,93 @@
+import {
+  OperatorsEnum,
+  PolicyHandlerInterface,
+  PolicyHandlerParamsInterface,
+  PolicyHandlerStaticInterface,
+  StatelessContextInterface,
+  TerritorySelectorsInterface,
+} from '../../interfaces';
+import { RunnableSlices } from '../../interfaces/engine/PolicyInterface';
+import {
+  isOperatorClassOrThrow,
+  isOperatorOrThrow,
+  LimitTargetEnum,
+  onDistanceRange,
+  onDistanceRangeOrThrow,
+  perKm,
+  perSeat,
+  watchForGlobalMaxAmount,
+  watchForPersonMaxAmountByMonth,
+} from '../helpers';
+import { startAndEndAtOrThrow } from '../helpers/startAndEndAtOrThrow';
+import { AbstractPolicyHandler } from './AbstractPolicyHandler';
+import { description } from './Atmb.html';
+
+// Politique sur le réseau ATMB
+// eslint-disable-next-line max-len
+export const Atmb: PolicyHandlerStaticInterface = class extends AbstractPolicyHandler implements PolicyHandlerInterface {
+  static readonly id = 'atmb_2023';
+  protected operators = [OperatorsEnum.BlaBlaDaily, OperatorsEnum.Karos, OperatorsEnum.Klaxit];
+  protected operator_class = ['B', 'C'];
+
+  constructor(public max_amount: number) {
+    super();
+    this.limits = [
+      ['AFE1C47D-BF05-4FA9-9133-853D29797D09', 120_00, watchForPersonMaxAmountByMonth, LimitTargetEnum.Driver],
+      ['98B26189-C6FC-4DB1-AC1C-41F779C5B3C7', this.max_amount, watchForGlobalMaxAmount],
+    ];
+  }
+
+  protected selector: TerritorySelectorsInterface = {
+    aom: ['200033116', '200023372', '247000623'],
+    epci: ['200034882', '200034098', '247400047', '200070852'],
+  };
+
+  protected slices: RunnableSlices = [
+    {
+      start: 4_000,
+      end: 20_000,
+      fn: (ctx: StatelessContextInterface) => perSeat(ctx, 200),
+    },
+    {
+      start: 20_000,
+      end: 40_000,
+      fn: (ctx: StatelessContextInterface) => perSeat(ctx, perKm(ctx, { amount: 10, offset: 20_000, limit: 40_000 })),
+    },
+  ];
+
+  protected processExclusion(ctx: StatelessContextInterface) {
+    isOperatorOrThrow(ctx, this.operators);
+    onDistanceRangeOrThrow(ctx, { min: 4_000 });
+    isOperatorClassOrThrow(ctx, this.operator_class);
+    startAndEndAtOrThrow(ctx, this.selector);
+  }
+
+  processStateless(ctx: StatelessContextInterface): void {
+    this.processExclusion(ctx);
+    super.processStateless(ctx);
+
+    // Par kilomètre
+    let amount = 0;
+    for (const { start, fn } of this.slices) {
+      if (onDistanceRange(ctx, { min: start })) {
+        amount += fn(ctx);
+      }
+    }
+
+    ctx.incentive.set(amount);
+  }
+
+  params(): PolicyHandlerParamsInterface {
+    return {
+      slices: this.slices,
+      operators: this.operators,
+      limits: {
+        glob: this.max_amount,
+      },
+    };
+  }
+
+  describe(): string {
+    return description;
+  }
+};

--- a/api/services/policy/src/engine/policies/MetropoleSavoie.spec.ts
+++ b/api/services/policy/src/engine/policies/MetropoleSavoie.spec.ts
@@ -109,11 +109,6 @@ test(
   },
   {
     incentive: [0, 0],
-    meta: [
-      {
-        key: 'max_amount_restriction.global.campaign.global',
-        value: 0,
-      },
-    ],
+    meta: [],
   },
 );

--- a/api/services/policy/src/engine/policies/MetropoleSavoie.ts
+++ b/api/services/policy/src/engine/policies/MetropoleSavoie.ts
@@ -1,4 +1,3 @@
-import { RunnableSlices } from '../../interfaces/engine/PolicyInterface';
 import {
   OperatorsEnum,
   PolicyHandlerInterface,
@@ -6,7 +5,7 @@ import {
   PolicyHandlerStaticInterface,
   StatelessContextInterface,
 } from '../../interfaces';
-import { NotEligibleTargetException } from '../exceptions/NotEligibleTargetException';
+import { RunnableSlices } from '../../interfaces/engine/PolicyInterface';
 import {
   isOperatorClassOrThrow,
   isOperatorOrThrow,
@@ -14,9 +13,9 @@ import {
   onDistanceRangeOrThrow,
   perKm,
   perSeat,
-  startsAndEndsAt,
   watchForGlobalMaxAmount,
 } from '../helpers';
+import { startAndEndAtOrThrow } from '../helpers/startAndEndAtOrThrow';
 import { AbstractPolicyHandler } from './AbstractPolicyHandler';
 import { description } from './MetropoleSavoie.html';
 
@@ -41,16 +40,12 @@ export const MetropoleSavoie: PolicyHandlerStaticInterface = class extends Abstr
     isOperatorOrThrow(ctx, this.operators);
     onDistanceRangeOrThrow(ctx, { min: 5_000 });
     isOperatorClassOrThrow(ctx, ['B', 'C']);
+    startAndEndAtOrThrow(ctx, { aom: ['200068674', '200069110'], epci: ['200041010'] });
   }
 
   processStateless(ctx: StatelessContextInterface): void {
     this.processExclusion(ctx);
     super.processStateless(ctx);
-
-    // Départ et arrivée dans l'aom
-    if (!startsAndEndsAt(ctx, { aom: ['200068674', '200069110'], epci: ['200041010'] })) {
-      throw new NotEligibleTargetException('Journey start & end not in region');
-    }
 
     // Calcul des incitations par tranche
     let amount = 0;

--- a/api/services/policy/src/engine/policies/Nm.ts
+++ b/api/services/policy/src/engine/policies/Nm.ts
@@ -1,4 +1,3 @@
-import { RunnableSlices } from '../../interfaces/engine/PolicyInterface';
 import {
   OperatorsEnum,
   PolicyHandlerInterface,
@@ -6,9 +5,8 @@ import {
   PolicyHandlerStaticInterface,
   StatelessContextInterface,
 } from '../../interfaces';
-import { NotEligibleTargetException } from '../exceptions/NotEligibleTargetException';
+import { RunnableSlices } from '../../interfaces/engine/PolicyInterface';
 import {
-  endsAt,
   isOperatorClassOrThrow,
   isOperatorOrThrow,
   LimitTargetEnum,
@@ -16,12 +14,12 @@ import {
   onDistanceRangeOrThrow,
   perKm,
   perSeat,
-  startsAt,
   watchForGlobalMaxAmount,
   watchForGlobalMaxTrip,
   watchForPassengerMaxByTripByDay,
   watchForPersonMaxTripByDay,
 } from '../helpers';
+import { startAndEndAtOrThrow } from '../helpers/startAndEndAtOrThrow';
 import { AbstractPolicyHandler } from './AbstractPolicyHandler';
 import { description } from './Nm.html';
 
@@ -50,11 +48,8 @@ export const Nm: PolicyHandlerStaticInterface = class extends AbstractPolicyHand
     isOperatorOrThrow(ctx, this.operators);
     onDistanceRangeOrThrow(ctx, { min: 2_000 });
     isOperatorClassOrThrow(ctx, this.operatorClass);
-
     // Exclure les trajets qui ne sont pas dans l'aom NM
-    if (!startsAt(ctx, { aom: ['244400404'] }) || !endsAt(ctx, { aom: ['244400404'] })) {
-      throw new NotEligibleTargetException();
-    }
+    startAndEndAtOrThrow(ctx, { aom: ['244400404'] });
   }
 
   processStateless(ctx: StatelessContextInterface): void {

--- a/api/services/policy/src/engine/policies/Normandie.ts
+++ b/api/services/policy/src/engine/policies/Normandie.ts
@@ -9,10 +9,10 @@ import {
   isOperatorClassOrThrow,
   LimitTargetEnum,
   onDistanceRangeOrThrow,
-  startsAndEndsAt,
   watchForGlobalMaxAmount,
   watchForPersonMaxTripByDay,
 } from '../helpers';
+import { startAndEndAtOrThrow } from '../helpers/startAndEndAtOrThrow';
 import { AbstractPolicyHandler } from './AbstractPolicyHandler';
 import { description } from './Normandie.html';
 
@@ -38,11 +38,7 @@ export const Normandie: PolicyHandlerStaticInterface = class
   protected processExclusion(ctx: StatelessContextInterface) {
     onDistanceRangeOrThrow(ctx, { min: 5_000 });
     isOperatorClassOrThrow(ctx, this.operator_class);
-
-    // Dans la région
-    if (!startsAndEndsAt(ctx, { reg: ['28'] })) {
-      throw new NotEligibleTargetException('Journey start & end not in region');
-    }
+    startAndEndAtOrThrow(ctx, { reg: ['28'] });
 
     // En excluant les trajets intra aom excepté les epci n'ayant pas la compétence mobilité
     if (

--- a/api/services/policy/src/engine/policies/Occitanie.ts
+++ b/api/services/policy/src/engine/policies/Occitanie.ts
@@ -14,10 +14,10 @@ import {
   LimitTargetEnum,
   onDistanceRangeOrThrow,
   onWeekday,
-  startsAndEndsAt,
   watchForGlobalMaxAmount,
   watchForPersonMaxTripByDay,
 } from '../helpers';
+import { startAndEndAtOrThrow } from '../helpers/startAndEndAtOrThrow';
 import { AbstractPolicyHandler } from './AbstractPolicyHandler';
 import { description } from './Occitanie.html';
 
@@ -62,9 +62,8 @@ export const Occitanie: PolicyHandlerStaticInterface = class
       throw new NotEligibleTargetException('Sunday is forbidden');
     }
     // Dans la région
-    if (!startsAndEndsAt(ctx, { reg: ['76'] })) {
-      throw new NotEligibleTargetException('Journey start & end not in region');
-    }
+    startAndEndAtOrThrow(ctx, { reg: ['76'] });
+
     // En excluant les trajets intra aom
     if (ctx.carpool.start.aom === ctx.carpool.end.aom && ctx.carpool.start.aom != '200053791') {
       throw new NotEligibleTargetException('Journey start/end inside aom');

--- a/api/services/policy/src/engine/policies/Pdll2023.html.ts
+++ b/api/services/policy/src/engine/policies/Pdll2023.html.ts
@@ -11,7 +11,7 @@ export const description = `<p _ngcontent-fyn-c231="" id="summary" class="campai
 <p>Les restrictions suivantes seront appliquées :</p>
 <ul>
   <li><b>6 trajets maximum pour le conducteur par jour.</b></li>
-  <li><b>120€ maximum pour le conducteur par jour.</b></li>
+  <li><b>120€ maximum pour le conducteur par mois.</b></li>
 </ul>
 <p>La campagne est éligible à tous les opérateurs du RPC proposant des preuves de classe <b>C</b>.</p>
 <p>Les trajets au départ et à l'arrivée des AOMs suivantes ne sont pas incités : </p>

--- a/api/services/policy/src/engine/policies/Pmgf2023.html.ts
+++ b/api/services/policy/src/engine/policies/Pmgf2023.html.ts
@@ -34,6 +34,6 @@ sont incités selon les règles suivantes : </p>
 <ul>
   <li><b>120 € maximum pour le conducteur par mois.</b></li>
 </ul>
-<p>La campagne est limitée à l'opérateur <b>Klaxit, Karos et BlablaCar Daily</b> proposant des preuves de classe <b>B ou C</b>.</p>
+<p>La campagne est limitée aux opérateurs <b>Klaxit, Karos et BlablaCar Daily</b> proposant des preuves de classe <b>B ou C</b>.</p>
 <p></p>
 </p>`;

--- a/api/services/policy/src/engine/policies/Pmgf2023.html.ts
+++ b/api/services/policy/src/engine/policies/Pmgf2023.html.ts
@@ -1,0 +1,39 @@
+export const description = `<p _ngcontent-pmm-c231="" id="summary" class="campaignSummaryText-content-text">
+<p>Campagne d’incitation au covoiturage du <b> 2 mai 2023 au 31 décembre 2023</b>, toute la semaine
+</p>
+<p>Cette campagne est limitée à
+  <b>24 400 euros </b>.
+</p>
+<p>
+Le périmètre géographique de la campagne comprend les zones suivantes
+</p>
+<ul>
+  <li>Communauté de communes Cluses Arve et Montagnes</li>
+  <li>Communauté de communes Pays du Mont Blanc</li>
+  <li>Communauté de communes Vallée de Chamonix</li>
+  <li>Communauté de communes des Montagnes du Giffre</li>
+  <li>Communauté de communes des 4 rivières</li>
+  <li>Communauté de communes de Vallée Verte</li>
+
+  <li>CC du Genevois</li>
+  <li>CA du Pays de Gex</li>
+  <li>CC du Pays Bellegardien (CCPB)</li>
+  <li>CC du Pays Rochois</li>
+  <li>CC Faucigny-Glières</li>
+  <li>CC Arve et Salève</li>
+  <li>CA Annemasse-Les Voirons-Agglomération</li>
+  <li>CA Thonon Agglomération</li>
+</ul>
+<p>Les <b> conducteurs </b> effectuant un trajet d'au moins 2 km, avec pour origine et destination le périmètre ci-dessus,
+sont incités selon les règles suivantes : </p>
+<ul>
+  <li><b>De 4 à 20 km : 2 euros par trajet par passager transporté.</b></li>
+  <li><b>De 20 à 40 km : 0.1 euros (10 centimes d'euro) par km par passager</b></li>
+</ul>
+<p>Les restrictions suivantes seront appliquées :</p>
+<ul>
+  <li><b>120 € maximum pour le conducteur par mois.</b></li>
+</ul>
+<p>La campagne est limitée à l'opérateur <b>Klaxit, Karos et BlablaCar Daily</b> proposant des preuves de classe <b>B ou C</b>.</p>
+<p></p>
+</p>`;

--- a/api/services/policy/src/engine/policies/Pmgf2023.spec.ts
+++ b/api/services/policy/src/engine/policies/Pmgf2023.spec.ts
@@ -68,7 +68,7 @@ test(
     incentive: [200, 400, 250, 400, 800, 400],
     meta: [
       {
-        key: 'max_amount_restriction.0-one.month.3-2023',
+        key: 'max_amount_restriction.0-one.month.4-2023',
         value: 2450,
       },
       {

--- a/api/services/policy/src/engine/policies/Pmgf2023.spec.ts
+++ b/api/services/policy/src/engine/policies/Pmgf2023.spec.ts
@@ -1,0 +1,111 @@
+import test from 'ava';
+import { v4 } from 'uuid';
+import { OperatorsEnum } from '../../interfaces';
+import { makeProcessHelper } from '../tests/macro';
+import { Atmb as Handler } from './Atmb';
+
+const defaultPosition = {
+  arr: '74278',
+  com: '74278',
+  aom: '200033116',
+  epci: '200033116',
+  dep: '74',
+  reg: '84',
+  country: 'XXXXX',
+  reseau: '142',
+};
+
+const defaultCarpool = {
+  _id: 1,
+  trip_id: v4(),
+  passenger_identity_uuid: v4(),
+  driver_identity_uuid: v4(),
+  operator_siret: OperatorsEnum.Klaxit,
+  operator_class: 'C',
+  passenger_is_over_18: true,
+  passenger_has_travel_pass: true,
+  driver_has_travel_pass: true,
+  datetime: new Date('2023-05-15'),
+  seats: 1,
+  duration: 600,
+  distance: 5_000,
+  cost: 20,
+  driver_payment: 20,
+  passenger_payment: 20,
+  start: { ...defaultPosition },
+  end: { ...defaultPosition },
+};
+
+const process = makeProcessHelper(defaultCarpool);
+
+test(
+  'should work with exclusion',
+  process,
+  {
+    policy: { handler: Handler.id },
+    carpool: [{ operator_siret: 'not in list' }, { distance: 100 }, { operator_class: 'A' }],
+    meta: [],
+  },
+  { incentive: [0, 0, 0], meta: [] },
+);
+
+test(
+  'should work basic',
+  process,
+  {
+    policy: { handler: Handler.id },
+    carpool: [
+      { distance: 5_000, driver_identity_uuid: 'one' },
+      { distance: 5_000, seats: 2, driver_identity_uuid: 'one' },
+      { distance: 25_000, driver_identity_uuid: 'one', passenger_identity_uuid: 'two' },
+      { distance: 40_000, driver_identity_uuid: 'one', passenger_identity_uuid: 'three' },
+      { distance: 40_000, seats: 2, driver_identity_uuid: 'one', passenger_identity_uuid: 'three' },
+      { distance: 60_000, driver_identity_uuid: 'one' },
+    ],
+    meta: [],
+  },
+  {
+    incentive: [200, 400, 250, 400, 800, 400],
+    meta: [
+      {
+        key: 'max_amount_restriction.0-one.month.3-2023',
+        value: 2450,
+      },
+      {
+        key: 'max_amount_restriction.global.campaign.global',
+        value: 2450,
+      },
+    ],
+  },
+);
+
+test(
+  'should work with driver month limits',
+  process,
+  {
+    policy: { handler: Handler.id },
+    carpool: [
+      { distance: 5_000, driver_identity_uuid: 'one' },
+      { distance: 5_000, driver_identity_uuid: 'one' },
+    ],
+    meta: [
+      {
+        key: 'max_amount_restriction.0-one.month.4-2023',
+        value: 118_00,
+      },
+    ],
+  },
+  {
+    incentive: [200, 0],
+    meta: [
+      {
+        key: 'max_amount_restriction.0-one.month.4-2023',
+        value: 120_00,
+      },
+      {
+        key: 'max_amount_restriction.global.campaign.global',
+        value: 200,
+      },
+    ],
+  },
+);

--- a/api/services/policy/src/engine/policies/Pmgf2023.ts
+++ b/api/services/policy/src/engine/policies/Pmgf2023.ts
@@ -1,0 +1,87 @@
+import {
+  OperatorsEnum,
+  PolicyHandlerInterface,
+  PolicyHandlerParamsInterface,
+  PolicyHandlerStaticInterface,
+  StatelessContextInterface,
+} from '../../interfaces';
+import { RunnableSlices } from '../../interfaces/engine/PolicyInterface';
+import {
+  isOperatorClassOrThrow,
+  isOperatorOrThrow,
+  LimitTargetEnum,
+  onDistanceRange,
+  onDistanceRangeOrThrow,
+  perKm,
+  perSeat,
+  watchForGlobalMaxAmount,
+  watchForPersonMaxAmountByMonth,
+} from '../helpers';
+import { AbstractPolicyHandler } from './AbstractPolicyHandler';
+import { description } from './Atmb.html';
+
+// Politique Pole Métropolitain du Genevois
+export const Pmgf2023: PolicyHandlerStaticInterface = class
+  extends AbstractPolicyHandler
+  implements PolicyHandlerInterface
+{
+  static readonly id = 'pmgf_2023';
+  protected operators = [OperatorsEnum.BlaBlaDaily, OperatorsEnum.Karos, OperatorsEnum.Klaxit];
+  protected operator_class = ['B', 'C'];
+
+  constructor(public max_amount: number) {
+    super();
+    this.limits = [
+      ['AFE1C47D-BF05-4FA9-9133-853D29797D09', 120_00, watchForPersonMaxAmountByMonth, LimitTargetEnum.Driver],
+      ['98B26189-C6FC-4DB1-AC1C-41F779C5B3C7', this.max_amount, watchForGlobalMaxAmount],
+    ];
+  }
+
+  protected slices: RunnableSlices = [
+    {
+      start: 4_000,
+      end: 20_000,
+      fn: (ctx: StatelessContextInterface) => perSeat(ctx, 200),
+    },
+    {
+      start: 20_000,
+      end: 40_000,
+      fn: (ctx: StatelessContextInterface) => perSeat(ctx, perKm(ctx, { amount: 10, offset: 20_000, limit: 40_000 })),
+    },
+  ];
+
+  protected processExclusion(ctx: StatelessContextInterface) {
+    isOperatorOrThrow(ctx, this.operators);
+    onDistanceRangeOrThrow(ctx, { min: 4_000 });
+    isOperatorClassOrThrow(ctx, this.operator_class);
+  }
+
+  processStateless(ctx: StatelessContextInterface): void {
+    this.processExclusion(ctx);
+    super.processStateless(ctx);
+
+    // Par kilomètre
+    let amount = 0;
+    for (const { start, fn } of this.slices) {
+      if (onDistanceRange(ctx, { min: start })) {
+        amount += fn(ctx);
+      }
+    }
+
+    ctx.incentive.set(amount);
+  }
+
+  params(): PolicyHandlerParamsInterface {
+    return {
+      slices: this.slices,
+      operators: this.operators,
+      limits: {
+        glob: this.max_amount,
+      },
+    };
+  }
+
+  describe(): string {
+    return description;
+  }
+};

--- a/api/services/policy/src/engine/policies/index.ts
+++ b/api/services/policy/src/engine/policies/index.ts
@@ -20,6 +20,7 @@ import { MetropoleSavoie } from './MetropoleSavoie';
 import { Smt2023 } from './Smt2023';
 import { LaRochelle } from './LaRochelle';
 import { PaysBasque } from './PaysBasque';
+import { Atmb } from './Atmb';
 
 export const policies: Map<string, PolicyHandlerStaticInterface> = new Map(
   // disable prettier to avoid having it reformat to a single line
@@ -47,6 +48,7 @@ export const policies: Map<string, PolicyHandlerStaticInterface> = new Map(
     Cotentin,
     LaRochelle,
     PaysBasque,
+    Atmb,
   ].map((h) => [h.id, h]),
   /* eslint-enable prettier/prettier */
 );

--- a/api/services/policy/src/engine/policies/index.ts
+++ b/api/services/policy/src/engine/policies/index.ts
@@ -21,6 +21,7 @@ import { Smt2023 } from './Smt2023';
 import { LaRochelle } from './LaRochelle';
 import { PaysBasque } from './PaysBasque';
 import { Atmb } from './Atmb';
+import { Pmgf2023 } from './Pmgf2023';
 
 export const policies: Map<string, PolicyHandlerStaticInterface> = new Map(
   // disable prettier to avoid having it reformat to a single line
@@ -49,6 +50,7 @@ export const policies: Map<string, PolicyHandlerStaticInterface> = new Map(
     LaRochelle,
     PaysBasque,
     Atmb,
+    Pmgf2023
   ].map((h) => [h.id, h]),
   /* eslint-enable prettier/prettier */
 );


### PR DESCRIPTION
```
-- Ajout du périmètre pour ATMB
INSERT INTO TERRITORY.TERRITORY_GROUP_SELECTOR VALUES (36368, 'aom', '200033116');  -- Communauté de communes Cluses Arve et Montagnes
INSERT INTO TERRITORY.TERRITORY_GROUP_SELECTOR VALUES (36368, 'epci', '200034882');  -- Communauté de communes Pays Du Mont-Blanc
INSERT INTO TERRITORY.TERRITORY_GROUP_SELECTOR VALUES (36368, 'aom', '200023372');  -- CC de la Vallée de Chamonix-Mont-Blanc
INSERT INTO TERRITORY.TERRITORY_GROUP_SELECTOR VALUES (36368, 'epci', '200034098');  -- CC des Montagnes du Giffre
INSERT INTO TERRITORY.TERRITORY_GROUP_SELECTOR VALUES (36368, 'aom', '247000623');  -- CC des Quatre Rivières
INSERT INTO TERRITORY.TERRITORY_GROUP_SELECTOR VALUES (36368, 'epci', '247400047');  -- CC de la Vallée Verte
INSERT INTO TERRITORY.TERRITORY_GROUP_SELECTOR VALUES (36368, 'epci', '200070852');  -- CC Usses et Rhône

-- Ajout du périmètre ATMB dans PMGF
INSERT INTO TERRITORY.TERRITORY_GROUP_SELECTOR VALUES (36102, 'aom', '200033116');  -- Communauté de communes Cluses Arve et Montagnes
INSERT INTO TERRITORY.TERRITORY_GROUP_SELECTOR VALUES (36102, 'epci', '200034882');  -- Communauté de communes Pays Du Mont-Blanc
INSERT INTO TERRITORY.TERRITORY_GROUP_SELECTOR VALUES (36102, 'aom', '200023372');  -- CC de la Vallée de Chamonix-Mont-Blanc
INSERT INTO TERRITORY.TERRITORY_GROUP_SELECTOR VALUES (36102, 'epci', '200034098');  -- CC des Montagnes du Giffre
INSERT INTO TERRITORY.TERRITORY_GROUP_SELECTOR VALUES (36102, 'aom', '247000623');  -- CC des Quatre Rivières
INSERT INTO TERRITORY.TERRITORY_GROUP_SELECTOR VALUES (36102, 'epci', '247400047');  -- CC de la Vallée Verte
INSERT INTO TERRITORY.TERRITORY_GROUP_SELECTOR VALUES (36102, 'epci', '200070852');  -- CC Usses et Rhône


-- ATMB
INSERT INTO policy.policies(
	_id,      created_at, updated_at, deleted_at, territory_id, start_date, end_date, name, description, unit, status, handler, incentive_sum, max_amount)
	VALUES
	(DEFAULT, DEFAULT,    DEFAULT,    NULL, 36368, '2023-05-02 00:00:00+00', '2023-12-31 00:00:00+00', 'ATMB_2023_05', NULL, 'euro', 'active', 'atmb_2023', 0, 2440000);

-- PMGF 2023
INSERT INTO policy.policies(
	_id,      created_at, updated_at, deleted_at, territory_id, start_date, end_date, name, description, unit, status, handler, incentive_sum, max_amount)
	VALUES
	(DEFAULT, DEFAULT,    DEFAULT,    NULL, 36102, '2023-05-02 00:00:00+00', '2023-12-31 00:00:00+00', 'PMGF_2023_05', NULL, 'euro', 'active', 'pmgf_2023', 0, 13600000);



```