### PR TITLE
npm run ilos

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -38,7 +38,7 @@
     "test:pdc:integration": "lerna run --scope @pdc/* test:integration",
     "test:ilos:integration": "lerna run --scope @ilos/* test:integration",
     "migrate": "DATABASE_URL=$APP_POSTGRES_URL npm --workspace @pdc/migrator run up",
-    "ilos": "npm --workspace @pdc/proxy run ilos"
+    "ilos": "npm run --workspace @pdc/proxy -- ilos"
   },
   "keywords": [
     "betagouv",


### PR DESCRIPTION
Fix du script `npm run ilos` pour pouvoir passer des arguments

ex
`npm run ilos campaign:apply --help`
--> `npm run -w @pdc/proxy -- ilos campaign:apply --help`
