### PR TITLE
Suppression des mois dans le titre des APDF

### DIFF
--- a/dashboard/src/app/modules/campaign/pages/campaign-apdf/campaign-apdf.component.html
+++ b/dashboard/src/app/modules/campaign/pages/campaign-apdf/campaign-apdf.component.html
@@ -1,5 +1,5 @@
 <div class="campaign-apdf">
-  <h4> Appels de fonds - Récapitulatif des 6 derniers mois </h4>
+  <h4>Appels de fonds</h4>
   <div class="campaign-apdf-content">
 
     <div class="loader" *ngIf="!list">


### PR DESCRIPTION
#1761

L'historique complet des APDF est affiché et non les 6 derniers mois.
Mise à jour du titre pour refléter le changement.

TODO : Fermer la #1761 quand la PR est fusionnée