### PR TITLE
Make code more readable by avoiding chaining ternary ops

### DIFF
--- a/api/services/cee/src/actions/RegisterCeeAction.ts
+++ b/api/services/cee/src/actions/RegisterCeeAction.ts
@@ -72,7 +72,8 @@ export class RegisterCeeAction extends AbstractAction {
         case e instanceof ConflictException:
             errorType = CeeApplicationErrorEnum.Conflict;
             break;
-        default: CeeApplicationErrorEnum.Validation;
+        default: 
+            errorType = CeeApplicationErrorEnum.Validation;
       }
       const errorData: CeeApplicationError = {
         operator_id,

--- a/api/services/cee/src/actions/RegisterCeeAction.ts
+++ b/api/services/cee/src/actions/RegisterCeeAction.ts
@@ -61,16 +61,21 @@ export class RegisterCeeAction extends AbstractAction {
           return await this.proceesForLongApplication(operator_id, params);
       }
     } catch (e) {
+      let errorType;
+      switch(true){
+        case e instanceof InvalidParamsException:
+            errorType = CeeApplicationErrorEnum.Date;
+            break;
+        case e instanceof NotFoundException:
+            errorType = CeeApplicationErrorEnum.NonEligible;
+            break;
+        case e instanceof ConflictException:
+            errorType = CeeApplicationErrorEnum.Conflict;
+            break;
+        default: CeeApplicationErrorEnum.Validation;
       const errorData: CeeApplicationError = {
         operator_id,
-        error_type:
-          e instanceof InvalidParamsException
-            ? CeeApplicationErrorEnum.Date
-            : e instanceof NotFoundException
-            ? CeeApplicationErrorEnum.NonEligible
-            : e instanceof ConflictException
-            ? CeeApplicationErrorEnum.Conflict
-            : CeeApplicationErrorEnum.Validation,
+        error_type: errorType,
         journey_type: params.journey_type,
         datetime: params['datetime'],
         last_name_trunc: params['last_name_trunc'],

--- a/api/services/cee/src/actions/RegisterCeeAction.ts
+++ b/api/services/cee/src/actions/RegisterCeeAction.ts
@@ -73,6 +73,7 @@ export class RegisterCeeAction extends AbstractAction {
             errorType = CeeApplicationErrorEnum.Conflict;
             break;
         default: CeeApplicationErrorEnum.Validation;
+      }
       const errorData: CeeApplicationError = {
         operator_id,
         error_type: errorType,


### PR DESCRIPTION
Chaining ternaries like this makes the code difficult to parse.

While TS doesn't support an instance-of switch statement, there exists a solid workaround, such as proposed here.