### PR TITLE
Fixes sur les campagnes

### DIFF
--- a/api/src/pdc/services/policy/engine/policies/GrandPoitiers.ts
+++ b/api/src/pdc/services/policy/engine/policies/GrandPoitiers.ts
@@ -22,6 +22,8 @@ import { AbstractPolicyHandler } from './AbstractPolicyHandler';
 import { description } from './GrandPoitiers.html';
 
 // Politique Grands poitiers
+// territory_id: 323
+// aom: 200069854
 export const GrandPoitiers: PolicyHandlerStaticInterface = class
   extends AbstractPolicyHandler
   implements PolicyHandlerInterface

--- a/api/src/pdc/services/policy/engine/policies/GrandPoitiers.ts
+++ b/api/src/pdc/services/policy/engine/policies/GrandPoitiers.ts
@@ -61,7 +61,7 @@ export const GrandPoitiers: PolicyHandlerStaticInterface = class
   protected slices: RunnableSlices = [
     {
       start: 5_000,
-      end: 79_999,
+      end: 80_000,
       fn: (ctx: StatelessContextInterface) => perSeat(ctx, 150),
     },
   ];

--- a/api/src/pdc/services/policy/engine/policies/PaysDeLaLoire2024.html.ts
+++ b/api/src/pdc/services/policy/engine/policies/PaysDeLaLoire2024.html.ts
@@ -1,7 +1,7 @@
 export const description = `<div _ngcontent-fyn-c231="" id="summary" class="campaignSummaryText-content-text">
 
   <p>Campagne d'incitation au covoiturage du <b> 01 janvier 2024 au 31 Décembre 2025</b></p>
-  
+
   <p>Cette campagne est limitée à <b>4 400 000 euros </b>.</p>
 
   <p>
@@ -10,21 +10,21 @@ export const description = `<div _ngcontent-fyn-c231="" id="summary" class="camp
   </p>
 
   <ul>
-    <li><b>De 5 à 17 km : 0.75 euro par trajet par passager.</b></li>
-    <li><b>De 17 à 30 km : 0.1 euro par trajet par km par passager avec un maximum de 2 euros</b></li>  
+    <li><b>De 5 à 17 km : 0,75 € par trajet par passager.</b></li>
+    <li><b>De 17 à 30 km : 0,10 € par trajet par km par passager avec un maximum de 2,00 €</b></li>
   </ul>
-  
+
   <p>Les restrictions suivantes seront appliquées :</p>
-  
+
   <ul>
     <li><b>6 trajets maximum pour le conducteur par jour.</b></li>
-    <li><b>84€ maximum pour le conducteur par mois.</b></li>
+    <li><b>84,00 € maximum pour le conducteur par mois.</b></li>
   </ul>
-  
+
   <p>La campagne est éligible à tous les opérateurs du RPC proposant des preuves de classe <b>C</b>.</p>
-  
+
   <p>Les trajets au départ et à l'arrivée des AOMs suivantes ne sont pas incités : </p>
-  
+
   <ul>
     <li><b>Nantes Métropole (244400404)</b></li>
     <li><b>CU d'Angers Loire Métropole (244900015)</b></li>

