### PR TITLE
Mise à jour des statuts des campagnes terminées

### DIFF
--- a/api/src/pdc/services/policy/commands/ApplyCommand.ts
+++ b/api/src/pdc/services/policy/commands/ApplyCommand.ts
@@ -65,6 +65,9 @@ export class ApplyCommand implements CommandInterface {
     try {
       const { tz, override } = options;
 
+      // update all campaign statuses
+      await this.policyRepository.updateAllCampaignStatuses();
+
       // list campaigns
       const campaigns = options.campaigns.length
         ? options.campaigns

--- a/api/src/pdc/services/policy/interfaces/providers/PolicyRepositoryProviderInterface.ts
+++ b/api/src/pdc/services/policy/interfaces/providers/PolicyRepositoryProviderInterface.ts
@@ -25,4 +25,5 @@ export abstract class PolicyRepositoryProviderInterfaceResolver {
   abstract listApplicablePoliciesId(): Promise<number[]>;
   abstract activeOperators(policy_id: number): Promise<number[]>;
   abstract syncIncentiveSum(campaign_id: number): Promise<void>;
+  abstract updateAllCampaignStatuses(): Promise<void>;
 }

--- a/api/src/pdc/services/policy/providers/PolicyRepositoryProvider.ts
+++ b/api/src/pdc/services/policy/providers/PolicyRepositoryProvider.ts
@@ -381,4 +381,19 @@ export class PolicyRepositoryProvider implements PolicyRepositoryProviderInterfa
       values: [campaign_id, incentive_sum],
     });
   }
+
+  /**
+   * Mass update campaign status
+   *
+   * For each campaign, check if it is still active and update its status
+   */
+  async updateAllCampaignStatuses(): Promise<void> {
+    await this.connection.getClient().query({
+      text: `
+        UPDATE ${this.table} SET status = $1
+        WHERE end_date < CURRENT_TIMESTAMP AND status = $2
+      `,
+      values: [PolicyStatusEnum.FINISHED, PolicyStatusEnum.ACTIVE],
+    });
+  }
 }


### PR DESCRIPTION
Ajout de la mise à jour du statut des campagnes avant de faire le `apply`.

Passe en `finished` toutes les campagnes dont la date de fin est dépassée.

fix #2451


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced campaign management with the ability to automatically update all campaign statuses based on their end dates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->