### PR TITLE
hotfix: avoid querying from old carpool table

### DIFF
--- a/api/src/db/migrations/policy/20240423000000_migrate_to_carpool_v2.up.sql
+++ b/api/src/db/migrations/policy/20240423000000_migrate_to_carpool_v2.up.sql
@@ -2,4 +2,5 @@ ALTER TABLE policy.incentives
   ADD COLUMN operator_id INTEGER REFERENCES operator.operators(_id),
   ADD operator_journey_id VARCHAR;
 
-CREATE UNIQUE INDEX IF NOT EXISTS policy_incentives_operator_operator_journey_id_idx ON policy.incentives (operator_id, operator_journey_id);
+CREATE INDEX IF NOT EXISTS policy_incentives_operator_operator_journey_id_idx ON policy.incentives (operator_id, operator_journey_id);
+CREATE UNIQUE INDEX IF NOT EXISTS policy_incentives_policy_operator_operator_journey_id_idx ON policy.incentives (policy_id, operator_id, operator_journey_id);

--- a/api/src/pdc/services/policy/actions/SimulateOnFutureAction.ts
+++ b/api/src/pdc/services/policy/actions/SimulateOnFutureAction.ts
@@ -75,7 +75,6 @@ export class SimulateOnFutureAction extends AbstractAction {
       .map((i) => i.export())
       .filter((i) => i.statelessAmount > 0)
       .map((i) => ({
-        carpool_id: i.carpool_id,
         amount: i.statelessAmount,
         siret: uuidList.find((s) => s._id === policies.find((c) => c._id === i.policy_id).territory_id).uuid,
       }));

--- a/api/src/pdc/services/policy/actions/SimulateOnPastByGeoAction.spec.ts
+++ b/api/src/pdc/services/policy/actions/SimulateOnPastByGeoAction.spec.ts
@@ -91,7 +91,6 @@ test('SimulateOnPastByGeoAction: should process trip with default time frame', a
   });
   t.context.tripRepositoryResolverStub!.callsFake(function* fake() {
     const carpool: Partial<CarpoolInterface> = {
-      _id: 1,
       operator_trip_id: '',
       operator_class: 'C',
       datetime: faker.date.between({ from: t.context.todayMinusSizMonthes, to: new Date() }),
@@ -125,7 +124,6 @@ test('SimulateOnPastByGeoAction: should exclude trip with start and end not in 2
   });
   t.context.tripRepositoryResolverStub!.callsFake(function* fake() {
     const carpool: Partial<CarpoolInterface> = {
-      _id: 1,
       operator_trip_id: '',
       operator_class: 'C',
       datetime: faker.date.between({ from: t.context.todayMinusSizMonthes, to: new Date() }),

--- a/api/src/pdc/services/policy/engine/entities/Context.ts
+++ b/api/src/pdc/services/policy/engine/entities/Context.ts
@@ -22,14 +22,7 @@ export class StatelessContext implements StatelessContextInterface {
   static fromCarpool(policy_id: number, carpool: CarpoolInterface): StatelessContext {
     const registry = MetadataRegistry.create(policy_id, carpool.datetime);
     return new StatelessContext(
-      Incentive.create(
-        policy_id,
-        carpool._id,
-        carpool.operator_id,
-        carpool.operator_journey_id,
-        carpool.datetime,
-        registry,
-      ),
+      Incentive.create(policy_id, carpool.operator_id, carpool.operator_journey_id, carpool.datetime, registry),
       registry,
       carpool,
     );

--- a/api/src/pdc/services/policy/engine/entities/Incentive.ts
+++ b/api/src/pdc/services/policy/engine/entities/Incentive.ts
@@ -12,7 +12,6 @@ export class Incentive<T> {
   constructor(
     public readonly _id: T,
     public readonly policy_id: number,
-    public readonly carpool_id: number,
     public readonly operator_id: number,
     public readonly operator_journey_id: string,
     public readonly datetime: Date,
@@ -25,7 +24,6 @@ export class Incentive<T> {
 
   static create(
     policy_id: number,
-    carpool_id: number,
     operator_id: number,
     operator_journey_id: string,
     datetime: Date,
@@ -34,7 +32,6 @@ export class Incentive<T> {
     return new StatelessIncentive(
       undefined,
       policy_id,
-      carpool_id,
       operator_id,
       operator_journey_id,
       datetime,
@@ -50,7 +47,6 @@ export class Incentive<T> {
     return new Incentive(
       data._id,
       data.policy_id,
-      data.carpool_id,
       data.operator_id,
       data.operator_journey_id,
       data.datetime,
@@ -66,7 +62,6 @@ export class Incentive<T> {
     return {
       _id: this._id,
       policy_id: this.policy_id,
-      carpool_id: this.carpool_id,
       operator_id: this.operator_id,
       operator_journey_id: this.operator_journey_id,
       datetime: this.datetime,

--- a/api/src/pdc/services/policy/engine/entities/Policy.ts
+++ b/api/src/pdc/services/policy/engine/entities/Policy.ts
@@ -87,7 +87,9 @@ export class Policy implements PolicyInterface {
           context.incentive.set(0);
           return context.incentive;
         }
-        console.error(`Stateless incentive calculation for carpool ${carpool._id} failed : ${e.message}`);
+        console.error(
+          `Stateless incentive calculation for carpool ${carpool.operator_id} ${carpool.operator_journey_id} failed : ${e.message}`,
+        );
         console.debug(e);
         throw e;
       }

--- a/api/src/pdc/services/policy/engine/helpers/limits.spec.ts
+++ b/api/src/pdc/services/policy/engine/helpers/limits.spec.ts
@@ -163,7 +163,6 @@ test('should watch and apply', async (t) => {
   ctxStateless.incentive.set(100);
   t.deepEqual(ctxStateless.incentive.export(), {
     _id: undefined,
-    carpool_id: ctxStateless.carpool._id,
     operator_id: ctxStateless.carpool.operator_id,
     operator_journey_id: ctxStateless.carpool.operator_journey_id,
     datetime: ctxStateless.carpool.datetime,
@@ -225,7 +224,6 @@ test('should watch and apply for custom data', async (t) => {
   ctxStateless.incentive.set(100);
   t.deepEqual(ctxStateless.incentive.export(), {
     _id: undefined,
-    carpool_id: ctxStateless.carpool._id,
     operator_id: ctxStateless.carpool.operator_id,
     operator_journey_id: ctxStateless.carpool.operator_journey_id,
     datetime: ctxStateless.carpool.datetime,

--- a/api/src/pdc/services/policy/engine/policies/LannionTregor2024.spec.ts
+++ b/api/src/pdc/services/policy/engine/policies/LannionTregor2024.spec.ts
@@ -20,7 +20,6 @@ const defaultLat = 48.81387693883991;
 const defaultLon = -3.4424441671291306;
 
 const defaultCarpool: CarpoolInterface = {
-  _id: 1,
   passenger_contribution: 150,
   passenger_identity_key: v4(),
   passenger_has_travel_pass: true,

--- a/api/src/pdc/services/policy/engine/policies/Occitanie20232024.spec.ts
+++ b/api/src/pdc/services/policy/engine/policies/Occitanie20232024.spec.ts
@@ -18,7 +18,6 @@ const defaultLat = 48.72565703413325;
 const defaultLon = 2.261827843187402;
 
 const defaultCarpool: CarpoolInterface = {
-  _id: 1,
   operator_trip_id: v4(),
   passenger_identity_key: v4(),
   driver_identity_key: v4(),

--- a/api/src/pdc/services/policy/engine/tests/helpers.ts
+++ b/api/src/pdc/services/policy/engine/tests/helpers.ts
@@ -21,7 +21,6 @@ const defaultLat = 48.72565703413325;
 const defaultLon = 2.261827843187402;
 
 const dftCarpool: CarpoolInterface = {
-  _id: 1,
   operator_trip_id: v4(),
   driver_identity_key: v4(),
   passenger_identity_key: v4(),
@@ -55,7 +54,6 @@ export function generateCarpool(
 const defaultIncentive: SerializedIncentiveInterface = {
   _id: 1,
   policy_id: 1,
-  carpool_id: 1,
   operator_id: 1,
   operator_journey_id: dftCarpool.operator_journey_id,
   datetime: new Date('2019-01-15'),

--- a/api/src/pdc/services/policy/interfaces/engine/IncentiveInterface.ts
+++ b/api/src/pdc/services/policy/interfaces/engine/IncentiveInterface.ts
@@ -17,7 +17,6 @@ export enum IncentiveStatusEnum {
 export interface SerializedIncentiveInterface<T = number> {
   _id: T;
   policy_id: number;
-  carpool_id: number;
   operator_id: number;
   operator_journey_id: string;
   datetime: Date;

--- a/api/src/pdc/services/policy/interfaces/engine/index.ts
+++ b/api/src/pdc/services/policy/interfaces/engine/index.ts
@@ -45,7 +45,6 @@ export interface CarpoolMetaInterface {
 }
 
 export interface CarpoolInterface {
-  _id: number;
   passenger_contribution: number;
   passenger_identity_key: string;
   passenger_has_travel_pass: boolean;

--- a/api/src/pdc/services/policy/providers/IncentiveRepositoryProvider.integration.spec.ts
+++ b/api/src/pdc/services/policy/providers/IncentiveRepositoryProvider.integration.spec.ts
@@ -27,9 +27,8 @@ test.serial('Should create many incentives', async (t) => {
     {
       _id: undefined,
       policy_id: 0,
-      carpool_id: 1,
       operator_id: 1,
-      operator_journey_id: 'operator_journey_id',
+      operator_journey_id: 'operator_journey_id-1',
       datetime: new Date(),
       statelessAmount: 0,
       statefulAmount: 0,
@@ -40,9 +39,8 @@ test.serial('Should create many incentives', async (t) => {
     {
       _id: undefined,
       policy_id: 0,
-      carpool_id: 1,
       operator_id: 1,
-      operator_journey_id: 'operator_journey_id',
+      operator_journey_id: 'operator_journey_id-1',
       datetime: new Date(),
       statelessAmount: 100,
       statefulAmount: 100,
@@ -53,9 +51,8 @@ test.serial('Should create many incentives', async (t) => {
     {
       _id: undefined,
       policy_id: 0,
-      carpool_id: 2,
       operator_id: 1,
-      operator_journey_id: 'operator_journey_id_2',
+      operator_journey_id: 'operator_journey_id-2',
       datetime: new Date(),
       statelessAmount: 200,
       statefulAmount: 200,
@@ -77,8 +74,8 @@ test.serial('Should create many incentives', async (t) => {
     values: [0],
   });
   t.is(incentiveResults.rowCount, 2);
-  t.is(incentiveResults.rows.find((i) => i.carpool_id === 1).result, 100);
-  t.is(incentiveResults.rows.find((i) => i.carpool_id === 2).result, 200);
+  t.is(incentiveResults.rows.find((i) => i.operator_journey_id === 'operator_journey_id-1').result, 100);
+  t.is(incentiveResults.rows.find((i) => i.operator_journey_id === 'operator_journey_id-2').result, 200);
 });
 
 test.serial('Should update many incentives', async (t) => {
@@ -86,9 +83,8 @@ test.serial('Should update many incentives', async (t) => {
     {
       _id: undefined,
       policy_id: 0,
-      carpool_id: 1,
       operator_id: 1,
-      operator_journey_id: 'operator_journey_id',
+      operator_journey_id: 'operator_journey_id-1',
       datetime: new Date(),
       statelessAmount: 0,
       statefulAmount: 0,
@@ -104,9 +100,8 @@ test.serial('Should update many incentives', async (t) => {
     {
       _id: undefined,
       policy_id: 0,
-      carpool_id: 2,
       operator_id: 1,
-      operator_journey_id: 'operator_journey_id_2',
+      operator_journey_id: 'operator_journey_id-2',
       datetime: new Date(),
       statelessAmount: 500,
       statefulAmount: 500,
@@ -117,9 +112,8 @@ test.serial('Should update many incentives', async (t) => {
     {
       _id: undefined,
       policy_id: 0,
-      carpool_id: 3,
       operator_id: 1,
-      operator_journey_id: 'operator_journey_id_3',
+      operator_journey_id: 'operator_journey_id-3',
       datetime: new Date(),
       statelessAmount: 100,
       statefulAmount: 100,
@@ -137,10 +131,10 @@ test.serial('Should update many incentives', async (t) => {
   });
 
   t.is(incentiveResults.rowCount, 3);
-  t.is(incentiveResults.rows.find((i) => i.carpool_id === 1).result, 0);
-  t.is(incentiveResults.rows.find((i) => i.carpool_id === 1).state, 'null');
-  t.is(incentiveResults.rows.find((i) => i.carpool_id === 2).result, 500);
-  t.is(incentiveResults.rows.find((i) => i.carpool_id === 3).result, 100);
+  t.is(incentiveResults.rows.find((i) => i.operator_journey_id === 'operator_journey_id-1').result, 0);
+  t.is(incentiveResults.rows.find((i) => i.operator_journey_id === 'operator_journey_id-1').state, 'null');
+  t.is(incentiveResults.rows.find((i) => i.operator_journey_id === 'operator_journey_id-2').result, 500);
+  t.is(incentiveResults.rows.find((i) => i.operator_journey_id === 'operator_journey_id-3').result, 100);
 });
 
 test.serial('Should update many incentives amount', async (t) => {
@@ -167,23 +161,27 @@ test.serial('Should list draft incentive', async (t) => {
   await cursor.next();
   t.true(Array.isArray(value));
   const incentives = (Array.isArray(value) ? value : []).map((v) => ({
-    carpool_id: v.carpool_id,
+    operator_id: v.operator_id,
+    operator_journey_id: v.operator_journey_id,
     statefulAmount: v.statefulAmount,
     statelessAmount: v.statelessAmount,
   }));
   t.deepEqual(incentives, [
     {
-      carpool_id: 1,
+      operator_id: 1,
+      operator_journey_id: 'operator_journey_id-1',
       statefulAmount: 0,
       statelessAmount: 0,
     },
     {
-      carpool_id: 2,
+      operator_id: 1,
+      operator_journey_id: 'operator_journey_id-2',
       statefulAmount: 0,
       statelessAmount: 500,
     },
     {
-      carpool_id: 3,
+      operator_id: 1,
+      operator_journey_id: 'operator_journey_id-3',
       statefulAmount: 0,
       statelessAmount: 100,
     },

--- a/api/src/pdc/services/policy/providers/IncentiveRepositoryProvider.ts
+++ b/api/src/pdc/services/policy/providers/IncentiveRepositoryProvider.ts
@@ -89,7 +89,7 @@ export class IncentiveRepositoryProvider implements IncentiveRepositoryProviderI
 
     // get only last incentive for each carpool / policy
     const filteredData = data.reverse().filter((d) => {
-      const key = `${d.policy_id}/${d.carpool_id}`;
+      const key = `${d.policy_id}/${d.operator_id}/${d.operator_journey_id}`;
       if (idSet.has(key)) {
         return false;
       }
@@ -165,7 +165,6 @@ export class IncentiveRepositoryProvider implements IncentiveRepositoryProviderI
       text: `
       SELECT
         _id,
-        carpool_id,
         policy_id,
         datetime,
         result as stateless_amount,
@@ -216,7 +215,7 @@ export class IncentiveRepositoryProvider implements IncentiveRepositoryProviderI
     const filteredData = data
       .reverse()
       .filter((d) => {
-        const key = `${d.policy_id}/${d.carpool_id}`;
+        const key = `${d.policy_id}/${d.operator_id}/${d.operator_journey_id}`;
         if (idSet.has(key)) {
           return false;
         }
@@ -232,7 +231,6 @@ export class IncentiveRepositoryProvider implements IncentiveRepositoryProviderI
 
     const values: [
       Array<number>,
-      Array<number>,
       Array<Date>,
       Array<number>,
       Array<number>,
@@ -245,7 +243,6 @@ export class IncentiveRepositoryProvider implements IncentiveRepositoryProviderI
       (
         [
           policyIds,
-          carpoolIds,
           datetimes,
           statelessAmounts,
           statefulAmounts,
@@ -258,7 +255,6 @@ export class IncentiveRepositoryProvider implements IncentiveRepositoryProviderI
         i,
       ) => {
         policyIds.push(i.policy_id);
-        carpoolIds.push(i.carpool_id);
         datetimes.push(i.datetime);
         statelessAmounts.push(i.statelessAmount);
         statefulAmounts.push(i.statefulAmount);
@@ -269,7 +265,6 @@ export class IncentiveRepositoryProvider implements IncentiveRepositoryProviderI
         metas.push(JSON.stringify(i.meta));
         return [
           policyIds,
-          carpoolIds,
           datetimes,
           statelessAmounts,
           statefulAmounts,
@@ -280,8 +275,10 @@ export class IncentiveRepositoryProvider implements IncentiveRepositoryProviderI
           metas,
         ];
       },
-      [[], [], [], [], [], [], [], [], [], []],
+      [[], [], [], [], [], [], [], [], []],
     );
+
+    console.table(values);
 
     const query = {
       text: `
@@ -296,32 +293,41 @@ export class IncentiveRepositoryProvider implements IncentiveRepositoryProviderI
           operator_id,
           operator_journey_id,
           meta
-        ) SELECT * FROM UNNEST(
+        )
+        SELECT 
+          unnest_data.policy_id,
+          cc._id as carpool_id,
+          unnest_data.datetime,
+          unnest_data.result,
+          unnest_data.amount,
+          unnest_data.status,
+          unnest_data.state,
+          unnest_data.operator_id,
+          unnest_data.operator_journey_id,
+          unnest_data.meta
+        FROM UNNEST(
           $1::int[],
-          $2::int[],
-          $3::timestamp[],
+          $2::timestamp[],
+          $3::int[],
           $4::int[],
-          $5::int[],
-          $6::policy.incentive_status_enum[],
-          $7::policy.incentive_state_enum[],
-          $8::int[],
-          $9::varchar[],
-          $10::json[]
-        )
-        ON CONFLICT (policy_id, carpool_id)
-        DO UPDATE SET (
-          result,
-          amount,
-          status,
-          state,
-          meta
-        ) = (
-          excluded.result,
-          excluded.amount,
-          excluded.status,
-          excluded.state,
-          excluded.meta
-        )
+          $5::policy.incentive_status_enum[],
+          $6::policy.incentive_state_enum[],
+          $7::int[],
+          $8::varchar[],
+          $9::json[]
+        ) AS unnest_data(policy_id, datetime, result, amount, status, state, operator_id, operator_journey_id, meta)
+        JOIN carpool.carpools cc
+          ON cc.operator_id = unnest_data.operator_id
+          AND cc.operator_journey_id = unnest_data.operator_journey_id
+          AND cc.datetime >= '2024-03-01'::timestamp
+          AND cc.is_driver IS TRUE
+        ON CONFLICT (policy_id, operator_id, operator_journey_id)
+        DO UPDATE SET 
+          result = excluded.result,
+          amount = excluded.amount,
+          status = excluded.status,
+          state = excluded.state,
+          meta = excluded.meta;
       `,
       values,
     };

--- a/api/src/pdc/services/policy/providers/IncentiveRepositoryProvider.ts
+++ b/api/src/pdc/services/policy/providers/IncentiveRepositoryProvider.ts
@@ -278,8 +278,6 @@ export class IncentiveRepositoryProvider implements IncentiveRepositoryProviderI
       [[], [], [], [], [], [], [], [], []],
     );
 
-    console.table(values);
-
     const query = {
       text: `
         INSERT INTO ${this.table} (


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced error logging with additional details for incentive calculation failures.
  - Updated data structures and key identifiers in the Incentive Repository to improve data filtering and insertion processes.

- **Bug Fixes**
  - Removed unnecessary parameters in the creation of `Incentive` instances, simplifying the process.

- **Refactor**
  - Simplified object mappings by removing `carpool_id` across various modules, aligning with updated data handling standards.
  - Modified indexes in the `policy.incentives` table to improve database performance and uniqueness of data entries.

- **Tests**
  - Adjusted test cases to reflect changes in data structures, removing deprecated fields like `_id` and `carpool_id`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->