### PR TITLE
Campagne: Lannion-Trégor 2024

### DIFF
--- a/.vscode/typescript.json.code-snippets
+++ b/.vscode/typescript.json.code-snippets
@@ -1,0 +1,25 @@
+{
+  // Place your preuve-covoiturage workspace snippets here. Each snippet is defined under a snippet name and has a scope, prefix, body and 
+  // description. Add comma separated ids of the languages where the snippet is applicable in the scope field. If scope 
+  // is left empty or omitted, the snippet gets applied to all languages. The prefix is what is 
+  // used to trigger the snippet and the body will be expanded and inserted. Possible variables are: 
+  // $1, $2 for tab stops, $0 for the final cursor position, and ${1:label}, ${2:another} for placeholders. 
+  // Placeholders with the same ids are connected.
+  // Example:
+  // "Print to console": {
+  // 	"scope": "javascript,typescript",
+  // 	"prefix": "log",
+  // 	"body": [
+  // 		"console.log('$1');",
+  // 		"$2"
+  // 	],
+  // 	"description": "Log output to console"
+  // }
+  "console.debug": {
+    "description": "console.debug",
+    "prefix": "cd",
+    "body": [
+      "console.debug('$1', { $1 });$0",
+    ]
+  }
+}

--- a/api/src/pdc/services/policy/engine/helpers/onDistanceRange.spec.ts
+++ b/api/src/pdc/services/policy/engine/helpers/onDistanceRange.spec.ts
@@ -1,38 +1,66 @@
+import { InvalidParamsException } from '@ilos/common';
 import test from 'ava';
-
 import { StatelessContext } from '../entities/Context';
 import { NotEligibleTargetException } from '../exceptions/NotEligibleTargetException';
 import { generateCarpool } from '../tests/helpers';
 import { onDistanceRange, onDistanceRangeOrThrow } from './onDistanceRange';
 