--- a/api/src/pdc/services/policy/engine/policies/PaysDeLaLoire2024.spec.ts
+++ b/api/src/pdc/services/policy/engine/policies/PaysDeLaLoire2024.spec.ts
@@ -45,35 +45,66 @@ const defaultCarpool = {
 const process = makeProcessHelper(defaultCarpool);
 
 test(
-  'should work with exclusion',
+  'should work with regular exclusions',
   process,
   {
     policy: { handler: Handler.id },
     carpool: [
       { distance: 4999 },
       { operator_class: 'A' },
-
-      // Nantes Métropole (244400404)
-      { start: { ...defaultPosition, aom: '244400404' }, end: { ...defaultPosition, aom: '244400404' } },
-
-      // Angers (244900015)
-      { start: { ...defaultPosition, aom: '244900015' }, end: { ...defaultPosition, aom: '244900015' } },
-
-      // Le Mans (247200132)
-      { start: { ...defaultPosition, aom: '247200132' }, end: { ...defaultPosition, aom: '247200132' } },
-
-      // CA Agglomération du Choletais (200071678)
-      { start: { ...defaultPosition, aom: '200071678' }, end: { ...defaultPosition, aom: '200071678' } },
-
-      // Région Île-de-France
       { start: { ...defaultPosition, reg: '11' } },
       { end: { ...defaultPosition, reg: '11' } },
       { distance: 60_001 },
       { passenger_is_over_18: false },
     ],
-    meta: [],
   },
-  { incentive: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0], meta: [] },
+  { incentive: [0, 0, 0, 0, 0, 0] },
+);
+
+test(
+  'should work with AOM exclusions',
+  process,
+  {
+    policy: { handler: Handler.id },
+    carpool: [
+      // Nantes Métropole (244400404)
+      {
+        driver_identity_key: 'nantes',
+        start: { ...defaultPosition, aom: '244400404' },
+        end: { ...defaultPosition, aom: '244400404' },
+      },
+      { driver_identity_key: 'nantes', start: { ...defaultPosition, aom: '244400404' }, end: { ...defaultPosition } },
+      { driver_identity_key: 'nantes', start: { ...defaultPosition }, end: { ...defaultPosition, aom: '244400404' } },
+
+      // Angers (244900015)
+      {
+        driver_identity_key: 'angers',
+        start: { ...defaultPosition, aom: '244900015' },
+        end: { ...defaultPosition, aom: '244900015' },
+      },
+      { driver_identity_key: 'angers', start: { ...defaultPosition, aom: '244900015' }, end: { ...defaultPosition } },
+      { driver_identity_key: 'angers', start: { ...defaultPosition }, end: { ...defaultPosition, aom: '244900015' } },
+
+      // Le Mans (247200132)
+      {
+        driver_identity_key: 'le_mans',
+        start: { ...defaultPosition, aom: '247200132' },
+        end: { ...defaultPosition, aom: '247200132' },
+      },
+      { driver_identity_key: 'le_mans', start: { ...defaultPosition, aom: '247200132' }, end: { ...defaultPosition } },
+      { driver_identity_key: 'le_mans', start: { ...defaultPosition }, end: { ...defaultPosition, aom: '247200132' } },
+
+      // CA Agglomération du Choletais (200071678)
+      {
+        driver_identity_key: 'cholet',
+        start: { ...defaultPosition, aom: '200071678' },
+        end: { ...defaultPosition, aom: '200071678' },
+      },
+      { driver_identity_key: 'cholet', start: { ...defaultPosition, aom: '200071678' }, end: { ...defaultPosition } },
+      { driver_identity_key: 'cholet', start: { ...defaultPosition }, end: { ...defaultPosition, aom: '200071678' } },
+    ],
+  },
+  { incentive: [0, 75, 75, 0, 75, 75, 0, 75, 75, 0, 75, 75] },
 );
 
 test(

--- a/api/src/pdc/services/policy/engine/policies/PaysDeLaLoire2024.ts
+++ b/api/src/pdc/services/policy/engine/policies/PaysDeLaLoire2024.ts
@@ -67,8 +67,8 @@ export const PaysDeLaLoire2024: PolicyHandlerStaticInterface = class extends Abs
     /*
       Exclure les trajets :
        - 244400404: Nantes Métropole -> Nantes Métropole,
-       - 244900015: Angers -> Angers,
-       - 247200132: Le Mans -> Le Mans, 
+       - 244900015: CU Angers Loire Métropole -> CU Angers Loire Métropole,
+       - 247200132: CU Le Mans Métropole -> CU Le Mans Métropole,
        - 200071678: CA Agglomération du Choletais -> CA Agglomération du Choletais
      */
     if (

--- a/api/src/pdc/services/policy/engine/policies/SMTC2024.ts
+++ b/api/src/pdc/services/policy/engine/policies/SMTC2024.ts
@@ -21,6 +21,7 @@ import { AbstractPolicyHandler } from './AbstractPolicyHandler';
 import { description } from './SMTC2024.html';
 
 // Politique Syndicat Mixte des Transports en Commun de l’Agglomération Clermontoise (SMTC)
+// aom = 256300120
 export const SMTC2024: PolicyHandlerStaticInterface = class
   extends AbstractPolicyHandler
   implements PolicyHandlerInterface


### PR DESCRIPTION
Quelques fixes sur les campagnes SMTC et PDLL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated currency formatting to use commas for euros in the PaysDeLaLoire2024 policy.

- **Bug Fixes**
  - Adjusted end value in GrandPoitiers policy for correct slice range.
  - Updated names of locations in the exclusion list for PaysDeLaLoire2024 policy.

- **Tests**
  - Added tests for AOM exclusions for specific regions in PaysDeLaLoire2024 policy.

- **Documentation**
  - Added comments for territory_id and aom in GrandPoitiers and SMTC2024 policies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->