### PR TITLE
fix(proxy): case sensitive regex code scanning error

### DIFF
--- a/api/proxy/src/HttpTransport.ts
+++ b/api/proxy/src/HttpTransport.ts
@@ -182,7 +182,7 @@ export class HttpTransport implements TransportInterface {
 
     // use CORS asynchronously to log the calls and check against a list of domains
     this.app.use(
-      /\/(observatory|geo\/search)/,
+      /\/(observatory|geo\/search)/i,
       cors((req: Request, callback) => {
         const domains = [
           'https://demo.covoiturage.beta.gouv.fr',


### PR DESCRIPTION
Fix de la Regex de observatory / geo/search suite à la remontée d'erreur du scan de code Github.