### PR TITLE
Ajout de la campagne SMTC passager

### DIFF
--- a/api/src/pdc/services/policy/engine/helpers/per.ts
+++ b/api/src/pdc/services/policy/engine/helpers/per.ts
@@ -15,6 +15,25 @@ export interface PerKmParams {
   limit?: number;
 }
 
+/**
+ * Multiply the carpool distance by the amount
+ *
+ * @example
+ * // 0,10 € per km
+ * perKm(ctx, { amount: 10 })
+ *
+ * @example
+ * // 0,10 € per km, but limit to 30 km
+ * perKm(ctx, { amount: 10, limit: 30_000 })
+ *
+ * @example
+ * // 0,10 € per km, but start at 5 km
+ * perKm(ctx, { amount: 10, offset: 5_000 })
+ *
+ * @param {StatelessContextInterface} ctx
+ * @param {PerKmParams} params
+ * @returns {number}
+ */
 export const perKm = (ctx: StatelessContextInterface, params: PerKmParams): number => {
   let { distance } = ctx.carpool;
 
@@ -33,6 +52,17 @@ export const perKm = (ctx: StatelessContextInterface, params: PerKmParams): numb
   return (distance / 1000) * params.amount;
 };
 
+/**
+ * Multiply the amount by the number of seats booked by the passenger
+ *
+ * @example
+ * // 0,10 € per seat
+ * perSeat(ctx, 10)
+ *
+ * @param {StatelessContextInterface} ctx
+ * @param {number} amount
+ * @returns {number}
+ */
 export const perSeat = (ctx: StatelessContextInterface, amount: number): number => {
   return (ctx.carpool.seats || 1) * amount;
 };

