### PR TITLE
check whether the identity_key is null on the carpool

### DIFF
--- a/api/src/pdc/services/policy/engine/helpers/limits.ts
+++ b/api/src/pdc/services/policy/engine/helpers/limits.ts
@@ -22,6 +22,12 @@ interface LimitStatelessStageHelper {
 
 function getTargetUuid(target: LimitTargetEnum, ctx: StatelessContextInterface): string {
   const uuid = target === LimitTargetEnum.Driver ? ctx.carpool.driver_identity_key : ctx.carpool.passenger_identity_key;
+
+  if (uuid === null || typeof uuid === 'undefined') {
+    const targetName = target === LimitTargetEnum.Driver ? 'driver_identity_key' : 'passenger_identity_key';
+    throw new Error(`[getTargetUuid] Missing ${targetName} to build the limit key.`);
+  }
+
   return `${target.toString()}-${uuid}`;
 }
 


### PR DESCRIPTION
Vérification de la valeur de `driver_identity_key` ou `passenger_identity_key` lors de la création de la clé des limites pour le calcul des campagnes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling in the policy engine to ensure better feedback when a required key is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->