### PR TITLE
Feat/compute insentive for fraud

### DIFF
--- a/api/providers/seed/src/carpools.ts
+++ b/api/providers/seed/src/carpools.ts
@@ -92,4 +92,5 @@ function makeCarpoolsFromAcquisition(acquisition_id: number, data: Partial<Carpo
 export const carpools: Carpool[] = [
   ...makeCarpoolsFromAcquisition(1, { datetime: new Date('2022-06-15') }),
   ...makeCarpoolsFromAcquisition(2, { datetime: new Date('2022-06-16') }),
+  ...makeCarpoolsFromAcquisition(3, { datetime: new Date('2022-06-16'), status: 'fraudcheck_error' }),
 ];

--- a/api/services/acquisition/src/providers/AcquisitionRepositoryProvider.integration.spec.ts
+++ b/api/services/acquisition/src/providers/AcquisitionRepositoryProvider.integration.spec.ts
@@ -276,8 +276,8 @@ test.serial('Should find then update with selectors', async (t) => {
   t.deepEqual(
     result.map(({ created_at, ...r }) => r),
     [
-      { _id: 5, payload: { test: '12345' }, api_version: 1, operator_id: t.context.operator_id },
       { _id: 6, payload: { test: '12345' }, api_version: 1, operator_id: t.context.operator_id },
+      { _id: 7, payload: { test: '12345' }, api_version: 1, operator_id: t.context.operator_id },
     ],
   );
   await fn();
@@ -291,7 +291,7 @@ test.serial('Should find and update with lock', async (t) => {
 
   t.deepEqual(
     result1.map(({ created_at, ...r }) => r),
-    [{ _id: 5, payload: { test: '12345' }, api_version: 1, operator_id: t.context.operator_id }],
+    [{ _id: 6, payload: { test: '12345' }, api_version: 1, operator_id: t.context.operator_id }],
   );
 
   const [result2, fn2] = await t.context.repository.findThenUpdate({
@@ -301,7 +301,7 @@ test.serial('Should find and update with lock', async (t) => {
 
   t.deepEqual(
     result2.map(({ created_at, ...r }) => r),
-    [{ _id: 6, payload: { test: '12345' }, api_version: 1, operator_id: t.context.operator_id }],
+    [{ _id: 7, payload: { test: '12345' }, api_version: 1, operator_id: t.context.operator_id }],
   );
 
   await fn1(); // release lock 1
@@ -312,9 +312,9 @@ test.serial('Should find and update with lock', async (t) => {
 
   t.deepEqual(
     result3.map(({ created_at, ...r }) => r),
-    [{ _id: 5, payload: { test: '12345' }, api_version: 1, operator_id: t.context.operator_id }],
+    [{ _id: 6, payload: { test: '12345' }, api_version: 1, operator_id: t.context.operator_id }],
   );
-  await fn2({ acquisition_id: 6, status: AcquisitionStatusEnum.Ok });
+  await fn2({ acquisition_id: 6, status: AcquisitionStatusEnum.Ok }); // <-- error
   await fn2({ acquisition_id: 7, status: AcquisitionStatusEnum.Ok });
   await fn2();
   // release lock 2
@@ -425,7 +425,7 @@ test.serial('Should list acquisition status', async (t) => {
   };
 
   const result = await t.context.repository.list(search);
-  t.deepEqual(result, [{ operator_journey_id: '3' }, { operator_journey_id: '2' }, { operator_journey_id: '5' }]);
+  t.deepEqual(result, [{ operator_journey_id: '4' }, { operator_journey_id: '2' }, { operator_journey_id: '5' }]);
 
   const result1 = await t.context.repository.list({
     ...search,

--- a/api/services/acquisition/src/providers/AcquisitionRepositoryProvider.integration.spec.ts
+++ b/api/services/acquisition/src/providers/AcquisitionRepositoryProvider.integration.spec.ts
@@ -314,8 +314,8 @@ test.serial('Should find and update with lock', async (t) => {
     result3.map(({ created_at, ...r }) => r),
     [{ _id: 6, payload: { test: '12345' }, api_version: 1, operator_id: t.context.operator_id }],
   );
-  await fn2({ acquisition_id: 6, status: AcquisitionStatusEnum.Ok }); // <-- error
-  await fn2({ acquisition_id: 7, status: AcquisitionStatusEnum.Ok });
+  await fn2({ acquisition_id: 7, status: AcquisitionStatusEnum.Ok }); // <-- error
+  await fn2({ acquisition_id: 8, status: AcquisitionStatusEnum.Ok });
   await fn2();
   // release lock 2
 
@@ -425,7 +425,7 @@ test.serial('Should list acquisition status', async (t) => {
   };
 
   const result = await t.context.repository.list(search);
-  t.deepEqual(result, [{ operator_journey_id: '4' }, { operator_journey_id: '2' }, { operator_journey_id: '5' }]);
+  t.deepEqual(result, [{ operator_journey_id: '3' }, { operator_journey_id: '2' }, { operator_journey_id: '5' }]);
 
   const result1 = await t.context.repository.list({
     ...search,

--- a/api/services/policy/src/providers/TripRepositoryProvider.integration.spec.ts
+++ b/api/services/policy/src/providers/TripRepositoryProvider.integration.spec.ts
@@ -22,7 +22,7 @@ test.after.always(async (t) => {
   await after(t.context.db);
 });
 
-test.serial('Should find carpools', async (t) => {
+test.serial('Should find carpools even with fraudcheck_error', async (t) => {
   const start_date = new Date('2022-06-01');
   const end_date = new Date('2022-06-30');
 
@@ -41,11 +41,10 @@ test.serial('Should find carpools', async (t) => {
   });
 
   const cursor = t.context.repository.findTripByPolicy(policy, start_date, end_date);
-  const { value } = await cursor.next();
-  await cursor.next();
-  if (value) {
-    t.is(value.length, 2);
-  }
+  const { value } = await cursor.next(); // ok carpool
+  await cursor.next(); // ok carpool
+  await cursor.next(); // fraudcheck_error carpool
+  t.is((value || []).length, 3);
   t.true(Array.isArray(value));
   t.deepEqual(
     (value || [])

--- a/api/services/policy/src/providers/TripRepositoryProvider.integration.spec.ts
+++ b/api/services/policy/src/providers/TripRepositoryProvider.integration.spec.ts
@@ -43,6 +43,9 @@ test.serial('Should find carpools', async (t) => {
   const cursor = t.context.repository.findTripByPolicy(policy, start_date, end_date);
   const { value } = await cursor.next();
   await cursor.next();
+  if (value) {
+    t.is(value.length, 2);
+  }
   t.true(Array.isArray(value));
   t.deepEqual(
     (value || [])

--- a/api/services/policy/src/providers/TripRepositoryProvider.ts
+++ b/api/services/policy/src/providers/TripRepositoryProvider.ts
@@ -108,7 +108,9 @@ export class TripRepositoryProvider implements TripRepositoryProviderInterfaceRe
           (t.start_geo_code = ANY($1::varchar[]) OR t.end_geo_code = ANY($1::varchar[]))
           AND t.datetime >= $2::timestamp
           AND t.datetime < $3::timestamp
-          AND t.carpool_status = 'ok'::carpool.carpool_status_enum
+          AND ( t.carpool_status = 'ok'::carpool.carpool_status_enum 
+                or 
+                t.carpool_status = 'fraudcheck_error'::carpool.carpool_status_enum)
           ${override ? '' : 'AND pi.carpool_id IS NULL'}
         ORDER BY t.datetime ASC
         `,


### PR DESCRIPTION
On laisse le `apply` calculer les incitations sur les carpools en `fraudcheck_error`.
Les trajets seront par la suite écarté via le statefull avec `await this.incentiveRepository.disableOnCanceledTrip();`