### PR TITLE
fix(apdf): filter APDF carpools by status

### DIFF
--- a/api/src/pdc/services/apdf/providers/APDFRepositoryProvider.ts
+++ b/api/src/pdc/services/apdf/providers/APDFRepositoryProvider.ts
@@ -81,6 +81,7 @@ export class DataRepositoryProvider implements DataRepositoryInterface {
             and pi.policy_id = $4
             and pi.status = 'validated'
             and cc.operator_id = $3
+            and cc.status in ('ok', 'canceled')
           )
         select
           count(acquisition_id)::int as total_count,


### PR DESCRIPTION
Filtrage des carpools dans la requête de stats des APDF par `ok` et `canceled` pour avoir les mêmes résultats que la requête de liste.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the accuracy of search results by adjusting filtering conditions to include items with 'ok' or 'canceled' status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->