### PR TITLE
Ajout de la timezone dans les campagnes

### DIFF
--- a/api/services/export/src/shared/policy/common/interfaces/PolicyInterface.ts
+++ b/api/services/export/src/shared/policy/common/interfaces/PolicyInterface.ts
@@ -1,0 +1,23 @@
+import { Timezone } from '@pdc/provider-validator';
+import { BoundedSlices, UnboundedSlices } from './Slices';
+
+export interface PolicyInterface {
+  _id: number;
+  territory_id: number;
+  name: string;
+  description: string;
+  start_date: Date;
+  end_date: Date;
+  status: string;
+  handler: string;
+  incentive_sum: number;
+  params: {
+    slices?: BoundedSlices | UnboundedSlices;
+    operators?: Array<string>;
+    limits?: {
+      glob?: number;
+    };
+    booster_dates?: Array<string>;
+    tz?: Timezone;
+  };
+}

--- a/api/services/policy/src/engine/policies/Atmb.ts
+++ b/api/services/policy/src/engine/policies/Atmb.ts
@@ -93,6 +93,7 @@ export const Atmb: PolicyHandlerStaticInterface = class
 
   params(): PolicyHandlerParamsInterface {
     return {
+      tz: 'Europe/Paris',
       slices: this.slices,
       operators: this.operators,
       limits: {

--- a/api/services/policy/src/engine/policies/Cannes.ts
+++ b/api/services/policy/src/engine/policies/Cannes.ts
@@ -75,6 +75,7 @@ export const Cannes: PolicyHandlerStaticInterface = class
 
   params(): PolicyHandlerParamsInterface {
     return {
+      tz: 'Europe/Paris',
       slices: this.slices,
       operators: this.operators,
       limits: {

--- a/api/services/policy/src/engine/policies/Cotentin.ts
+++ b/api/services/policy/src/engine/policies/Cotentin.ts
@@ -70,6 +70,7 @@ export const Cotentin: PolicyHandlerStaticInterface = class
 
   params(): PolicyHandlerParamsInterface {
     return {
+      tz: 'Europe/Paris',
       slices: this.slices,
       operators: this.operators,
       limits: {

--- a/api/services/policy/src/engine/policies/GrandPoitiers.ts
+++ b/api/services/policy/src/engine/policies/GrandPoitiers.ts
@@ -75,6 +75,7 @@ export const GrandPoitiers: PolicyHandlerStaticInterface = class
 
   params(): PolicyHandlerParamsInterface {
     return {
+      tz: 'Europe/Paris',
       slices: this.slices,
       operators: this.operators,
       limits: {

--- a/api/services/policy/src/engine/policies/Idfm.ts
+++ b/api/services/policy/src/engine/policies/Idfm.ts
@@ -130,6 +130,7 @@ export const Idfm: PolicyHandlerStaticInterface = class extends AbstractPolicyHa
 
   params(): PolicyHandlerParamsInterface {
     return {
+      tz: 'Europe/Paris',
       slices: this.slices,
       operators: this.operators,
       limits: {

--- a/api/services/policy/src/engine/policies/LaRochelle.ts
+++ b/api/services/policy/src/engine/policies/LaRochelle.ts
@@ -90,6 +90,7 @@ export const LaRochelle: PolicyHandlerStaticInterface = class extends AbstractPo
 
   params(): PolicyHandlerParamsInterface {
     return {
+      tz: 'Europe/Paris',
       slices: this.slices,
       operators: this.operators,
       limits: {

--- a/api/services/policy/src/engine/policies/Lannion.ts
+++ b/api/services/policy/src/engine/policies/Lannion.ts
@@ -70,6 +70,7 @@ export const Lannion: PolicyHandlerStaticInterface = class
 
   params(): PolicyHandlerParamsInterface {
     return {
+      tz: 'Europe/Paris',
       slices: this.slices,
       operators: this.operators,
       limits: {

--- a/api/services/policy/src/engine/policies/Laval.ts
+++ b/api/services/policy/src/engine/policies/Laval.ts
@@ -60,6 +60,7 @@ export const Laval: PolicyHandlerStaticInterface = class
 
   params(): PolicyHandlerParamsInterface {
     return {
+      tz: 'Europe/Paris',
       slices: this.slices,
       operators: this.operators,
       limits: {

--- a/api/services/policy/src/engine/policies/MetropoleSavoie.ts
+++ b/api/services/policy/src/engine/policies/MetropoleSavoie.ts
@@ -60,6 +60,7 @@ export const MetropoleSavoie: PolicyHandlerStaticInterface = class extends Abstr
 
   params(): PolicyHandlerParamsInterface {
     return {
+      tz: 'Europe/Paris',
       slices: this.slices,
       operators: this.operators,
       limits: {

--- a/api/services/policy/src/engine/policies/Montpellier.ts
+++ b/api/services/policy/src/engine/policies/Montpellier.ts
@@ -64,6 +64,7 @@ export const Montpellier: PolicyHandlerStaticInterface = class extends AbstractP
 
   params(): PolicyHandlerParamsInterface {
     return {
+      tz: 'Europe/Paris',
       slices: this.slices,
       operators: this.operators,
       limits: {

--- a/api/services/policy/src/engine/policies/Mrn.ts
+++ b/api/services/policy/src/engine/policies/Mrn.ts
@@ -67,6 +67,7 @@ export const Mrn: PolicyHandlerStaticInterface = class extends AbstractPolicyHan
 
   params(): PolicyHandlerParamsInterface {
     return {
+      tz: 'Europe/Paris',
       slices: this.slices,
       operators: this.operators,
       limits: {

--- a/api/services/policy/src/engine/policies/Nm.ts
+++ b/api/services/policy/src/engine/policies/Nm.ts
@@ -69,6 +69,7 @@ export const Nm: PolicyHandlerStaticInterface = class extends AbstractPolicyHand
 
   params(): PolicyHandlerParamsInterface {
     return {
+      tz: 'Europe/Paris',
       slices: this.slices,
       operators: this.operators,
       limits: {

--- a/api/services/policy/src/engine/policies/Occitanie.ts
+++ b/api/services/policy/src/engine/policies/Occitanie.ts
@@ -92,6 +92,7 @@ export const Occitanie: PolicyHandlerStaticInterface = class
 
   params(): PolicyHandlerParamsInterface {
     return {
+      tz: 'Europe/Paris',
       slices: this.slices,
       operators: this.operators,
       limits: {

--- a/api/services/policy/src/engine/policies/PaysBasque.ts
+++ b/api/services/policy/src/engine/policies/PaysBasque.ts
@@ -76,6 +76,7 @@ export const PaysBasque: PolicyHandlerStaticInterface = class
 
   params(): PolicyHandlerParamsInterface {
     return {
+      tz: 'Europe/Paris',
       slices: this.slices,
       operators: this.operators,
       limits: {

--- a/api/services/policy/src/engine/policies/Pdll.ts
+++ b/api/services/policy/src/engine/policies/Pdll.ts
@@ -84,6 +84,7 @@ export const Pdll: PolicyHandlerStaticInterface = class extends AbstractPolicyHa
 
   params(): PolicyHandlerParamsInterface {
     return {
+      tz: 'Europe/Paris',
       slices: this.slices,
       operators: this.operators,
       limits: {

--- a/api/services/policy/src/engine/policies/Pdll2023.ts
+++ b/api/services/policy/src/engine/policies/Pdll2023.ts
@@ -96,6 +96,7 @@ export const Pdll2023: PolicyHandlerStaticInterface = class extends AbstractPoli
 
   params(): PolicyHandlerParamsInterface {
     return {
+      tz: 'Europe/Paris',
       slices: this.slices,
       operators: this.operators,
       limits: {

--- a/api/services/policy/src/engine/policies/Pdll2024.ts
+++ b/api/services/policy/src/engine/policies/Pdll2024.ts
@@ -94,6 +94,7 @@ export const Pdll2024: PolicyHandlerStaticInterface = class extends AbstractPoli
 
   params(): PolicyHandlerParamsInterface {
     return {
+      tz: 'Europe/Paris',
       slices: this.slices,
       operators: this.operators,
       limits: {

--- a/api/services/policy/src/engine/policies/Pmgf.ts
+++ b/api/services/policy/src/engine/policies/Pmgf.ts
@@ -201,6 +201,7 @@ export const Pmgf: PolicyHandlerStaticInterface = class
 
   params(): PolicyHandlerParamsInterface {
     return {
+      tz: 'Europe/Paris',
       slices: this.slices,
       operators: this.operators,
       limits: {

--- a/api/services/policy/src/engine/policies/Pmgf2023.ts
+++ b/api/services/policy/src/engine/policies/Pmgf2023.ts
@@ -73,6 +73,7 @@ export const Pmgf2023: PolicyHandlerStaticInterface = class
 
   params(): PolicyHandlerParamsInterface {
     return {
+      tz: 'Europe/Paris',
       slices: this.slices,
       operators: this.operators,
       limits: {

--- a/api/services/policy/src/engine/policies/PmgfLate2023.ts
+++ b/api/services/policy/src/engine/policies/PmgfLate2023.ts
@@ -73,6 +73,7 @@ export const PmgfLate2023: PolicyHandlerStaticInterface = class
 
   params(): PolicyHandlerParamsInterface {
     return {
+      tz: 'Europe/Paris',
       slices: this.slices,
       operators: this.operators,
       limits: {

--- a/api/services/policy/src/engine/policies/SMTC.ts
+++ b/api/services/policy/src/engine/policies/SMTC.ts
@@ -70,6 +70,7 @@ export const SMTC: PolicyHandlerStaticInterface = class
 
   params(): PolicyHandlerParamsInterface {
     return {
+      tz: 'Europe/Paris',
       slices: this.slices,
       operators: this.operators,
       limits: {

--- a/api/services/policy/src/engine/policies/Smt.ts
+++ b/api/services/policy/src/engine/policies/Smt.ts
@@ -65,6 +65,7 @@ export const Smt: PolicyHandlerStaticInterface = class extends AbstractPolicyHan
 
   params(): PolicyHandlerParamsInterface {
     return {
+      tz: 'Europe/Paris',
       slices: this.slices,
       operators: this.operators,
       limits: {

--- a/api/services/policy/src/engine/policies/Smt2023.ts
+++ b/api/services/policy/src/engine/policies/Smt2023.ts
@@ -91,6 +91,7 @@ export const Smt2023: PolicyHandlerStaticInterface = class
 
   params(): PolicyHandlerParamsInterface {
     return {
+      tz: 'Europe/Paris',
       slices: this.getSlices(),
       operators: this.operators,
       limits: {

--- a/api/services/policy/src/engine/policies/Vitre.ts
+++ b/api/services/policy/src/engine/policies/Vitre.ts
@@ -112,6 +112,7 @@ export const Vitre: PolicyHandlerStaticInterface = class
 
   params(): PolicyHandlerParamsInterface {
     return {
+      tz: 'Europe/Paris',
       slices: this.slices,
       operators: this.operators,
       limits: {

--- a/api/services/policy/src/interfaces/engine/PolicyInterface.ts
+++ b/api/services/policy/src/interfaces/engine/PolicyInterface.ts
@@ -59,6 +59,7 @@ export interface PolicyHandlerStaticInterface {
 }
 
 export interface PolicyHandlerParamsInterface {
+  tz?: Timezone;
   slices?: RunnableSlices | BoundedSlices;
   operators?: Array<OperatorsEnum>;
   limits?: {


### PR DESCRIPTION
Pour simplifier la gestion des dates dans les exports, ajout de la propriété `tz` dans les `params` du fichier de campagne.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a standardized policy interface for defining policy objects with comprehensive fields.
  - Implemented a consistent 'Europe/Paris' timezone parameter across various policy handlers to ensure uniform date and time handling.

- **Enhancements**
  - Updated policy handler interfaces to include an optional timezone field, improving policy configuration accuracy and localization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->