### PR TITLE
[fix] campaign:apply

### DIFF
--- a/api/services/policy/src/commands/ApplyCommand.ts
+++ b/api/services/policy/src/commands/ApplyCommand.ts
@@ -104,7 +104,11 @@ export class ApplyCommand implements CommandInterface {
           console.info(`[campaign:apply] run policy ${policy_id} in detached mode`);
           await this.kernel.notify(apply, params, context);
         } else {
-          await this.kernel.call(apply, params, context);
+          try {
+            await this.kernel.call(apply, params, context);
+          } catch (e) {
+            console.error(e.message, { params });
+          }
         }
       }
 


### PR DESCRIPTION
Fix de la gestion des dates dans `campaign:apply` action.

Quand la campagne est terminée mais encore active, on vérifie que le `from` est avant la date de fin de la campagne.

Ajout d'un try/catch pour pouvoir continuer à traiter les campagnes de la liste même si l'une d'elles crash.