### PR TITLE
Suppression de /uptime

### DIFF
--- a/api/proxy/src/HttpTransport.ts
+++ b/api/proxy/src/HttpTransport.ts
@@ -106,7 +106,6 @@ export class HttpTransport implements TransportInterface {
     this.registerCeeRoutes();
     this.registerHonorRoutes();
     this.registerObservatoryRoutes();
-    this.registerUptimeRoute();
     this.registerContactformRoute();
     this.registerCallHandler();
     this.registerAfterAllHandlers();
@@ -831,19 +830,6 @@ export class HttpTransport implements TransportInterface {
         }),
       );
     }
-  }
-
-  private registerUptimeRoute() {
-    /**
-     * Simple GET route for uptime checking services
-     */
-    this.app.get(
-      '/uptime',
-      rateLimiter(),
-      asyncHandler(async (req, res, next) => {
-        res.json({ hello: 'world' });
-      }),
-    );
   }
 
   /**


### PR DESCRIPTION
La convention étant d'utiliser les routes `/health` et `/metrics`, la route `/uptime` n'est plus utile.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Removed an unused uptime checking route from the backend services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->