### PR TITLE
Colonnes APDF

### DIFF
--- a/api/services/apdf/README.md
+++ b/api/services/apdf/README.md
@@ -59,7 +59,7 @@ Compilation des fichiers XLSX pour un mois donné. Les fichiers sont générés 
 Les exports sont programmés pour être calculés le 6 de chaque mois.
 ## Commandes
 
-### Export : `npm run -w @pdc/proxy ilos apdf:export`
+### Export : `npm run -w @pdc/proxy -- ilos apdf:export`
 
 Exporte les APDF et upload les fichiers sur le S3.
 

--- a/api/services/apdf/src/actions/ExportAction.spec.ts
+++ b/api/services/apdf/src/actions/ExportAction.spec.ts
@@ -1,7 +1,7 @@
 /* eslint-disable max-len */
 import faker from '@faker-js/faker';
 import { ConfigInterfaceResolver, KernelInterfaceResolver } from '@ilos/common';
-import { uuid } from '@pdc/helper-test/dist';
+import { uuid } from '@pdc/helper-test';
 import { BucketName, S3StorageProvider } from '@pdc/provider-storage';
 import anyTest, { TestFn } from 'ava';
 import { startOfMonth, subMonths } from 'date-fns';
@@ -54,7 +54,7 @@ test.beforeEach((t) => {
   t.context.kernel = new (class extends KernelInterfaceResolver {})();
   t.context.checkCampaign = new CheckCampaign(null as any);
   t.context.s3StorageProvider = new S3StorageProvider(null as any);
-  t.context.buildExcel = new BuildExcel(null as any, null as any, null as any, null as any);
+  t.context.buildExcel = new BuildExcel(null as any, null as any, null as any, null as any, null as any);
   t.context.config = {
     get<T>(): T {
       return true as T; // enable upload

--- a/api/services/apdf/src/interfaces/APDFTripInterface.ts
+++ b/api/services/apdf/src/interfaces/APDFTripInterface.ts
@@ -2,14 +2,14 @@ export interface APDFTripInterface {
   journey_id: string;
   start_datetime: string;
   end_datetime: string;
-  driver_rpc_incentive: number;
-  passenger_rpc_incentive: number;
+  rpc_incentive: number;
   start_location: string;
   start_insee: string;
   end_location: string;
   end_insee: string;
   duration: number;
   distance: number;
+  operator: string;
   operator_class: string;
   trip_id: string;
   operator_trip_id: string;
@@ -17,4 +17,9 @@ export interface APDFTripInterface {
   operator_driver_id: string;
   passenger_uuid: string;
   operator_passenger_id: string;
+  incentive_type: 'normal' | 'booster';
+  start_epci_name: string;
+  start_epci: string;
+  end_epci_name: string;
+  end_epci: string;
 }

--- a/api/services/apdf/src/providers/APDFRepositoryProvider.ts
+++ b/api/services/apdf/src/providers/APDFRepositoryProvider.ts
@@ -152,7 +152,7 @@ export class DataRepositoryProvider implements DataRepositoryInterface {
         where
           datetime >= $1
           and datetime < $2
-          and status = 'ok'
+          and status in ('ok', 'canceled')
           and operator_id = $3
           and is_driver = true
       )

--- a/api/services/apdf/src/providers/APDFRepositoryProvider.ts
+++ b/api/services/apdf/src/providers/APDFRepositoryProvider.ts
@@ -147,7 +147,8 @@ export class DataRepositoryProvider implements DataRepositoryInterface {
           operator_journey_id,
           distance,
           duration,
-          operator_class
+          operator_class,
+          operator_id
         from carpool.carpools
         where
           datetime >= $1
@@ -165,23 +166,25 @@ export class DataRepositoryProvider implements DataRepositoryInterface {
         -- driver
         cid.uuid as driver_uuid,
         cid.operator_user_id as operator_driver_id,
-        pid.amount as driver_rpc_incentive,
+        pid.amount as rpc_incentive,
     
         -- passenger
         cip.uuid as passenger_uuid,
         cip.operator_user_id as operator_passenger_id,
-        pip.amount as passenger_rpc_incentive,
-        -- ccd.seats as passenger_seats,
-        -- cip.over_18 as passenger_over_18,
 
         ccd.datetime as start_datetime,
         ccd.datetime + (ccd.duration || ' seconds')::interval as end_datetime,
         gps.l_arr as start_location,
         gps.arr as start_insee,
+        gps.l_epci as start_epci_name,
+        gps.epci as start_epci,
         gpe.l_arr as end_location,
         gpe.arr as end_insee,
+        gpe.l_epci as end_epci_name,
+        gpe.epci as end_epci,
         ccd.duration,
         ccd.distance,
+        oo.name as operator,
         ccd.operator_class
 
       from ccd
@@ -189,11 +192,11 @@ export class DataRepositoryProvider implements DataRepositoryInterface {
       left join carpool.identities cid on cid._id = ccd.identity_id
       left join carpool.identities cip on cip._id = ccp.identity_id
       left join policy.incentives pid on ccd._id = pid.carpool_id and pid.policy_id = $4 and pid.status = 'validated'
-      left join policy.incentives pip on ccp._id = pip.carpool_id and pip.policy_id = $4 and pid.status = 'validated'
       left join geo.perimeters gps on ccp.start_geo_code = gps.arr and gps.year = geo.get_latest_millesime_or(extract(year from ccp.datetime)::smallint)
       left join geo.perimeters gpe on ccp.end_geo_code = gpe.arr and gpe.year = geo.get_latest_millesime_or(extract(year from (ccp.datetime + (ccd.duration || ' seconds')::interval))::smallint)
+      left join operator.operators oo on oo._id = ccd.operator_id
 
-      where pid.policy_id is not null or pip.policy_id is not null
+      where pid.policy_id is not null
 
       order by ccd.datetime
     `;

--- a/api/services/apdf/src/providers/excel/BuildExcel.spec.ts
+++ b/api/services/apdf/src/providers/excel/BuildExcel.spec.ts
@@ -22,6 +22,7 @@ interface Context {
   createSlicesSheetToWorkbook: SlicesWorksheetWriter;
 
   // Injected tokens method's stubs
+  kernelStub: SinonStub;
   getPolicyCursorStub: SinonStub;
   policyStatsStub: SinonStub<
     [params: CampaignSearchParamsInterface, slices: SliceInterface[]],
@@ -42,6 +43,7 @@ interface Context {
   operator_id: number;
   filename: string;
   filepath: string;
+  booster_dates: Set<string>;
 
   // Fake workbookWriter
   workbookWriterMock: any;
@@ -50,6 +52,7 @@ interface Context {
 const test = anyTest as TestFn<Partial<Context>>;
 
 test.beforeEach((t) => {
+  t.context.kernel = new (class extends KernelInterfaceResolver {})();
   t.context.createSlicesSheetToWorkbook = new SlicesWorksheetWriter();
   t.context.apdfRepositoryProvider = new DataRepositoryProvider(null as any);
   t.context.nameProvider = new APDFNameProvider();
@@ -63,6 +66,7 @@ test.beforeEach((t) => {
   );
   t.context.filenameStub = sinon.stub(t.context.nameProvider, 'filename');
   t.context.filepathStub = sinon.stub(t.context.nameProvider, 'filepath');
+  t.context.kernelStub = sinon.stub(t.context.kernel, 'call');
   t.context.tripsWorkbookWriterStub = sinon.stub(t.context.streamDataToWorkbook, 'call');
   t.context.getPolicyCursorStub = sinon.stub(t.context.apdfRepositoryProvider, 'getPolicyCursor');
   t.context.policyStatsStub = sinon.stub(t.context.apdfRepositoryProvider, 'getPolicyStats');
@@ -93,6 +97,7 @@ test.before((t) => {
   t.context.filename = 'APDF-idfm.xlsx';
   t.context.filepath = '/tmp/APDF-idfm.xlsx';
   t.context.workbookWriterMock = { commit: () => {} };
+  t.context.booster_dates = new Set<string>();
 
   t.context.workbookWriterStub = sinon
     .stub(BuildExcel, 'initWorkbookWriter')
@@ -102,6 +107,7 @@ test.before((t) => {
 test.afterEach((t) => {
   t.context.filenameStub!.restore();
   t.context.filepathStub!.restore();
+  t.context.kernelStub!.restore();
   t.context.tripsWorkbookWriterStub!.restore();
   t.context.getPolicyCursorStub!.restore();
   t.context.slicesWorkbookWriterStub!.restore();
@@ -115,6 +121,7 @@ test('BuildExcel: should call stream data and create slice then return excel fil
   t.context.filenameStub!.returns(t.context.filename);
   t.context.filepathStub!.returns(t.context.filepath);
   t.context.tripsWorkbookWriterStub!.resolves();
+  t.context.kernelStub!.resolves(t.context.booster_dates);
   t.context.policyStatsStub?.resolves({
     total_count: 111,
     total_sum: 222_00,
@@ -166,7 +173,12 @@ test('BuildExcel: should call stream data and create slice then return excel fil
     amount: 222_00,
   });
 
-  sinon.assert.calledOnceWithExactly(t.context.tripsWorkbookWriterStub!, cursorCallback, t.context.workbookWriterMock);
+  sinon.assert.calledOnceWithExactly(
+    t.context.tripsWorkbookWriterStub!,
+    cursorCallback,
+    t.context.booster_dates,
+    t.context.workbookWriterMock,
+  );
   sinon.assert.calledOnce(t.context.policyStatsStub!);
   sinon.assert.calledOnce(t.context.slicesWorkbookWriterStub!);
   t.is(filename, t.context.filename!);
@@ -180,6 +192,7 @@ test('BuildExcel: should call stream data and return filepath even if create sli
   t.context.filenameStub!.returns(t.context.filename);
   t.context.filepathStub!.returns(t.context.filepath);
   t.context.slicesWorkbookWriterStub!.rejects('Error while computing slices');
+  t.context.kernelStub!.resolves(t.context.booster_dates);
   t.context.policyStatsStub?.resolves({
     total_count: 111,
     total_sum: 222_00,
@@ -231,7 +244,12 @@ test('BuildExcel: should call stream data and return filepath even if create sli
     amount: 222_00,
   });
 
-  sinon.assert.calledOnceWithExactly(t.context.tripsWorkbookWriterStub!, cursorCallback, t.context.workbookWriterMock);
+  sinon.assert.calledOnceWithExactly(
+    t.context.tripsWorkbookWriterStub!,
+    cursorCallback,
+    t.context.booster_dates,
+    t.context.workbookWriterMock,
+  );
   sinon.assert.calledOnce(t.context.policyStatsStub!);
   sinon.assert.calledOnce(t.context.slicesWorkbookWriterStub!);
   t.is(filename, t.context.filename!);
@@ -247,6 +265,7 @@ test('BuildExcel: should call stream data and return excel filepath without slic
   t.context.filenameStub!.returns(t.context.filename);
   t.context.filepathStub!.returns(t.context.filepath);
   t.context.slicesWorkbookWriterStub!.rejects('Error while computing slices');
+  t.context.kernelStub!.resolves(t.context.booster_dates);
   t.context.policyStatsStub?.resolves({
     total_count: 111,
     total_sum: 222_00,
@@ -291,7 +310,12 @@ test('BuildExcel: should call stream data and return excel filepath without slic
     amount: 222_00,
   });
 
-  sinon.assert.calledOnceWithExactly(t.context.tripsWorkbookWriterStub!, cursorCallback, t.context.workbookWriterMock);
+  sinon.assert.calledOnceWithExactly(
+    t.context.tripsWorkbookWriterStub!,
+    cursorCallback,
+    t.context.booster_dates,
+    t.context.workbookWriterMock,
+  );
   sinon.assert.calledOnce(t.context.policyStatsStub!);
   sinon.assert.notCalled(t.context.slicesWorkbookWriterStub!);
   t.is(filename, t.context.filename!);

--- a/api/services/apdf/src/providers/excel/BuildExcel.spec.ts
+++ b/api/services/apdf/src/providers/excel/BuildExcel.spec.ts
@@ -1,3 +1,4 @@
+import { KernelInterfaceResolver } from '@ilos/common';
 import { APDFNameProvider } from '@pdc/provider-storage';
 import anyTest, { TestFn } from 'ava';
 import { stream } from 'exceljs';
@@ -14,6 +15,7 @@ import { wrapSlices } from './wrapSlicesHelper';
 
 interface Context {
   // Injected tokens
+  kernel: KernelInterfaceResolver;
   apdfRepositoryProvider: DataRepositoryProvider;
   nameProvider: APDFNameProvider;
   streamDataToWorkbook: TripsWorksheetWriter;
@@ -53,6 +55,7 @@ test.beforeEach((t) => {
   t.context.nameProvider = new APDFNameProvider();
   t.context.streamDataToWorkbook = new TripsWorksheetWriter();
   t.context.buildExcel = new BuildExcel(
+    t.context.kernel,
     t.context.apdfRepositoryProvider,
     t.context.streamDataToWorkbook,
     t.context.createSlicesSheetToWorkbook,

--- a/api/services/apdf/src/providers/excel/TripsWorksheetWriter.integration.spec.ts
+++ b/api/services/apdf/src/providers/excel/TripsWorksheetWriter.integration.spec.ts
@@ -20,10 +20,9 @@ const exportTripInterface: APDFTripInterface = {
   operator_trip_id: faker.datatype.uuid(),
   driver_uuid: faker.datatype.uuid(),
   operator_driver_id: faker.datatype.uuid(),
-  driver_rpc_incentive: faker.datatype.number(1000),
+  rpc_incentive: faker.datatype.number(1000),
   passenger_uuid: faker.datatype.uuid(),
   operator_passenger_id: faker.datatype.uuid(),
-  passenger_rpc_incentive: faker.datatype.number(1000),
   start_datetime: faker.date.past(2).toISOString(),
   end_datetime: faker.date.future(2).toISOString(),
   start_location: faker.address.cityName(),
@@ -32,7 +31,13 @@ const exportTripInterface: APDFTripInterface = {
   end_insee: faker.random.numeric(5, { allowLeadingZeros: true }),
   distance: faker.datatype.number({ min: 1_500, max: 150_000 }),
   duration: faker.datatype.number({ min: 300, max: 3600 }),
+  operator: faker.company.companyName(),
   operator_class: 'C',
+  incentive_type: faker.random.arrayElement(['normal', 'booster']),
+  start_epci_name: faker.address.cityName(),
+  start_epci: `${faker.random.alphaNumeric(5)}`,
+  end_epci_name: faker.address.cityName(),
+  end_epci: `${faker.random.alphaNumeric(5)}`,
 };
 
 test.before((t) => {
@@ -70,8 +75,9 @@ test('DataWorkBookWriter: should stream data to a workbook file', async (t) => {
   const filepath = '/tmp/stream-data-test.xlsx';
 
   // Act
+  const booster_dates = new Set<string>();
   const workbookWriter: stream.xlsx.WorkbookWriter = BuildExcel.initWorkbookWriter(filepath);
-  await dataWorkBookWriter.call({ read: cursorCallback, release: async () => {} }, workbookWriter);
+  await dataWorkBookWriter.call({ read: cursorCallback, release: async () => {} }, booster_dates, workbookWriter);
   await workbookWriter.commit();
 
   // Assert

--- a/api/services/apdf/src/providers/excel/TripsWorksheetWriter.ts
+++ b/api/services/apdf/src/providers/excel/TripsWorksheetWriter.ts
@@ -14,14 +14,14 @@ export class TripsWorksheetWriter extends AbstractWorksheetWriter {
     'journey_id',
     'start_datetime',
     'end_datetime',
-    'driver_rpc_incentive',
-    'passenger_rpc_incentive',
+    'rpc_incentive',
     'start_location',
     'start_insee',
     'end_location',
     'end_insee',
     'duration',
     'distance',
+    'operator',
     'operator_class',
     'trip_id',
     'operator_trip_id',
@@ -29,15 +29,24 @@ export class TripsWorksheetWriter extends AbstractWorksheetWriter {
     'operator_driver_id',
     'passenger_uuid',
     'operator_passenger_id',
+    'incentive_type',
+    'start_epci_name',
+    'start_epci',
+    'end_epci_name',
+    'end_epci',
   ].map((header) => ({ header, key: header }));
 
-  async call(cursor: PgCursorHandler<APDFTripInterface>, workbookWriter: stream.xlsx.WorkbookWriter): Promise<void> {
+  async call(
+    cursor: PgCursorHandler<APDFTripInterface>,
+    booster_dates: Set<string>,
+    workbookWriter: stream.xlsx.WorkbookWriter,
+  ): Promise<void> {
     const worksheet: Worksheet = this.initWorkSheet(workbookWriter, this.WORKSHEET_NAME, this.WORKSHEET_COLUMN_HEADERS);
 
     const b1 = new Date();
     let results: APDFTripInterface[] = await cursor.read(this.CURSOR_BATCH_SIZE);
     while (results.length !== 0) {
-      results.map((t) => worksheet.addRow(normalize(t, 'Europe/Paris')).commit());
+      results.map((t) => worksheet.addRow(normalize(t, booster_dates, 'Europe/Paris')).commit());
       results = await cursor.read(this.CURSOR_BATCH_SIZE);
     }
 


### PR DESCRIPTION
#2350 Modification des colonnes de l'export APDF

- Ajout du type de calcul (booster ou normal) par trajet
- Ajout de colonnes (EPCI, rpc_incentives...)

Les modifs seront reprises avec le travail sur le refacto de l'export pour rationaliser et dédoublonner le code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced data normalization to support "booster" mode trips, including logic for determining trip mode based on certain dates.
	- Updated the export functionality to include additional trip information such as operator details, incentive types, and start/end locations.
	- Introduced functionality to handle booster dates in export operations.

- **Refactor**
	- Consolidated `driver_rpc_incentive` and `passenger_rpc_incentive` into a single `rpc_incentive` field.
	- Modified data export and normalization processes to accommodate new and updated fields.
	- Improved command line execution syntax for better usability.

- **Documentation**
	- Updated README and inline documentation to reflect changes in functionality and command usage.

- **Tests**
	- Updated and added tests to cover new functionality and changes in data handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->