--- a/api/src/pdc/services/policy/engine/policies/SMTC2024.html.ts
+++ b/api/src/pdc/services/policy/engine/policies/SMTC2024.html.ts
@@ -5,7 +5,7 @@ export const description = `<p _ngcontent-pmm-c231="" id="summary" class="campai
 </p>
 
 <p>
-  Cette campagne est limitée à <b>30 000 €</b>.
+  Cette campagne est limitée à <b>15 000 €</b>.
 </p>
 
 <p>

--- a/api/src/pdc/services/policy/engine/policies/SMTC2024.ts
+++ b/api/src/pdc/services/policy/engine/policies/SMTC2024.ts
@@ -26,7 +26,7 @@ export const SMTC2024: PolicyHandlerStaticInterface = class
   extends AbstractPolicyHandler
   implements PolicyHandlerInterface
 {
-  static readonly id = 'smtc_2024';
+  static readonly id = 'smtc_2024_driver';
   protected operators = [OperatorsEnum.MOV_ICI];
   protected operator_class = ['B', 'C'];
 

--- a/api/src/pdc/services/policy/engine/policies/SMTC2024Passenger.html.ts
+++ b/api/src/pdc/services/policy/engine/policies/SMTC2024Passenger.html.ts
@@ -1,0 +1,39 @@
+export const description = `<p _ngcontent-pmm-c231="" id="summary" class="campaignSummaryText-content-text">
+
+<p>
+  Campagne d’incitation au covoiturage du <b>01 janvier 2024 au 31 décembre 2025</b>
+</p>
+
+<p>
+  Cette campagne est limitée à <b>15 000,00 €</b>.
+</p>
+
+<p>
+  Le périmètre géographique de la campagne comprend les zones suivantes
+</p>
+
+<ul>
+  <li>Syndicat Mixte des Transports en Commun de l’Agglomération Clermontoise (SMTC)</li>
+</ul>
+
+<p>
+  Les <b> passagers </b> effectuant un trajet entre 5 km et 30 km,
+  avec pour origine OU destination le périmètre ci-dessus,
+  sont incités selon les règles suivantes :
+</p>
+
+<ul>
+  <li><b>De 5 à 30 km : 0,10 € par kilomètre</b></li>
+</ul>
+
+<p>Les restrictions suivantes seront appliquées :</p>
+
+<ul>
+  <li><b>2 trajets par jour maximum.</b></li>
+</ul>
+
+<p>
+  La campagne est limitée aux opérateurs <b>Mov'ici</b>
+  proposant des preuves de classe <b>B ou C</b>.
+</p>
+`;

--- a/api/src/pdc/services/policy/engine/policies/SMTC2024Passenger.spec.ts
+++ b/api/src/pdc/services/policy/engine/policies/SMTC2024Passenger.spec.ts
@@ -1,0 +1,101 @@
+import test from 'ava';
+import { v4 } from 'uuid';
+import { OperatorsEnum } from '../../interfaces';
+import { makeProcessHelper } from '../tests/macro';
+import { SMTC2024Passenger as Handler } from './SMTC2024Passenger';
+
+const defaultPosition = {
+  arr: '74278',
+  com: '74278',
+  aom: '200033116',
+  epci: '200033116',
+  dep: '74',
+  reg: '84',
+  country: 'XXXXX',
+  reseau: '142',
+};
+const defaultLat = 48.72565703413325;
+const defaultLon = 2.261827843187402;
+
+const defaultCarpool = {
+  _id: 1,
+  operator_trip_id: v4(),
+  passenger_identity_key: v4(),
+  driver_identity_key: v4(),
+  operator_uuid: OperatorsEnum.MOV_ICI,
+  operator_class: 'C',
+  passenger_is_over_18: true,
+  passenger_has_travel_pass: true,
+  driver_has_travel_pass: true,
+  datetime: new Date('2024-05-15'),
+  seats: 1,
+  distance: 5_000,
+  operator_journey_id: v4(),
+  operator_id: 1,
+  driver_revenue: 20,
+  passenger_contribution: 20,
+  start: { ...defaultPosition },
+  end: { ...defaultPosition },
+  start_lat: defaultLat,
+  start_lon: defaultLon,
+  end_lat: defaultLat,
+  end_lon: defaultLon,
+};
+
+const process = makeProcessHelper(defaultCarpool);
+
+test(
+  'should work with exclusion',
+  process,
+  {
+    policy: { handler: Handler.id },
+    carpool: [
+      { operator_uuid: OperatorsEnum.MOBICOOP },
+      { distance: 100 },
+      { distance: 30_001 },
+      { operator_class: 'A' },
+    ],
+    meta: [],
+  },
+  { incentive: [0, 0, 0, 0], meta: [] },
+);
+
+test(
+  'should work based on distance and seats',
+  process,
+  {
+    policy: { handler: Handler.id },
+    carpool: [
+      { distance: 5_000, passenger_identity_key: 'one' },
+      { distance: 5_000, seats: 2, passenger_identity_key: 'one' },
+      { distance: 30_000, passenger_identity_key: 'two' },
+    ],
+    meta: [],
+  },
+  {
+    incentive: [50, 100, 300],
+    meta: [
+      {
+        key: 'max_amount_restriction.global.campaign.global',
+        value: 450,
+      },
+    ],
+  },
+);
+
+test(
+  'should apply daily limits',
+  process,
+  {
+    policy: { handler: Handler.id },
+    carpool: [
+      { distance: 5_000, passenger_identity_key: 'one' },
+      { distance: 5_000, passenger_identity_key: 'one' },
+      { distance: 5_000, passenger_identity_key: 'one' },
+      { distance: 5_000, passenger_identity_key: 'one' },
+    ],
+  },
+  {
+    incentive: [50, 50, 0, 0],
+  },
+);

--- a/api/src/pdc/services/policy/engine/policies/SMTC2024Passenger.ts
+++ b/api/src/pdc/services/policy/engine/policies/SMTC2024Passenger.ts
@@ -1,0 +1,84 @@
+import {
+  OperatorsEnum,
+  PolicyHandlerInterface,
+  PolicyHandlerParamsInterface,
+  PolicyHandlerStaticInterface,
+  StatelessContextInterface,
+} from '../../interfaces';
+import { RunnableSlices } from '../../interfaces/engine/PolicyInterface';
+import {
+  LimitTargetEnum,
+  isOperatorClassOrThrow,
+  isOperatorOrThrow,
+  onDistanceRange,
+  onDistanceRangeOrThrow,
+  perKm,
+  perSeat,
+  watchForGlobalMaxAmount,
+} from '../helpers';
+import { watchForPersonMaxTripByDay } from '../helpers/limits';
+import { AbstractPolicyHandler } from './AbstractPolicyHandler';
+import { description } from './SMTC2024Passenger.html';
+
+// Politique Syndicat Mixte des Transports en Commun de l’Agglomération Clermontoise (SMTC)
+// aom = 256300120
+export const SMTC2024Passenger: PolicyHandlerStaticInterface = class
+  extends AbstractPolicyHandler
+  implements PolicyHandlerInterface
+{
+  static readonly id = 'smtc_2024_passenger';
+  protected operators = [OperatorsEnum.MOV_ICI];
+  protected operator_class = ['B', 'C'];
+
+  constructor(public max_amount: number) {
+    super();
+    this.limits = [
+      ['be9c45cf-5e07-4c37-b8bf-59601e3607f7', 2, watchForPersonMaxTripByDay, LimitTargetEnum.Passenger],
+      ['4a17073a-e8d7-40ba-bcc2-26d126b41ca4', this.max_amount, watchForGlobalMaxAmount],
+    ];
+  }
+
+  protected slices: RunnableSlices = [
+    {
+      start: 5_000,
+      end: 30_001,
+      fn: (ctx: StatelessContextInterface) => perSeat(ctx, perKm(ctx, { amount: 10 })),
+    },
+  ];
+
+  protected processExclusion(ctx: StatelessContextInterface) {
+    isOperatorOrThrow(ctx, this.operators);
+    onDistanceRangeOrThrow(ctx, { min: 5_000, max: 30_001 });
+    isOperatorClassOrThrow(ctx, this.operator_class);
+  }
+
+  processStateless(ctx: StatelessContextInterface): void {
+    this.processExclusion(ctx);
+    super.processStateless(ctx);
+
+    // Par kilomètre
+    let amount = 0;
+    for (const { start, fn } of this.slices) {
+      if (onDistanceRange(ctx, { min: start })) {
+        amount += fn(ctx);
+      }
+    }
+
+    ctx.incentive.set(amount);
+  }
+
+  params(): PolicyHandlerParamsInterface {
+    return {
+      tz: 'Europe/Paris',
+      slices: this.slices,
+      operators: this.operators,
+      limits: {
+        glob: this.max_amount,
+      },
+    };
+  }
+
+  describe(): string {
+    return description;
+  }
+};

--- a/api/src/pdc/services/policy/engine/policies/index.ts
+++ b/api/src/pdc/services/policy/engine/policies/index.ts
@@ -27,6 +27,7 @@ import { PmgfLate2023 } from './PmgfLate2023';
 import { SMT2022 } from './SMT2022';
 import { SMT2023 } from './SMT2023';
 import { SMTC2024 } from './SMTC2024';
+import { SMTC2024Passenger } from './SMTC2024Passenger';
 import { TerresTouloises2024 } from './TerresTouloises2024';
 import { Vitre2023 } from './Vitre2023';
 import { PolicyTemplateOne } from './unbound/PolicyTemplateOne';
@@ -69,6 +70,7 @@ export const policies: Map<string, PolicyHandlerStaticInterface> = new Map(
     SMT2022,
     SMT2023,
     SMTC2024,
+    SMTC2024Passenger,
     TerresTouloises2024,
     Vitre2023,
   ].map((h) => [h.id, h]),


### PR DESCRIPTION
La campagne SMTC 2024 est appliquée aux conducteurs
La campagne SMTC 2024 (passager) est ajoutée pour inciter les  km parcourus par les passagers.

Séparation de l'enveloppe SMTC en 2 (50/50).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new policy handler `SMTC2024Passenger` for carpooling incentives, detailing specific rules and limitations.
  - Added test cases for the new `SMTC2024Passenger` policy handler to validate carpooling data.

- **Updates**
  - Updated the campaign limit in `SMTC2024` from €30,000 to €15,000.
  - Changed the `id` of the `SMTC2024` policy to `smtc_2024_driver`.

- **Documentation**
  - Added documentation and examples for `perKm` and `perSeat` functions, clarifying their usage and parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->