### PR TITLE
Amélioration des helpers kernel et db pour les TI

### DIFF
--- a/api/src/pdc/providers/test/dbMacro.ts
+++ b/api/src/pdc/providers/test/dbMacro.ts
@@ -16,6 +16,28 @@ export interface DbBeforeAfter {
   after(cfg: DbContext): Promise<void>;
 }
 
+/**
+ * Export helpers to create a clean up a test database before and after tests
+ *
+ * You can pass a connectionString in the config to override the default
+ * APP_POSTGRES_URL environment variable.
+ *
+ * @example
+ * import { DbContext, makeDbBeforeAfter } from "@/pdc/providers/test/dbMacro.ts";
+ *
+ * const { before, after } = makeDbBeforeAfter();
+ * let db: DbContext;
+ *
+ * beforeAll(async () => {
+ *    db = await before();
+ * });
+ * afterAll(async () => {
+ *   await after(db);
+ * });
+ *
+ * @param {Config} cfg
+ * @returns
+ */
 export function makeDbBeforeAfter(cfg?: Config): DbBeforeAfter {
   return {
     before: async (): Promise<DbContext> => {

--- a/api/src/pdc/providers/test/handlerMacro.ts
+++ b/api/src/pdc/providers/test/handlerMacro.ts
@@ -21,7 +21,7 @@ export async function assertHandler<P = unknown, R = unknown>(
   currentContext: ContextType = {} as ContextType,
   handlerConfig: HandlerConfigInterface,
   params: P,
-  callback: (result: R) => Promise<void>,
+  callback: (result: R) => void | Promise<void>,
 ) {
   const callContext = { ...emptyContext, ...currentContext };
   const result = await context.kernel.call<P, R>(

--- a/api/src/pdc/services/export/actions/CreateAction.integration.spec.ts
+++ b/api/src/pdc/services/export/actions/CreateAction.integration.spec.ts
@@ -1,0 +1,116 @@
+/**
+ * Test the CreateActionV2 and CreateActionV3 classes with proper payloads
+ * Middlewares:
+ * - permission
+ * - castToArray ?
+ * - timezone
+ * - copyFromContext(created_by, operator_id, territory_id)
+ * - payload Validation
+ *
+ * Features:
+ * - recipients
+ * - creator as recipient
+ * - store: check response
+ * - store: check existence in DB
+ */
+import { afterAll, assertEquals, beforeAll, describe, it } from "@/dev_deps.ts";
+import { ContextType } from "@/ilos/common/index.ts";
+import { PostgresConnection } from "@/ilos/connection-postgres/index.ts";
+import {
+  AJVParamsInterface,
+  assertHandler,
+  DbContext,
+  KernelContext,
+  makeDbBeforeAfter,
+  makeKernelBeforeAfter,
+} from "@/pdc/providers/test/index.ts";
+import { ServiceProvider as ExportSP } from "@/pdc/services/export/ServiceProvider.ts";
+import {
+  ExportStatus,
+  ExportTarget,
+} from "@/pdc/services/export/models/Export.ts";
+import { ServiceProvider as UserSP } from "@/pdc/services/user/ServiceProvider.ts";
+import {
+  handlerConfigV3,
+  ParamsInterfaceV3,
+  ResultInterfaceV3,
+} from "@/shared/export/create.contract.ts";
+
+const { before: kernelBefore, after: kernelAfter } = makeKernelBeforeAfter(
+  UserSP,
+  ExportSP,
+);
+const { before: dbBefore, after: dbAfter } = makeDbBeforeAfter();
+
+describe("CreateAction V3", () => {
+  let db: DbContext;
+  let kc: KernelContext;
+
+  const defaultContext: ContextType = {
+    call: { user: { permissions: ["common.export.create"] } },
+    channel: { service: "proxy" },
+  };
+
+  /**
+   * - boot up postgresql connection
+   * - create the kernel
+   * - stop the existing kernel connection to replace it with the test one
+   */
+  beforeAll(async () => {
+    db = await dbBefore();
+    kc = await kernelBefore();
+    await kc.kernel.getContainer().get(PostgresConnection).down();
+    kc.kernel
+      .getContainer()
+      .rebind(PostgresConnection)
+      .toConstantValue(db.connection);
+  });
+
+  afterAll(async () => {
+    await kernelAfter(kc);
+    await dbAfter(db);
+  });
+
+  it("should create an export with a creator as recipient", async () => {
+    const start_at = "2024-01-01T00:00:00+0100";
+    const end_at = "2024-01-02T00:00:00+0100";
+
+    const params: AJVParamsInterface<
+      ParamsInterfaceV3,
+      "start_at" | "end_at"
+    > = {
+      tz: "Europe/Paris",
+      start_at,
+      end_at,
+      created_by: 1,
+      operator_id: [1],
+    };
+
+    // UUID is omitted as we have no way to predict it
+    const expected: Omit<ResultInterfaceV3, "uuid"> = {
+      // uuid: "uuid",
+      target: ExportTarget.OPENDATA,
+      status: ExportStatus.PENDING,
+      start_at: new Date(start_at),
+      end_at: new Date(end_at),
+    };
+
+    await assertHandler(
+      kc,
+      defaultContext,
+      handlerConfigV3,
+      params,
+      (response: ResultInterfaceV3) => {
+        const { uuid: _uuid, ...actual } = response;
+        assertEquals(actual, expected);
+      },
+    );
+  });
+
+  it("should create an export with multiple recipients", () => {});
+  it("should create a default export (opendata)", () => {});
+  it("should create a territory export", () => {});
+  it("should create an operator export", () => {});
+});
+
+describe("CreateAction V2", () => {});

--- a/api/src/pdc/services/export/actions/CreateActionV3.ts
+++ b/api/src/pdc/services/export/actions/CreateActionV3.ts
@@ -93,8 +93,8 @@ export class CreateActionV3 extends AbstractAction {
       uuid,
       target,
       status,
-      start_at: createParams.get().start_at,
-      end_at: createParams.get().end_at,
+      start_at: new Date(createParams.get().start_at),
+      end_at: new Date(createParams.get().end_at),
     };
   }
 }

--- a/api/src/pdc/services/export/actions/CreateActionV3.ts
+++ b/api/src/pdc/services/export/actions/CreateActionV3.ts
@@ -5,10 +5,19 @@ import {
 } from "@/ilos/common/index.ts";
 import { Action as AbstractAction } from "@/ilos/core/index.ts";
 import {
+  castToArrayMiddleware,
+  copyFromContextMiddleware,
+  hasPermissionMiddleware,
+  validateDateMiddleware,
+} from "@/pdc/providers/middleware/middlewares.ts";
+import { DefaultTimezoneMiddleware } from "@/pdc/services/export/middlewares/DefaultTimezoneMiddleware.ts";
+import {
   handlerConfigV3,
   ParamsInterfaceV3,
   ResultInterfaceV3,
 } from "@/shared/export/create.contract.ts";
+import { aliasV3 } from "@/shared/export/create.schema.ts";
+import { maxEndDefault, minStartDefault } from "../config/export.ts";
 import { Export } from "../models/Export.ts";
 import { ExportParams } from "../models/ExportParams.ts";
 import { ExportRecipient } from "../models/ExportRecipient.ts";
@@ -19,19 +28,19 @@ import { TerritoryServiceInterfaceResolver } from "../services/TerritoryService.
 @handler({
   ...handlerConfigV3,
   middlewares: [
-    // hasPermissionMiddleware("common.export.create"),
-    // castToArrayMiddleware(["operator_id", "territory_id", "recipients"]),
-    // ["timezone", DefaultTimezoneMiddleware],
-    // copyFromContextMiddleware(`call.user._id`, "created_by", true),
-    // copyFromContextMiddleware(`call.user.operator_id`, "operator_id", true),
-    // copyFromContextMiddleware(`call.user.territory_id`, "territory_id", true),
-    // validateDateMiddleware({
-    //   startPath: "start_at",
-    //   endPath: "end_at",
-    //   minStart: () => new Date(new Date().getTime() - minStartDefault),
-    //   maxEnd: () => new Date(new Date().getTime() - maxEndDefault),
-    // }),
-    // ["validate", aliasV3],
+    hasPermissionMiddleware("common.export.create"),
+    castToArrayMiddleware(["operator_id", "territory_id", "recipients"]),
+    ["timezone", DefaultTimezoneMiddleware],
+    copyFromContextMiddleware(`call.user._id`, "created_by", true),
+    copyFromContextMiddleware(`call.user.operator_id`, "operator_id", true),
+    copyFromContextMiddleware(`call.user.territory_id`, "territory_id", true),
+    validateDateMiddleware({
+      startPath: "start_at",
+      endPath: "end_at",
+      minStart: () => new Date(new Date().getTime() - minStartDefault),
+      maxEnd: () => new Date(new Date().getTime() - maxEndDefault),
+    }),
+    ["validate", aliasV3],
   ],
 })
 export class CreateActionV3 extends AbstractAction {

--- a/api/src/pdc/services/export/middlewares/ScopeToGroupMiddleware.integration.spec.ts
+++ b/api/src/pdc/services/export/middlewares/ScopeToGroupMiddleware.integration.spec.ts
@@ -8,6 +8,7 @@ import {
 } from "@/dev_deps.ts";
 import { ContextType, ForbiddenException } from "@/ilos/common/index.ts";
 import { PostgresConnection } from "@/ilos/connection-postgres/index.ts";
+import { TerritorySelectorsInterface } from "@/shared/territory/common/interfaces/TerritoryCodeInterface.ts";
 import { ScopeToGroupMiddleware } from "./ScopeToGroupMiddleware.ts";
 
 describe("ScopeToGroupMiddleware", () => {
@@ -97,7 +98,8 @@ describe("ScopeToGroupMiddleware", () => {
         territory_id: 1,
         authorizedZoneCodes: geo_selector,
       }),
-      (params: any) => params.geo_selector,
+      (params: { geo_selector: TerritorySelectorsInterface }) =>
+        params.geo_selector,
       middlewareConfig,
     );
     assertEquals(result, { com: geo_selector.com });
@@ -111,7 +113,8 @@ describe("ScopeToGroupMiddleware", () => {
         territory_id: 1,
         authorizedZoneCodes: geo_selector,
       }),
-      (params: any) => params.geo_selector,
+      (params: { geo_selector: TerritorySelectorsInterface }) =>
+        params.geo_selector,
       middlewareConfig,
     );
     assertEquals(result, { com: geo_selector.com });
@@ -170,7 +173,7 @@ describe("ScopeToGroupMiddleware", () => {
         permissions: ["operator.trip.list"],
         operator_id: 2,
       }),
-      (params: any) => params.operator_id,
+      (params: { operator_id: number }) => params.operator_id,
       middlewareConfig,
     );
 

--- a/shared/export/create.schema.ts
+++ b/shared/export/create.schema.ts
@@ -1,35 +1,35 @@
-import { territoryCodeSchema } from '../territory/common/schema';
+import { territoryCodeSchema } from "../territory/common/schema";
 
 export const schemaV2 = {
-  type: 'object',
+  type: "object",
   additionalProperties: false,
-  required: ['date'],
+  required: ["date"],
   properties: {
     tz: {
-      macro: 'tz',
+      macro: "tz",
     },
     date: {
-      type: 'object',
+      type: "object",
       additionalProperties: false,
-      required: ['start', 'end'],
+      required: ["start", "end"],
       properties: {
         start: {
-          macro: 'timestamp',
+          macro: "timestamp",
         },
         end: {
-          macro: 'timestamp',
+          macro: "timestamp",
         },
       },
     },
     operator_id: {
       oneOf: [
         {
-          type: 'array',
+          type: "array",
           minItems: 1,
-          items: { macro: 'serial' },
+          items: { macro: "serial" },
         },
         {
-          macro: 'serial',
+          macro: "serial",
         },
       ],
     },
@@ -38,42 +38,42 @@ export const schemaV2 = {
 };
 
 export const schemaV3 = {
-  type: 'object',
+  type: "object",
   additionalProperties: false,
-  required: ['tz', 'start_at', 'end_at', 'operator_id'],
+  required: ["tz", "start_at", "end_at", "operator_id"],
   properties: {
     tz: {
-      macro: 'tz',
+      macro: "tz",
     },
     start_at: {
-      macro: 'timestamp',
+      macro: "timestamp",
     },
     end_at: {
-      macro: 'timestamp',
+      macro: "timestamp",
     },
     created_by: {
-      macro: 'serial',
+      macro: "serial",
     },
     operator_id: {
-      type: 'array',
+      type: "array",
       minItems: 0,
-      items: { macro: 'serial' },
+      items: { macro: "serial" },
     },
     territory_id: {
-      type: 'array',
+      type: "array",
       minItems: 0,
-      items: { macro: 'serial' },
+      items: { macro: "serial" },
     },
     recipients: {
-      type: 'array',
+      type: "array",
       minItems: 0,
-      items: { macro: 'varchar' },
+      items: { macro: "varchar" },
     },
     geo_selector: territoryCodeSchema,
   },
 };
 
-export const aliasV2 = 'export.create.v2';
-export const aliasV3 = 'export.create.v3';
+export const aliasV2 = "export.create.v2";
+export const aliasV3 = "export.create.v3";
 export const bindingV2 = [aliasV2, schemaV2];
 export const bindingV3 = [aliasV3, schemaV3];


### PR DESCRIPTION
- [x] ajout de jsdoc
- [ ] ajout de la possibilité de passer plusieurs ServiceProviders au helper.

:warning: l'API de sortie du helper `before` a été modifiée : `service -> services`. La propriété n'était pas utilisée.
