### PR TITLE
Ajout des opérateurs du Grand Poitiers

### DIFF
--- a/api/services/policy/src/engine/policies/GrandPoitiers.spec.ts
+++ b/api/services/policy/src/engine/policies/GrandPoitiers.spec.ts
@@ -5,6 +5,40 @@ import { makeProcessHelper } from '../tests/macro';
 import { GrandPoitiers as Handler } from './GrandPoitiers';
 import { generatePartialCarpools } from '../tests/helpers';
 
+// Unit test the getOperators method
+
+test('should return the last operators if no datetime is provided', (t) => {
+  const handler = new Handler(100);
+  t.deepEqual(handler.getOperators(), [
+    OperatorsEnum.Karos,
+    OperatorsEnum.Mobicoop,
+    OperatorsEnum.BlaBlaDaily,
+    OperatorsEnum.Klaxit,
+  ]);
+});
+
+test('should return Karos only if datetime is before 16/10/2023', (t) => {
+  const handler = new Handler(100);
+  t.deepEqual(handler.getOperators(new Date('2023-10-15')), [OperatorsEnum.Karos]);
+});
+
+test('should return Karos and Mobicoop if datetime is after 16/10/2023', (t) => {
+  const handler = new Handler(100);
+  t.deepEqual(handler.getOperators(new Date('2023-10-16')), [OperatorsEnum.Karos, OperatorsEnum.Mobicoop]);
+});
+
+test('should return all operators if datetime is after 22/12/2023', (t) => {
+  const handler = new Handler(100);
+  t.deepEqual(handler.getOperators(new Date('2023-12-23')), [
+    OperatorsEnum.Karos,
+    OperatorsEnum.Mobicoop,
+    OperatorsEnum.BlaBlaDaily,
+    OperatorsEnum.Klaxit,
+  ]);
+});
+
+// Unit test calculations
+
 const defaultPosition = {
   arr: '74278',
   com: '74278',

--- a/api/services/policy/src/interfaces/engine/PolicyInterface.ts
+++ b/api/services/policy/src/interfaces/engine/PolicyInterface.ts
@@ -75,6 +75,7 @@ export interface PolicyHandlerInterface {
   processStateful(context: StatefulContextInterface): void;
   params(): PolicyHandlerParamsInterface;
   describe(): string;
+  getOperators?(datetime?: Date): OperatorsEnum[]; // TODO generalise this from GrandPoitiers campaign
 }
 
 export type StatelessRuleHelper<P> = (ctx: StatelessContextInterface, params: P) => boolean;


### PR DESCRIPTION
Prise en charge des ajouts d'opérateurs sur la campagne du Grand Poitiers en fonction des dates.

> Système à généraliser aux autres campagnes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the policy management system to dynamically retrieve operators based on specific dates, improving the flexibility and accuracy of policy applications.
- **Tests**
	- Added new unit tests for the dynamic operator retrieval feature, ensuring robustness and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->