### PR TITLE
fix: Active Campaigns

### DIFF
--- a/api/src/pdc/services/apdf/actions/ExportAction.ts
+++ b/api/src/pdc/services/apdf/actions/ExportAction.ts
@@ -1,18 +1,19 @@
 import { ConfigInterfaceResolver, ContextType, handler, KernelInterfaceResolver } from '@ilos/common';
 import { Action } from '@ilos/core';
-import { BucketName, S3StorageProvider } from '@pdc/providers/storage';
 import { internalOnlyMiddlewares } from '@pdc/providers/middleware';
+import { BucketName, S3StorageProvider } from '@pdc/providers/storage';
+import { handlerConfig, ParamsInterface, ResultInterface } from '@shared/apdf/export.contract';
+import { alias } from '@shared/apdf/export.schema';
+import { ResultInterface as PolicyResultInterface } from '@shared/policy/find.contract';
 import { addMonths, startOfMonth, subMonths } from 'date-fns';
 import { zonedTimeToUtc } from 'date-fns-tz';
 import fs from 'fs';
 import { get } from 'lodash';
+import { castExportParams } from '../helpers/castExportParams.helper';
 import { getDeclaredOperators } from '../helpers/getDeclaredOperators.helper';
 import { DataRepositoryProviderInterfaceResolver } from '../interfaces/APDFRepositoryProviderInterface';
 import { CheckCampaign } from '../providers/CheckCampaign';
 import { BuildExcel } from '../providers/excel/BuildExcel';
-import { handlerConfig, ParamsInterface, ResultInterface } from '@shared/apdf/export.contract';
-import { alias } from '@shared/apdf/export.schema';
-import { ResultInterface as PolicyResultInterface } from '@shared/policy/find.contract';
 
 @handler({
   ...handlerConfig,
@@ -31,7 +32,7 @@ export class ExportAction extends Action {
   }
 
   public async handle(params: ParamsInterface, context: ContextType): Promise<ResultInterface> {
-    const { start_date, end_date } = this.castOrGetDefaultDates(params);
+    const { start_date, end_date } = castExportParams(params);
     const verbose = this.isVerbose(context);
 
     if (verbose) {

--- a/api/src/pdc/services/apdf/helpers/castExportParams.helper.ts
+++ b/api/src/pdc/services/apdf/helpers/castExportParams.helper.ts
@@ -1,0 +1,35 @@
+import { ParamsInterface } from '@shared/apdf/export.contract';
+import { addMonths, startOfMonth, subMonths } from 'date-fns';
+import { zonedTimeToUtc } from 'date-fns-tz';
+import { get } from 'lodash';
+
+export function castExportParams(params: ParamsInterface): { start_date: Date; end_date: Date } {
+  // use the local times
+  const start_date_lc = get(params, 'query.date.start', null);
+  const end_date_lc = get(params, 'query.date.end', null);
+
+  // having both
+  if (start_date_lc && end_date_lc) {
+    return { start_date: new Date(start_date_lc), end_date: new Date(end_date_lc) };
+  }
+
+  // make a 1 month date range from start_date
+  if (start_date_lc && !end_date_lc) {
+    return { start_date: new Date(start_date_lc), end_date: addMonths(start_date_lc, 1) };
+  }
+
+  // make a 1 month date range from end_date
+  if (!start_date_lc && end_date_lc) {
+    return { start_date: subMonths(end_date_lc, 1), end_date: new Date(end_date_lc) };
+  }
+
+  // defaults
+  const start = startOfMonth(subMonths(new Date(), 1));
+  const end = startOfMonth(new Date());
+
+  // timezoned
+  return {
+    start_date: zonedTimeToUtc(start, params.format?.tz),
+    end_date: zonedTimeToUtc(end, params.format?.tz),
+  };
+}

--- a/shared/policy/list.contract.ts
+++ b/shared/policy/list.contract.ts
@@ -1,6 +1,7 @@
 import { PolicyInterface } from './common/interfaces/PolicyInterface';
 
 export interface ParamsInterface {
+  datetime?: Date;
   territory_id?: number | null;
   operator_id?: number | null;
   status?: string;

--- a/shared/policy/list.schema.ts
+++ b/shared/policy/list.schema.ts
@@ -16,6 +16,9 @@ export const schema = {
       type: 'string',
       enum: ['template', 'draft', 'active', 'finished'],
     },
+    datetime: {
+      macro: 'timestamp',
+    },
   },
 };
 


### PR DESCRIPTION
Fix de l'algo de récupération des campagnes actives pour utiliser le mois d'export de l'APDF et non l'état au moment de la génération.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for an optional `datetime` parameter in policy listings to enhance search and filtering capabilities.

- **Refactor**
	- Improved date handling in file naming for exports, ensuring more accurate and timezone-aware filenames.
	- Enhanced the export functionality with better parameter handling and active campaign detection, leading to more efficient data processing and logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->