### PR TITLE
feat: add booster date policy param

### DIFF
--- a/api/services/policy/src/engine/policies/Idfm.ts
+++ b/api/services/policy/src/engine/policies/Idfm.ts
@@ -50,7 +50,7 @@ export const Idfm: PolicyHandlerStaticInterface = class extends AbstractPolicyHa
     },
   ];
 
-  protected pollutionAndStrikeDates = [
+  protected boosterDates = [
     '2022-02-18',
     '2022-03-25',
     '2022-03-26',
@@ -120,8 +120,8 @@ export const Idfm: PolicyHandlerStaticInterface = class extends AbstractPolicyHa
       }
     }
 
-    // Jour de pollution
-    if (atDate(ctx, { dates: this.pollutionAndStrikeDates })) {
+    // Jour de pollution/grève
+    if (atDate(ctx, { dates: this.boosterDates })) {
       amount *= 1.5;
     }
 
@@ -135,6 +135,7 @@ export const Idfm: PolicyHandlerStaticInterface = class extends AbstractPolicyHa
       limits: {
         glob: this.max_amount,
       },
+      booster_dates: [...this.boosterDates],
     };
   }
 

--- a/api/services/policy/src/interfaces/engine/PolicyInterface.ts
+++ b/api/services/policy/src/interfaces/engine/PolicyInterface.ts
@@ -64,6 +64,7 @@ export interface PolicyHandlerParamsInterface {
   limits?: {
     glob?: number;
   };
+  booster_dates?: Array<string>;
 }
 
 export interface PolicyHandlerInterface {

--- a/shared/policy/common/interfaces/PolicyInterface.ts
+++ b/shared/policy/common/interfaces/PolicyInterface.ts
@@ -16,5 +16,6 @@ export interface PolicyInterface {
     limits?: {
       glob?: number;
     };
+    booster_dates?: Array<string>;
   };
 }


### PR DESCRIPTION
- renommage de `pollutionAndStrikeDates` en `boosterDates` dans le fichier de configuration des campagnes
- ajout de `booster_dates` dans les paramètres pour permettre une utilisation dans les exports