-function setup(distance: number) {
+function distance(distance: number) {
   return StatelessContext.fromCarpool(1, generateCarpool({ distance }));
 }
 
 test('should return false if under range', async (t) => {
-  const ctx = setup(10);
-  const res = onDistanceRange(ctx, { min: 14, max: 16 });
-  t.is(res, false);
+  t.false(onDistanceRange(distance(10), { min: 14, max: 16 }));
 });
 
 test('should return false if above range', async (t) => {
-  const ctx = setup(20);
-  const res = onDistanceRange(ctx, { min: 14, max: 16 });
-  t.is(res, false);
+  t.false(onDistanceRange(distance(20), { min: 14, max: 16 }));
 });
 
 test('should return true if in range', async (t) => {
-  const ctx = setup(15);
-  const res = onDistanceRange(ctx, { min: 14, max: 16 });
-  t.is(res, true);
+  t.true(onDistanceRange(distance(15), { min: 14, max: 16 }));
+});
+
+test('should return true if on min', async (t) => {
+  t.true(onDistanceRange(distance(14), { min: 14, max: 16 }));
+});
+
+test('should return false if on max', async (t) => {
+  t.false(onDistanceRange(distance(16), { min: 14, max: 16 }));
+});
+
+test('should return true on missing params', (t) => {
+  t.true(onDistanceRange(distance(10), {}));
+});
+
+test('should return true on missing min param if in range', (t) => {
+  t.true(onDistanceRange(distance(10), { max: 15 }));
+});
+
+test('should return false on missing min param if not in range', (t) => {
+  t.false(onDistanceRange(distance(20), { max: 15 }));
+});
+
+test('should return true on missing max param if in range', (t) => {
+  t.true(onDistanceRange(distance(10), { min: 5 }));
+});
+
+test('should return false on missing max param if not in range', (t) => {
+  t.false(onDistanceRange(distance(10), { min: 15 }));
 });
 
 test('should not throw if in range', async (t) => {
-  const ctx = setup(15);
-  t.notThrows(() => onDistanceRangeOrThrow(ctx, { min: 14, max: 16 }));
+  t.notThrows(() => onDistanceRangeOrThrow(distance(15), { min: 14, max: 16 }));
 });
 
 test('should throw if not in range', async (t) => {
-  const ctx = setup(20);
-  t.throws(() => onDistanceRangeOrThrow(ctx, { min: 14, max: 16 }), { instanceOf: NotEligibleTargetException });
+  t.throws(() => onDistanceRangeOrThrow(distance(20), { min: 14, max: 16 }), {
+    instanceOf: NotEligibleTargetException,
+  });
+});
+
+test('should throw on missing distance', (t) => {
+  t.throws(() => onDistanceRange(distance(undefined), { max: 15 }), {
+    instanceOf: InvalidParamsException,
+  });
 });

--- a/api/src/pdc/services/policy/engine/helpers/onDistanceRange.ts
+++ b/api/src/pdc/services/policy/engine/helpers/onDistanceRange.ts
@@ -1,5 +1,6 @@
-import { NotEligibleTargetException } from '../exceptions/NotEligibleTargetException';
+import { InvalidParamsException } from '@ilos/common';
 import { StatelessContextInterface, StatelessRuleHelper } from '../../interfaces';
+import { NotEligibleTargetException } from '../exceptions/NotEligibleTargetException';
 
 interface OnDistanceParams {
   min?: number;
@@ -10,12 +11,18 @@ export const onDistanceRange: StatelessRuleHelper<OnDistanceParams> = (
   ctx: StatelessContextInterface,
   params: OnDistanceParams,
 ): boolean => {
-  if (params.min && ctx.carpool.distance < params.min) {
+  if (ctx?.carpool?.distance === null || typeof ctx?.carpool?.distance === 'undefined') {
+    throw new InvalidParamsException('[onDistanceRange] distance is missing from carpool');
+  }
+
+  if (params?.min !== null && typeof params?.min !== 'undefined' && ctx.carpool.distance < params.min) {
     return false;
   }
-  if (params.max && ctx.carpool.distance >= params.max) {
+
+  if (params?.max !== null && typeof params?.max !== 'undefined' && ctx.carpool.distance >= params.max) {
     return false;
   }
+
   return true;
 };
 

--- a/api/src/pdc/services/policy/engine/helpers/per.ts
+++ b/api/src/pdc/services/policy/engine/helpers/per.ts
@@ -16,7 +16,8 @@ export interface PerKmParams {
 }
 
 export const perKm = (ctx: StatelessContextInterface, params: PerKmParams): number => {
-  let distance = ctx.carpool.distance;
+  let { distance } = ctx.carpool;
+
   if (Number.isNaN(distance) || distance === 0) {
     return 0;
   }

--- a/api/src/pdc/services/policy/engine/policies/LannionTregor2024.html.ts
+++ b/api/src/pdc/services/policy/engine/policies/LannionTregor2024.html.ts
@@ -1,0 +1,35 @@
+/* eslint-disable max-len */
+export const description = `<div _ngcontent-fyn-c231="" id="summary" class="campaignSummaryText-content-text">
+
+  <p>Campagne d'incitation au covoiturage du <b> 01 avril 2024 au 31 décembre 2024</b></p>
+  
+  <p>Cette campagne est limitée à <b>144 906,00 €</b>.</p>
+
+  <p>
+    Les <b> conducteurs </b> effectuant un trajet entre 2 et 80 km
+    au départ ou à l'arrivée de la Communauté d'Agglomération Lannion-Trégor Communauté
+    sont incités selon les règles suivantes.
+  </p>
+
+  <p><strong>Départ <u>ou</u> Arrivée au sein de la communauté d'agglomération :</strong></p>
+
+  <ul>
+    <li><b>De 2 à 20 km : 1,50 € pour le conducteur par trajet et par passager&nbsp;;</b></li>
+    <li><b>De 20 à 30 km : 1,50 € pour le conducteur par trajet + 0,10 € par passager par kilomètre supplémentaire&nbsp;;</b></li>
+    <li><b>Au delà de 30 km : 2,50 € pour le conducteur par trajet et par passager avec une limite à 80 km.</b></li>
+  </ul>
+
+  <p>Les restrictions suivantes seront appliquées :</p>
+  
+  <ul>
+    <li><b>6 trajets pour le conducteur par jour (= 1 aller-retour avec 3 passagers).</b></li>
+    <li><b>50€ maximum pour le conducteur par mois.</b></li>
+  </ul>
+  
+  <p>
+    La campagne est éligible à l'opérateur de covoiturage
+    Blablacar Daily
+    proposant des preuves de classe <b>B</b> ou <b>C</b>
+  </p>
+
+</div>`;

--- a/api/src/pdc/services/policy/engine/policies/LannionTregor2024.spec.ts
+++ b/api/src/pdc/services/policy/engine/policies/LannionTregor2024.spec.ts
@@ -1,0 +1,203 @@
+import test from 'ava';
+import { v4 } from 'uuid';
+import { OperatorsEnum } from '../../interfaces';
+import { makeProcessHelper } from '../tests/macro';
+import { LannionTregor2024 as Handler } from './LannionTregor2024';
+
+const defaultPosition = {
+  arr: '74206',
+  com: '74206',
+  aom: '200067551',
+  epci: '200067551',
+  dep: '74',
+  reg: '84',
+  country: 'XXXXX',
+  reseau: null,
+};
+
+const defaultLat = 46.313355215729146;
+const defaultLon = 6.487631441991693;
+
+const defaultCarpool = {
+  _id: 1,
+  trip_id: v4(),
+  passenger_identity_uuid: v4(),
+  driver_identity_uuid: v4(),
+  operator_uuid: OperatorsEnum.BLABLACAR_DAILY,
+  operator_class: 'C',
+  passenger_is_over_18: true,
+  passenger_has_travel_pass: true,
+  driver_has_travel_pass: true,
+  datetime: new Date('2024-04-15'),
+  seats: 1,
+  duration: 600,
+  distance: 5_000,
+  cost: 150,
+  driver_payment: 150,
+  passenger_payment: 150,
+  start: { ...defaultPosition },
+  end: { ...defaultPosition },
+  start_lat: defaultLat,
+  start_lon: defaultLon,
+  end_lat: defaultLat,
+  end_lon: defaultLon,
+};
+
+const process = makeProcessHelper(defaultCarpool);
+
+test(
+  'should work with exclusions',
+  process,
+  {
+    policy: { handler: Handler.id },
+    carpool: [
+      { operator_uuid: 'not in list' },
+      { distance: 100 },
+      { operator_class: 'A' },
+      {
+        start: {
+          ...defaultPosition,
+          epci: '200070852', // Usses et Rhône
+          aom: '200070852',
+        },
+        end: {
+          ...defaultPosition,
+          epci: '200070852',
+          aom: '200070852',
+        },
+        datetime: new Date('2024-04-15'),
+      },
+      {
+        start: {
+          ...defaultPosition,
+          epci: '247400047', // CC Vallée Verte
+          aom: '247400047',
+        },
+        end: {
+          ...defaultPosition,
+          epci: '247400047',
+          aom: '247400047',
+        },
+        datetime: new Date('2024-04-15'),
+      },
+      {
+        end: {
+          ...defaultPosition,
+          aom: '247000623', // CC Quatre Rivière
+        },
+        start: {
+          ...defaultPosition,
+          aom: '247000623',
+        },
+        datetime: new Date('2024-04-15'),
+      },
+    ],
+    meta: [],
+  },
+  { incentive: [0, 0, 0, 0, 0, 0], meta: [] },
+);
+
+test(
+  'trips inside AOM',
+  process,
+  {
+    policy: { handler: Handler.id },
+    carpool: [
+      { distance: 5_000, driver_identity_uuid: 'one' },
+      { distance: 5_000, seats: 2, driver_identity_uuid: 'one' },
+      { distance: 20_000, driver_identity_uuid: 'one', passenger_identity_uuid: 'two' },
+      { distance: 30_000, driver_identity_uuid: 'one', passenger_identity_uuid: 'two' },
+      { distance: 40_000, driver_identity_uuid: 'one', passenger_identity_uuid: 'three' },
+      { distance: 40_000, seats: 2, driver_identity_uuid: 'one', passenger_identity_uuid: 'three' },
+      { distance: 70_000, driver_identity_uuid: 'one' },
+    ],
+  },
+  {
+    incentive: [150, 300, 150, 275, 400, 800, 400],
+  },
+);
+
+test(
+  'trips outside AOM',
+  process,
+  {
+    policy: { handler: Handler.id },
+    carpool: [
+      {
+        distance: 5_000,
+        driver_identity_uuid: 'one',
+        start: { ...defaultPosition, epci: '200070852', aom: '200070852' },
+      },
+      {
+        distance: 5_000,
+        seats: 2,
+        driver_identity_uuid: 'one',
+        start: { ...defaultPosition, epci: '200070852', aom: '200070852' },
+      },
+      {
+        distance: 20_000,
+        driver_identity_uuid: 'one',
+        passenger_identity_uuid: 'two',
+        start: { ...defaultPosition, epci: '200070852', aom: '200070852' },
+      },
+      {
+        distance: 30_000,
+        driver_identity_uuid: 'one',
+        passenger_identity_uuid: 'two',
+        start: { ...defaultPosition, epci: '200070852', aom: '200070852' },
+      },
+      {
+        distance: 40_000,
+        driver_identity_uuid: 'one',
+        passenger_identity_uuid: 'three',
+        start: { ...defaultPosition, epci: '200070852', aom: '200070852' },
+      },
+      {
+        distance: 40_000,
+        seats: 2,
+        driver_identity_uuid: 'one',
+        passenger_identity_uuid: 'three',
+        start: { ...defaultPosition, epci: '200070852', aom: '200070852' },
+      },
+      {
+        distance: 70_000,
+        driver_identity_uuid: 'one',
+        start: { ...defaultPosition, epci: '200070852', aom: '200070852' },
+      },
+    ],
+  },
+  {
+    incentive: [50, 100, 50, 175, 300, 600, 300],
+  },
+);
+
+test(
+  'should work with driver month limits',
+  process,
+  {
+    policy: { handler: Handler.id },
+    carpool: [
+      { distance: 5_000, driver_identity_uuid: 'one' },
+      { distance: 5_000, driver_identity_uuid: 'one' },
+    ],
+    meta: [
+      {
+        key: 'max_amount_restriction.0-one.month.3-2024',
+        value: 48_50,
+      },
+    ],
+  },
+  {
+    incentive: [150, 0],
+    meta: [
+      {
+        key: 'max_amount_restriction.0-one.month.3-2024',
+        value: 50_00,
+      },
+      {
+        key: 'max_amount_restriction.global.campaign.global',
+        value: 150,
+      },
+    ],
+  },
+);

--- a/api/src/pdc/services/policy/engine/policies/LannionTregor2024.spec.ts
+++ b/api/src/pdc/services/policy/engine/policies/LannionTregor2024.spec.ts
@@ -4,19 +4,20 @@ import { OperatorsEnum } from '../../interfaces';
 import { makeProcessHelper } from '../tests/macro';
 import { LannionTregor2024 as Handler } from './LannionTregor2024';
 
+// Perros-Guirec
 const defaultPosition = {
-  arr: '74206',
-  com: '74206',
-  aom: '200067551',
-  epci: '200067551',
-  dep: '74',
-  reg: '84',
+  arr: '22168',
+  com: '22168',
+  aom: '200065928',
+  epci: '200065928',
+  dep: '22',
+  reg: '53',
   country: 'XXXXX',
-  reseau: null,
+  reseau: '194',
 };
 
-const defaultLat = 46.313355215729146;
-const defaultLon = 6.487631441991693;
+const defaultLat = 48.81387693883991;
+const defaultLon = -3.4424441671291306;
 
 const defaultCarpool = {
   _id: 1,
@@ -98,77 +99,21 @@ test(
 );
 
 test(
-  'trips inside AOM',
+  'validate calculations',
   process,
   {
     policy: { handler: Handler.id },
     carpool: [
       { distance: 5_000, driver_identity_uuid: 'one' },
-      { distance: 5_000, seats: 2, driver_identity_uuid: 'one' },
+      { distance: 5_000, driver_identity_uuid: 'one', seats: 2 },
       { distance: 20_000, driver_identity_uuid: 'one', passenger_identity_uuid: 'two' },
-      { distance: 30_000, driver_identity_uuid: 'one', passenger_identity_uuid: 'two' },
-      { distance: 40_000, driver_identity_uuid: 'one', passenger_identity_uuid: 'three' },
-      { distance: 40_000, seats: 2, driver_identity_uuid: 'one', passenger_identity_uuid: 'three' },
-      { distance: 70_000, driver_identity_uuid: 'one' },
+      { distance: 29_000, driver_identity_uuid: 'one', passenger_identity_uuid: 'two' },
+      { distance: 30_000, driver_identity_uuid: 'one', passenger_identity_uuid: 'three' },
+      { distance: 40_000, driver_identity_uuid: 'one', passenger_identity_uuid: 'three', seats: 2 },
+      { distance: 80_000, driver_identity_uuid: 'one' },
     ],
   },
-  {
-    incentive: [150, 300, 150, 275, 400, 800, 400],
-  },
-);
-
-test(
-  'trips outside AOM',
-  process,
-  {
-    policy: { handler: Handler.id },
-    carpool: [
-      {
-        distance: 5_000,
-        driver_identity_uuid: 'one',
-        start: { ...defaultPosition, epci: '200070852', aom: '200070852' },
-      },
-      {
-        distance: 5_000,
-        seats: 2,
-        driver_identity_uuid: 'one',
-        start: { ...defaultPosition, epci: '200070852', aom: '200070852' },
-      },
-      {
-        distance: 20_000,
-        driver_identity_uuid: 'one',
-        passenger_identity_uuid: 'two',
-        start: { ...defaultPosition, epci: '200070852', aom: '200070852' },
-      },
-      {
-        distance: 30_000,
-        driver_identity_uuid: 'one',
-        passenger_identity_uuid: 'two',
-        start: { ...defaultPosition, epci: '200070852', aom: '200070852' },
-      },
-      {
-        distance: 40_000,
-        driver_identity_uuid: 'one',
-        passenger_identity_uuid: 'three',
-        start: { ...defaultPosition, epci: '200070852', aom: '200070852' },
-      },
-      {
-        distance: 40_000,
-        seats: 2,
-        driver_identity_uuid: 'one',
-        passenger_identity_uuid: 'three',
-        start: { ...defaultPosition, epci: '200070852', aom: '200070852' },
-      },
-      {
-        distance: 70_000,
-        driver_identity_uuid: 'one',
-        start: { ...defaultPosition, epci: '200070852', aom: '200070852' },
-      },
-    ],
-  },
-  {
-    incentive: [50, 100, 50, 175, 300, 600, 300],
-  },
+  { incentive: [150, 300, 150, 240, 250, 500, 0] },
 );
 
 test(
@@ -183,7 +128,7 @@ test(
     meta: [
       {
         key: 'max_amount_restriction.0-one.month.3-2024',
-        value: 48_50,
+        value: 148_50,
       },
     ],
   },
@@ -192,11 +137,47 @@ test(
     meta: [
       {
         key: 'max_amount_restriction.0-one.month.3-2024',
-        value: 50_00,
+        value: 150_00,
       },
       {
         key: 'max_amount_restriction.global.campaign.global',
         value: 150,
+      },
+    ],
+  },
+);
+
+test(
+  'should work with driver daily limits',
+  process,
+  {
+    policy: { handler: Handler.id },
+    carpool: [
+      { distance: 5_000, driver_identity_uuid: 'one' },
+      { distance: 5_000, driver_identity_uuid: 'one' },
+      { distance: 5_000, driver_identity_uuid: 'one' },
+      { distance: 5_000, driver_identity_uuid: 'one' },
+      { distance: 5_000, driver_identity_uuid: 'one' },
+      { distance: 5_000, driver_identity_uuid: 'one' },
+      { distance: 5_000, driver_identity_uuid: 'one' },
+    ],
+    meta: [
+      {
+        key: 'max_amount_restriction.0-one.month.3-2024',
+        value: 0,
+      },
+    ],
+  },
+  {
+    incentive: [150, 150, 150, 150, 150, 150, 0],
+    meta: [
+      {
+        key: 'max_amount_restriction.0-one.month.3-2024',
+        value: 900,
+      },
+      {
+        key: 'max_amount_restriction.global.campaign.global',
+        value: 900,
       },
     ],
   },

--- a/api/src/pdc/services/policy/engine/policies/LannionTregor2024.spec.ts
+++ b/api/src/pdc/services/policy/engine/policies/LannionTregor2024.spec.ts
@@ -1,6 +1,6 @@
 import test from 'ava';
 import { v4 } from 'uuid';
-import { OperatorsEnum } from '../../interfaces';
+import { CarpoolInterface, OperatorsEnum } from '../../interfaces';
 import { makeProcessHelper } from '../tests/macro';
 import { LannionTregor2024 as Handler } from './LannionTregor2024';
 
@@ -19,27 +19,27 @@ const defaultPosition = {
 const defaultLat = 48.81387693883991;
 const defaultLon = -3.4424441671291306;
 
-const defaultCarpool = {
+const defaultCarpool: CarpoolInterface = {
   _id: 1,
-  trip_id: v4(),
-  passenger_identity_uuid: v4(),
-  driver_identity_uuid: v4(),
+  passenger_contribution: 150,
+  passenger_identity_key: v4(),
+  passenger_has_travel_pass: true,
+  passenger_is_over_18: true,
+  driver_revenue: 150,
+  driver_identity_key: v4(),
+  driver_has_travel_pass: true,
+  operator_journey_id: v4(),
+  operator_id: 9,
+  operator_trip_id: v4(),
   operator_uuid: OperatorsEnum.BLABLACAR_DAILY,
   operator_class: 'C',
-  passenger_is_over_18: true,
-  passenger_has_travel_pass: true,
-  driver_has_travel_pass: true,
   datetime: new Date('2024-04-15'),
   seats: 1,
-  duration: 600,
   distance: 5_000,
-  cost: 150,
-  driver_payment: 150,
-  passenger_payment: 150,
   start: { ...defaultPosition },
-  end: { ...defaultPosition },
   start_lat: defaultLat,
   start_lon: defaultLon,
+  end: { ...defaultPosition },
   end_lat: defaultLat,
   end_lon: defaultLon,
 };
@@ -93,9 +93,8 @@ test(
         datetime: new Date('2024-04-15'),
       },
     ],
-    meta: [],
   },
-  { incentive: [0, 0, 0, 0, 0, 0], meta: [] },
+  { incentive: [0, 0, 0, 0, 0, 0] },
 );
 
 test(
@@ -104,13 +103,13 @@ test(
   {
     policy: { handler: Handler.id },
     carpool: [
-      { distance: 5_000, driver_identity_uuid: 'one' },
-      { distance: 5_000, driver_identity_uuid: 'one', seats: 2 },
-      { distance: 20_000, driver_identity_uuid: 'one', passenger_identity_uuid: 'two' },
-      { distance: 29_000, driver_identity_uuid: 'one', passenger_identity_uuid: 'two' },
-      { distance: 30_000, driver_identity_uuid: 'one', passenger_identity_uuid: 'three' },
-      { distance: 40_000, driver_identity_uuid: 'one', passenger_identity_uuid: 'three', seats: 2 },
-      { distance: 80_000, driver_identity_uuid: 'one' },
+      { distance: 5_000, driver_identity_key: 'one' },
+      { distance: 5_000, driver_identity_key: 'one', seats: 2 },
+      { distance: 20_000, driver_identity_key: 'one', passenger_identity_key: 'two' },
+      { distance: 29_000, driver_identity_key: 'one', passenger_identity_key: 'two' },
+      { distance: 30_000, driver_identity_key: 'one', passenger_identity_key: 'three' },
+      { distance: 40_000, driver_identity_key: 'one', passenger_identity_key: 'three', seats: 2 },
+      { distance: 80_000, driver_identity_key: 'one' },
     ],
   },
   { incentive: [150, 300, 150, 240, 250, 500, 0] },
@@ -122,8 +121,8 @@ test(
   {
     policy: { handler: Handler.id },
     carpool: [
-      { distance: 5_000, driver_identity_uuid: 'one' },
-      { distance: 5_000, driver_identity_uuid: 'one' },
+      { distance: 5_000, driver_identity_key: 'one' },
+      { distance: 5_000, driver_identity_key: 'one' },
     ],
     meta: [
       {
@@ -153,13 +152,13 @@ test(
   {
     policy: { handler: Handler.id },
     carpool: [
-      { distance: 5_000, driver_identity_uuid: 'one' },
-      { distance: 5_000, driver_identity_uuid: 'one' },
-      { distance: 5_000, driver_identity_uuid: 'one' },
-      { distance: 5_000, driver_identity_uuid: 'one' },
-      { distance: 5_000, driver_identity_uuid: 'one' },
-      { distance: 5_000, driver_identity_uuid: 'one' },
-      { distance: 5_000, driver_identity_uuid: 'one' },
+      { distance: 5_000, driver_identity_key: 'one' },
+      { distance: 5_000, driver_identity_key: 'one' },
+      { distance: 5_000, driver_identity_key: 'one' },
+      { distance: 5_000, driver_identity_key: 'one' },
+      { distance: 5_000, driver_identity_key: 'one' },
+      { distance: 5_000, driver_identity_key: 'one' },
+      { distance: 5_000, driver_identity_key: 'one' },
     ],
     meta: [
       {

--- a/api/src/pdc/services/policy/engine/policies/LannionTregor2024.ts
+++ b/api/src/pdc/services/policy/engine/policies/LannionTregor2024.ts
@@ -1,0 +1,126 @@
+import {
+  OperatorsEnum,
+  PolicyHandlerInterface,
+  PolicyHandlerParamsInterface,
+  PolicyHandlerStaticInterface,
+  StatelessContextInterface,
+  TerritoryCodeEnum,
+  TerritorySelectorsInterface,
+} from '../../interfaces';
+import { RunnableSlices } from '../../interfaces/engine/PolicyInterface';
+import {
+  LimitTargetEnum,
+  isOperatorClassOrThrow,
+  isOperatorOrThrow,
+  onDistanceRange,
+  onDistanceRangeOrThrow,
+  perKm,
+  perSeat,
+  startsAndEndsAt,
+  watchForGlobalMaxAmount,
+  watchForPersonMaxAmountByMonth,
+  watchForPersonMaxTripByDay,
+} from '../helpers';
+import { TimestampedOperators, getOperatorsAt } from '../helpers/getOperatorsAt';
+import { startsOrEndsAtOrThrow } from '../helpers/startsOrEndsAtOrThrow';
+import { AbstractPolicyHandler } from './AbstractPolicyHandler';
+import { description } from './LannionTregor2024.html';
+
+// INSERT INTO policy.policies (territory_id, start_date, end_date, name, unit, status, handler, max_amount)
+// VALUES (
+//   321,
+//   '2024-04-01T00:00:00+0200',
+//   '2025-01-01T00:00:00+0100',
+//   'Lannion-Trégor 2024',
+//   'euro',
+//   'draft',
+//   'lannion_tregor_2024',
+//   14490600
+// );
+
+export const LannionTregor2024: PolicyHandlerStaticInterface = class
+  extends AbstractPolicyHandler
+  implements PolicyHandlerInterface
+{
+  static readonly id = 'lannion_tregor_2024';
+
+  protected operator_class = ['B', 'C'];
+
+  protected readonly operators: TimestampedOperators = [
+    {
+      date: new Date('2024-04-01T00:00:00+0200'),
+      operators: [OperatorsEnum.BLABLACAR_DAILY],
+    },
+  ];
+
+  protected readonly territorySelector: TerritorySelectorsInterface = {
+    [TerritoryCodeEnum.Mobility]: ['200065928'], // CA Lannion-Trégor Communauté
+  };
+
+  constructor(public max_amount: number) {
+    super();
+    this.limits = [
+      ['2F2434E3-D2A5-428E-8027-8FD8C62F508B', 6, watchForPersonMaxTripByDay, LimitTargetEnum.Driver],
+      ['664572FC-0873-4F2F-9B42-BDDAF291BB73', 150_00, watchForPersonMaxAmountByMonth, LimitTargetEnum.Driver],
+      ['E7CC1FDC-65DB-4A88-A134-ECE3773B1293', this.max_amount, watchForGlobalMaxAmount], // required
+    ];
+  }
+
+  /**
+   * Trajets extra-AOM (origine OU destination dans l'AOM)
+   * - 1,50€ par passager de 2 à 20 km
+   * - 1,50€ par passager + 0,10€ pour les km >= 20 km et < 30 km
+   * - 2,50€ par passager >= 30 km
+   * - limite d'incitation à 80 km -> non incités au dessus
+   */
+  protected slices: RunnableSlices = [
+    { start: 2_000, end: 20_000, fn: (ctx: StatelessContextInterface) => perSeat(ctx, 150) },
+    {
+      start: 20_000,
+      end: 30_000,
+      fn: (ctx: StatelessContextInterface) => perSeat(ctx, perKm(ctx, { amount: 10, offset: 20_000, limit: 30_000 })),
+    },
+    {
+      start: 30_000,
+      end: 80_000,
+      fn: (ctx: StatelessContextInterface) => perSeat(ctx, 250),
+    },
+  ];
+
+  protected processExclusions(ctx: StatelessContextInterface) {
+    isOperatorOrThrow(ctx, getOperatorsAt(this.operators, ctx.carpool.datetime));
+    isOperatorClassOrThrow(ctx, this.operator_class);
+    startsOrEndsAtOrThrow(ctx, this.territorySelector);
+    onDistanceRangeOrThrow(ctx, { min: 1_999, max: 80_000 });
+  }
+
+  processStateless(ctx: StatelessContextInterface): void {
+    this.processExclusions(ctx);
+    super.processStateless(ctx);
+
+    // Apply each slice and sum up the results
+    let amount = 0;
+    for (const { start, fn } of this.slices) {
+      if (onDistanceRange(ctx, { min: start })) {
+        amount += fn(ctx);
+      }
+    }
+
+    ctx.incentive.set(amount);
+  }
+
+  params(): PolicyHandlerParamsInterface {
+    return {
+      tz: 'Europe/Paris',
+      slices: this.slices,
+      operators: getOperatorsAt(this.operators),
+      limits: {
+        glob: this.max_amount,
+      },
+    };
+  }
+
+  describe(): string {
+    return description;
+  }
+};

--- a/api/src/pdc/services/policy/engine/policies/index.ts
+++ b/api/src/pdc/services/policy/engine/policies/index.ts
@@ -7,6 +7,7 @@ import { GrandPoitiers } from './GrandPoitiers';
 import { Idfm } from './Idfm';
 import { LaRochelle20232024 } from './LaRochelle20232024';
 import { Lannion } from './Lannion';
+import { LannionTregor2024 } from './LannionTregor2024';
 import { Laval } from './Laval';
 import { MetropoleSavoie } from './MetropoleSavoie';
 import { Montpellier } from './Montpellier';
@@ -44,6 +45,7 @@ export const policies: Map<string, PolicyHandlerStaticInterface> = new Map(
     GrandPoitiers,
     Idfm,
     Lannion,
+    LannionTregor2024,
     LaRochelle20232024,
     Laval,
     MetropoleSavoie,

--- a/dashboard/src/app/modules/campaign/modules/campaign-ui/components/campaign-main-metrics/campaign-main-metrics.component.ts
+++ b/dashboard/src/app/modules/campaign/modules/campaign-ui/components/campaign-main-metrics/campaign-main-metrics.component.ts
@@ -51,9 +51,13 @@ export class CampaignMainMetricsComponent implements OnInit, OnChanges {
   }
 
   private initPeriod(): void {
-    const start = moment(this.campaign.start_date);
-    const end = moment(this.campaign.end_date);
     const today = moment();
+    const start = moment(this.campaign.start_date);
+
+    // configuration in the database is exclusive end_date
+    // to avoid displaying the day after the end of the campaign
+    // to the user, we display the day before.
+    const end = moment(this.campaign.end_date).subtract(1, 'second');
 
     const period = end.diff(start, 'days');
 


### PR DESCRIPTION
policy_id : `1056`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a detailed description of the Lannion-Trégor carpooling incentive campaign for 2024.
  - Implemented new policy rules for carpooling incentives in the Lannion-Trégor region for 2024.

- **Bug Fixes**
  - Adjusted the end date calculation in the Campaign Main Metrics to display the correct end date in the user interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->