### PR TITLE
fix(campaign): remove klaxit from PDLL 2024

### DIFF
--- a/api/src/pdc/services/policy/engine/policies/20240101_PaysDeLaLoire.spec.ts
+++ b/api/src/pdc/services/policy/engine/policies/20240101_PaysDeLaLoire.spec.ts
@@ -3,6 +3,8 @@ import { v4 } from 'uuid';
 import { OperatorsEnum } from '../../interfaces';
 import { makeProcessHelper } from '../tests/macro';
 import { PaysDeLaLoire2024 as Handler } from './20240101_PaysDeLaLoire';
+import { operator } from '../../../user/config/permissions';
+import { date } from '../../../trip/config/middlewares';
 
 const defaultPosition = {
   arr: '85047',
@@ -59,6 +61,19 @@ test(
     ],
   },
   { incentive: [0, 0, 0, 0, 0, 0] },
+);
+
+test(
+  'Klaxit removed on 2024-03-18',
+  process,
+  {
+    policy: { handler: Handler.id },
+    carpool: [
+      { operator_uuid: OperatorsEnum.KLAXIT, datetime: new Date('2024-03-17T23:00:00+0100') },
+      { operator_uuid: OperatorsEnum.KLAXIT, datetime: new Date('2024-03-18T10:00:00+0100') },
+    ],
+  },
+  { incentive: [75, 0] },
 );
 
 test(

--- a/api/src/pdc/services/policy/engine/policies/20240101_PaysDeLaLoire.spec.ts
+++ b/api/src/pdc/services/policy/engine/policies/20240101_PaysDeLaLoire.spec.ts
@@ -3,8 +3,6 @@ import { v4 } from 'uuid';
 import { OperatorsEnum } from '../../interfaces';
 import { makeProcessHelper } from '../tests/macro';
 import { PaysDeLaLoire2024 as Handler } from './20240101_PaysDeLaLoire';
-import { operator } from '../../../user/config/permissions';
-import { date } from '../../../trip/config/middlewares';
 
 const defaultPosition = {
   arr: '85047',

--- a/api/src/pdc/services/policy/engine/policies/20240101_PaysDeLaLoire.ts
+++ b/api/src/pdc/services/policy/engine/policies/20240101_PaysDeLaLoire.ts
@@ -37,6 +37,10 @@ export const PaysDeLaLoire2024: PolicyHandlerStaticInterface = class extends Abs
       date: new Date('2024-01-01T00:00:00+0100'),
       operators: [OperatorsEnum.BLABLACAR_DAILY, OperatorsEnum.KAROS, OperatorsEnum.KLAXIT, OperatorsEnum.MOBICOOP],
     },
+    {
+      date: new Date('2024-03-18T00:00:00+0100'),
+      operators: [OperatorsEnum.BLABLACAR_DAILY, OperatorsEnum.KAROS, OperatorsEnum.MOBICOOP],
+    },
   ];
 
   protected slices: RunnableSlices = [


### PR DESCRIPTION
Suppression de l'opérateur Klaxit au 18 mars 2024 de la campagne PDLL2024

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated policy for PaysDeLaLoire effective from March 18, 2024, affecting carpool operators and incentives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->