### PR TITLE
Hotfix/response

### DIFF
--- a/api/deno.lock
+++ b/api/deno.lock
@@ -3,7 +3,7 @@
   "packages": {
     "specifiers": {
       "npm:@faker-js/faker@^8.4": "npm:@faker-js/faker@8.4.1",
-      "npm:@sentry/node@^8.2": "npm:@sentry/node@8.10.0_@opentelemetry+api@1.9.0_@opentelemetry+core@1.25.1__@opentelemetry+api@1.9.0_@opentelemetry+instrumentation@0.52.1__@opentelemetry+api@1.9.0_@opentelemetry+sdk-trace-base@1.25.1__@opentelemetry+api@1.9.0_@opentelemetry+semantic-conventions@1.25.1",
+      "npm:@sentry/node@^8.2": "npm:@sentry/node@8.13.0_@opentelemetry+api@1.9.0_@opentelemetry+core@1.25.1__@opentelemetry+api@1.9.0_@opentelemetry+instrumentation@0.52.1__@opentelemetry+api@1.9.0_@opentelemetry+sdk-trace-base@1.25.1__@opentelemetry+api@1.9.0_@opentelemetry+semantic-conventions@1.25.1",
       "npm:@turf/boolean-point-in-polygon": "npm:@turf/boolean-point-in-polygon@7.0.0",
       "npm:@turf/distance": "npm:@turf/distance@7.0.0",
       "npm:@turf/helpers": "npm:@turf/helpers@7.0.0",
@@ -12,7 +12,7 @@
       "npm:@types/express-session@^1.18": "npm:@types/express-session@1.18.0",
       "npm:@types/jsonwebtoken@^9": "npm:@types/jsonwebtoken@9.0.6",
       "npm:@types/node-7z@^2": "npm:@types/node-7z@2.1.8",
-      "npm:@types/node@^20": "npm:@types/node@20.14.7",
+      "npm:@types/node@^20": "npm:@types/node@20.14.9",
       "npm:@types/nodemailer@^6.4": "npm:@types/nodemailer@6.4.15",
       "npm:@types/pg-cursor@^2.7": "npm:@types/pg-cursor@2.7.2",
       "npm:@types/pg@^8.11": "npm:@types/pg@8.11.6",
@@ -23,7 +23,7 @@
       "npm:ajv-formats@^3": "npm:ajv-formats@3.0.1_ajv@8.16.0",
       "npm:ajv-keywords@^5": "npm:ajv-keywords@5.1.0_ajv@8.16.0",
       "npm:ajv@^8.12": "npm:ajv@8.16.0",
-      "npm:axios-retry@^4": "npm:axios-retry@4.4.0_axios@1.7.2",
+      "npm:axios-retry@^4": "npm:axios-retry@4.4.1_axios@1.7.2",
       "npm:axios@^1.7": "npm:axios@1.7.2",
       "npm:body-parser@^1.20": "npm:body-parser@1.20.2",
       "npm:bullmq@^1.91": "npm:bullmq@1.91.1",
@@ -58,7 +58,7 @@
       "npm:pdf-lib@^1.17": "npm:pdf-lib@1.17.1",
       "npm:pg-cursor@^2.11": "npm:pg-cursor@2.11.0_pg@8.12.0",
       "npm:pg@^8.12": "npm:pg@8.12.0",
-      "npm:prom-client@^15.1": "npm:prom-client@15.1.2",
+      "npm:prom-client@^15.1": "npm:prom-client@15.1.3",
       "npm:rate-limit-redis@^4.2": "npm:rate-limit-redis@4.2.0_express-rate-limit@7.3.1__express@4.19.2_express@4.19.2",
       "npm:reflect-metadata@^0.2": "npm:reflect-metadata@0.2.2",
       "npm:sinon@^18": "npm:sinon@18.0.0",
@@ -143,18 +143,6 @@
         "integrity": "sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==",
         "dependencies": {}
       },
-      "@opentelemetry/api-logs@0.51.1": {
-        "integrity": "sha512-E3skn949Pk1z2XtXu/lxf6QAZpawuTM/IUEXcAzpiUkTd73Hmvw26FiN3cJuTmkpM5hZzHwkomVdtrh/n/zzwA==",
-        "dependencies": {
-          "@opentelemetry/api": "@opentelemetry/api@1.9.0"
-        }
-      },
-      "@opentelemetry/api-logs@0.52.0": {
-        "integrity": "sha512-HxjD7xH9iAE4OyhNaaSec65i1H6QZYBWSwWkowFfsc5YAcDvJG30/J1sRKXEQqdmUcKTXEAnA66UciqZha/4+Q==",
-        "dependencies": {
-          "@opentelemetry/api": "@opentelemetry/api@1.9.0"
-        }
-      },
       "@opentelemetry/api-logs@0.52.1": {
         "integrity": "sha512-qnSqB2DQ9TPP96dl8cDubDvrUyWc0/sK81xHTK8eSUspzDM3bsewX903qclQFvVhgStjRWdC5bLb3kQqMkfV5A==",
         "dependencies": {
@@ -169,13 +157,6 @@
         "integrity": "sha512-UW/ge9zjvAEmRWVapOP0qyCvPulWU6cQxGxDbWEFfGOj1VBBZAuOqTo3X6yWmDTD3Xe15ysCZChHncr2xFMIfQ==",
         "dependencies": {
           "@opentelemetry/api": "@opentelemetry/api@1.9.0"
-        }
-      },
-      "@opentelemetry/core@1.25.0_@opentelemetry+api@1.9.0": {
-        "integrity": "sha512-n0B3s8rrqGrasTgNkXLKXzN0fXo+6IYP7M5b7AMsrZM33f/y6DS6kJ0Btd7SespASWq8bgL3taLo0oe0vB52IQ==",
-        "dependencies": {
-          "@opentelemetry/api": "@opentelemetry/api@1.9.0",
-          "@opentelemetry/semantic-conventions": "@opentelemetry/semantic-conventions@1.25.0"
         }
       },
       "@opentelemetry/core@1.25.1_@opentelemetry+api@1.9.0": {
@@ -229,13 +210,13 @@
           "@opentelemetry/semantic-conventions": "@opentelemetry/semantic-conventions@1.25.1"
         }
       },
-      "@opentelemetry/instrumentation-http@0.52.0_@opentelemetry+api@1.9.0": {
-        "integrity": "sha512-E6ywZuxTa4LnVXZGwL1oj3e2Eog1yIaNqa8KjKXoGkDNKte9/SjQnePXOmhQYI0A9nf0UyFbP9aKd+yHrkJXUA==",
+      "@opentelemetry/instrumentation-http@0.52.1_@opentelemetry+api@1.9.0": {
+        "integrity": "sha512-dG/aevWhaP+7OLv4BQQSEKMJv8GyeOp3Wxl31NHqE8xo9/fYMfEljiZphUHIfyg4gnZ9swMyWjfOQs5GUQe54Q==",
         "dependencies": {
           "@opentelemetry/api": "@opentelemetry/api@1.9.0",
-          "@opentelemetry/core": "@opentelemetry/core@1.25.0_@opentelemetry+api@1.9.0",
-          "@opentelemetry/instrumentation": "@opentelemetry/instrumentation@0.52.0_@opentelemetry+api@1.9.0",
-          "@opentelemetry/semantic-conventions": "@opentelemetry/semantic-conventions@1.25.0",
+          "@opentelemetry/core": "@opentelemetry/core@1.25.1_@opentelemetry+api@1.9.0",
+          "@opentelemetry/instrumentation": "@opentelemetry/instrumentation@0.52.1_@opentelemetry+api@1.9.0",
+          "@opentelemetry/semantic-conventions": "@opentelemetry/semantic-conventions@1.25.1",
           "semver": "semver@7.6.2"
         }
       },
@@ -334,30 +315,6 @@
           "shimmer": "shimmer@1.2.1"
         }
       },
-      "@opentelemetry/instrumentation@0.51.1_@opentelemetry+api@1.9.0": {
-        "integrity": "sha512-JIrvhpgqY6437QIqToyozrUG1h5UhwHkaGK/WAX+fkrpyPtc+RO5FkRtUd9BH0MibabHHvqsnBGKfKVijbmp8w==",
-        "dependencies": {
-          "@opentelemetry/api": "@opentelemetry/api@1.9.0",
-          "@opentelemetry/api-logs": "@opentelemetry/api-logs@0.51.1",
-          "@types/shimmer": "@types/shimmer@1.0.5",
-          "import-in-the-middle": "import-in-the-middle@1.7.4_acorn@8.12.0",
-          "require-in-the-middle": "require-in-the-middle@7.3.0",
-          "semver": "semver@7.6.2",
-          "shimmer": "shimmer@1.2.1"
-        }
-      },
-      "@opentelemetry/instrumentation@0.52.0_@opentelemetry+api@1.9.0": {
-        "integrity": "sha512-LPwSIrw+60cheWaXsfGL8stBap/AppKQJFE+qqRvzYrgttXFH2ofoIMxWadeqPTq4BYOXM/C7Bdh/T+B60xnlQ==",
-        "dependencies": {
-          "@opentelemetry/api": "@opentelemetry/api@1.9.0",
-          "@opentelemetry/api-logs": "@opentelemetry/api-logs@0.52.0",
-          "@types/shimmer": "@types/shimmer@1.0.5",
-          "import-in-the-middle": "import-in-the-middle@1.8.0_acorn@8.12.0",
-          "require-in-the-middle": "require-in-the-middle@7.3.0",
-          "semver": "semver@7.6.2",
-          "shimmer": "shimmer@1.2.1"
-        }
-      },
       "@opentelemetry/instrumentation@0.52.1_@opentelemetry+api@1.9.0": {
         "integrity": "sha512-uXJbYU/5/MBHjMp1FqrILLRuiJCs3Ofk0MeRDk8g1S1gD47U8X3JnSwcMO1rtRo1x1a7zKaQHaoYu49p/4eSKw==",
         "dependencies": {
@@ -400,10 +357,6 @@
           "@opentelemetry/semantic-conventions": "@opentelemetry/semantic-conventions@1.25.1"
         }
       },
-      "@opentelemetry/semantic-conventions@1.25.0": {
-        "integrity": "sha512-M+kkXKRAIAiAP6qYyesfrC5TOmDpDVtsxuGfPcqd9B/iBrac+E14jYwrgm0yZBUIbIP2OnqC3j+UgkXLm1vxUQ==",
-        "dependencies": {}
-      },
       "@opentelemetry/semantic-conventions@1.25.1": {
         "integrity": "sha512-ZDjMJJQRlyk8A1KZFCc+bCbsyrn1wTwdNt56F7twdfUfnHUZUq77/WfONCj8p72NZOyP7pNTdUWSTYC3GTbuuQ==",
         "dependencies": {}
@@ -435,23 +388,23 @@
         "integrity": "sha512-Y6lprxpPfDxLoUyeNcI/vfxMkeWlTjNFvh73zlxfQtZ8TWIj+rmPY99l5wNFVkHQOAwCzLaBXyxULpbtaMGyHQ==",
         "dependencies": {}
       },
-      "@prisma/instrumentation@5.15.0_@opentelemetry+api@1.9.0": {
-        "integrity": "sha512-fCWOOOajTKOUEp43gRmBqwt6oN9bPJcLiloi2OG/2ED0N5z62Cuza6FDrlm3SJHQAXYlXqLE0HLdEE5WcUkOzg==",
+      "@prisma/instrumentation@5.16.0_@opentelemetry+api@1.9.0": {
+        "integrity": "sha512-MVzNRW2ikWvVNnMIEgQMcwWxpFD+XF2U2h0Qz7MjutRqJxrhWexWV2aSi2OXRaU8UL5wzWw7pnjdKUzYhWauLg==",
         "dependencies": {
           "@opentelemetry/api": "@opentelemetry/api@1.9.0",
-          "@opentelemetry/instrumentation": "@opentelemetry/instrumentation@0.51.1_@opentelemetry+api@1.9.0",
+          "@opentelemetry/instrumentation": "@opentelemetry/instrumentation@0.52.1_@opentelemetry+api@1.9.0",
           "@opentelemetry/sdk-trace-base": "@opentelemetry/sdk-trace-base@1.25.1_@opentelemetry+api@1.9.0"
         }
       },
-      "@sentry/core@8.10.0": {
-        "integrity": "sha512-NzrFqYsEHMd4TYYYxOvf+f+Z02u0nt12cIYYN9pOM3xBLKR+ORs7jhVnN0cB/H2yqtmtBaIzSehk/M/qUXFJGw==",
+      "@sentry/core@8.13.0": {
+        "integrity": "sha512-N9Qg4ZGxZWp8eb2eUUHVVKgjBLtFIjS805nG92s6yJmkvOpKm6mLtcUaT/iDf3Hta6nG+xRkhbE3r+Z4cbXG8w==",
         "dependencies": {
-          "@sentry/types": "@sentry/types@8.10.0",
-          "@sentry/utils": "@sentry/utils@8.10.0"
+          "@sentry/types": "@sentry/types@8.13.0",
+          "@sentry/utils": "@sentry/utils@8.13.0"
         }
       },
-      "@sentry/node@8.10.0_@opentelemetry+api@1.9.0_@opentelemetry+core@1.25.1__@opentelemetry+api@1.9.0_@opentelemetry+instrumentation@0.52.1__@opentelemetry+api@1.9.0_@opentelemetry+sdk-trace-base@1.25.1__@opentelemetry+api@1.9.0_@opentelemetry+semantic-conventions@1.25.1": {
-        "integrity": "sha512-cokBLwYGBFhFw4TFX5QCRat8JBkjT3U72PsptciO+ck3XUHJwQn2AipzzEk9itCvtnhQjhStRswyCK4zXHpW7w==",
+      "@sentry/node@8.13.0_@opentelemetry+api@1.9.0_@opentelemetry+core@1.25.1__@opentelemetry+api@1.9.0_@opentelemetry+instrumentation@0.52.1__@opentelemetry+api@1.9.0_@opentelemetry+sdk-trace-base@1.25.1__@opentelemetry+api@1.9.0_@opentelemetry+semantic-conventions@1.25.1": {
+        "integrity": "sha512-OeZ7K90RhyxfwfreerIi4cszzHrPRRH36STJno2+p3sIGbG5VScOccqXzYEOAqHpByxnti4KQN34BLAT2BFOEA==",
         "dependencies": {
           "@opentelemetry/api": "@opentelemetry/api@1.9.0",
           "@opentelemetry/context-async-hooks": "@opentelemetry/context-async-hooks@1.25.1_@opentelemetry+api@1.9.0",
@@ -462,7 +415,7 @@
           "@opentelemetry/instrumentation-fastify": "@opentelemetry/instrumentation-fastify@0.37.0_@opentelemetry+api@1.9.0",
           "@opentelemetry/instrumentation-graphql": "@opentelemetry/instrumentation-graphql@0.41.0_@opentelemetry+api@1.9.0",
           "@opentelemetry/instrumentation-hapi": "@opentelemetry/instrumentation-hapi@0.39.0_@opentelemetry+api@1.9.0",
-          "@opentelemetry/instrumentation-http": "@opentelemetry/instrumentation-http@0.52.0_@opentelemetry+api@1.9.0",
+          "@opentelemetry/instrumentation-http": "@opentelemetry/instrumentation-http@0.52.1_@opentelemetry+api@1.9.0",
           "@opentelemetry/instrumentation-ioredis": "@opentelemetry/instrumentation-ioredis@0.41.0_@opentelemetry+api@1.9.0",
           "@opentelemetry/instrumentation-koa": "@opentelemetry/instrumentation-koa@0.41.0_@opentelemetry+api@1.9.0",
           "@opentelemetry/instrumentation-mongodb": "@opentelemetry/instrumentation-mongodb@0.45.0_@opentelemetry+api@1.9.0",
@@ -475,35 +428,35 @@
           "@opentelemetry/resources": "@opentelemetry/resources@1.25.1_@opentelemetry+api@1.9.0",
           "@opentelemetry/sdk-trace-base": "@opentelemetry/sdk-trace-base@1.25.1_@opentelemetry+api@1.9.0",
           "@opentelemetry/semantic-conventions": "@opentelemetry/semantic-conventions@1.25.1",
-          "@prisma/instrumentation": "@prisma/instrumentation@5.15.0_@opentelemetry+api@1.9.0",
-          "@sentry/core": "@sentry/core@8.10.0",
-          "@sentry/opentelemetry": "@sentry/opentelemetry@8.10.0_@opentelemetry+api@1.9.0_@opentelemetry+core@1.25.1__@opentelemetry+api@1.9.0_@opentelemetry+instrumentation@0.52.1__@opentelemetry+api@1.9.0_@opentelemetry+sdk-trace-base@1.25.1__@opentelemetry+api@1.9.0_@opentelemetry+semantic-conventions@1.25.1",
-          "@sentry/types": "@sentry/types@8.10.0",
-          "@sentry/utils": "@sentry/utils@8.10.0",
+          "@prisma/instrumentation": "@prisma/instrumentation@5.16.0_@opentelemetry+api@1.9.0",
+          "@sentry/core": "@sentry/core@8.13.0",
+          "@sentry/opentelemetry": "@sentry/opentelemetry@8.13.0_@opentelemetry+api@1.9.0_@opentelemetry+core@1.25.1__@opentelemetry+api@1.9.0_@opentelemetry+instrumentation@0.52.1__@opentelemetry+api@1.9.0_@opentelemetry+sdk-trace-base@1.25.1__@opentelemetry+api@1.9.0_@opentelemetry+semantic-conventions@1.25.1",
+          "@sentry/types": "@sentry/types@8.13.0",
+          "@sentry/utils": "@sentry/utils@8.13.0",
           "opentelemetry-instrumentation-fetch-node": "opentelemetry-instrumentation-fetch-node@1.2.0_@opentelemetry+api@1.9.0"
         }
       },
-      "@sentry/opentelemetry@8.10.0_@opentelemetry+api@1.9.0_@opentelemetry+core@1.25.1__@opentelemetry+api@1.9.0_@opentelemetry+instrumentation@0.52.1__@opentelemetry+api@1.9.0_@opentelemetry+sdk-trace-base@1.25.1__@opentelemetry+api@1.9.0_@opentelemetry+semantic-conventions@1.25.1": {
-        "integrity": "sha512-OPdxZZWaOzOCOYbH7oGeDrz3veaxdlUMU0PMaqYYywN+iOx+0uZm+MfAiAEbInL8dmLMg0qJHde3vI9veDozgQ==",
+      "@sentry/opentelemetry@8.13.0_@opentelemetry+api@1.9.0_@opentelemetry+core@1.25.1__@opentelemetry+api@1.9.0_@opentelemetry+instrumentation@0.52.1__@opentelemetry+api@1.9.0_@opentelemetry+sdk-trace-base@1.25.1__@opentelemetry+api@1.9.0_@opentelemetry+semantic-conventions@1.25.1": {
+        "integrity": "sha512-NYn/HNE/SxFXe8pfnxJknhrrRzYRMHNssCoi5M1CeR5G7F2BGxxVmaGsd8j0WyTCpUS4i97G4vhYtDGxHvWN6w==",
         "dependencies": {
           "@opentelemetry/api": "@opentelemetry/api@1.9.0",
           "@opentelemetry/core": "@opentelemetry/core@1.25.1_@opentelemetry+api@1.9.0",
           "@opentelemetry/instrumentation": "@opentelemetry/instrumentation@0.52.1_@opentelemetry+api@1.9.0",
           "@opentelemetry/sdk-trace-base": "@opentelemetry/sdk-trace-base@1.25.1_@opentelemetry+api@1.9.0",
           "@opentelemetry/semantic-conventions": "@opentelemetry/semantic-conventions@1.25.1",
-          "@sentry/core": "@sentry/core@8.10.0",
-          "@sentry/types": "@sentry/types@8.10.0",
-          "@sentry/utils": "@sentry/utils@8.10.0"
+          "@sentry/core": "@sentry/core@8.13.0",
+          "@sentry/types": "@sentry/types@8.13.0",
+          "@sentry/utils": "@sentry/utils@8.13.0"
         }
       },
-      "@sentry/types@8.10.0": {
-        "integrity": "sha512-6kgh6NqgQHcnnD7dOe3THcVkzv2nor/f94x3odmPShN2AWBfPRprHZZsLTjh/3aC7l76V2nfuQ4wgRvwsddTWw==",
+      "@sentry/types@8.13.0": {
+        "integrity": "sha512-r63s/H5gvQnQM9tTGBXz2xErUbxZALh4e2Lg/1aHj4zIvGLBjA2z5qWsh6TEZYbpmgAyGShLDr6+rWeUVf9yBQ==",
         "dependencies": {}
       },
-      "@sentry/utils@8.10.0": {
-        "integrity": "sha512-tQPgB7lX1XqbEw2EXvWNsBQlmG+yJHVhBKKDPy5HZMjuTP3zlpVdP6NF87qwonmdtFNHxdrKbfOVRiLx71/JwA==",
+      "@sentry/utils@8.13.0": {
+        "integrity": "sha512-PxV0v9VbGWH9zP37P5w2msLUFDr287nYjoY2XVF+RSolyiTs1CQNI5ZMUO3o4MsSac/dpXxjyrZXQd72t/jRYA==",
         "dependencies": {
-          "@sentry/types": "@sentry/types@8.10.0"
+          "@sentry/types": "@sentry/types@8.13.0"
         }
       },
       "@sinonjs/commons@2.0.0": {
@@ -736,8 +689,8 @@
         "integrity": "sha512-IXl7o+R9iti9eBW4Wg2hx1xQDig183jj7YLn8F7udNceyfkbn1ZxmzZXuak20gR40D7pIkIY1kYGx5VIGbaHKA==",
         "dependencies": {}
       },
-      "@types/node@20.14.7": {
-        "integrity": "sha512-uTr2m2IbJJucF3KUxgnGOZvYbN0QgkGyWxG6973HCpMYFy2KfcgYuIwkJQMQkt1VbBMlvWRbpshFTLxnxCZjKQ==",
+      "@types/node@20.14.9": {
+        "integrity": "sha512-06OCtnTXtWOZBJlRApleWndH4JsRVs1pDCc8dLSQp+7PpUpX3ePdHyeNSFTeSe7FtKyQkrlPvHwJOW3SLd8Oyg==",
         "dependencies": {
           "undici-types": "undici-types@5.26.5"
         }
@@ -1009,8 +962,8 @@
           "possible-typed-array-names": "possible-typed-array-names@1.0.0"
         }
       },
-      "axios-retry@4.4.0_axios@1.7.2": {
-        "integrity": "sha512-yewTKjzl6jSgc+2M7FCJ3LxRGgL1iiXHcj+E6h6xie6H1mTHr7yqaUroWIvVXG1UKSPwGDXxV05YxtGvrD6Paw==",
+      "axios-retry@4.4.1_axios@1.7.2": {
+        "integrity": "sha512-JGzNoglDHtHWIEvvAampB0P7jxQ/sT4COmW0FgSQkVg6o4KqNjNMBI6uFVOq517hkw/OAYYAG08ADtBlV8lvmQ==",
         "dependencies": {
           "axios": "axios@1.7.2",
           "is-retry-allowed": "is-retry-allowed@2.2.0"
@@ -1943,7 +1896,7 @@
         "dependencies": {
           "foreground-child": "foreground-child@3.2.1",
           "jackspeak": "jackspeak@3.4.0",
-          "minimatch": "minimatch@9.0.4",
+          "minimatch": "minimatch@9.0.5",
           "minipass": "minipass@7.1.2",
           "package-json-from-dist": "package-json-from-dist@1.0.0",
           "path-scurry": "path-scurry@1.11.1"
@@ -2139,24 +2092,6 @@
         "dependencies": {
           "acorn": "acorn@8.12.0",
           "acorn-import-assertions": "acorn-import-assertions@1.9.0_acorn@8.12.0",
-          "cjs-module-lexer": "cjs-module-lexer@1.3.1",
-          "module-details-from-path": "module-details-from-path@1.0.3"
-        }
-      },
-      "import-in-the-middle@1.7.4_acorn@8.12.0": {
-        "integrity": "sha512-Lk+qzWmiQuRPPulGQeK5qq0v32k2bHnWrRPFgqyvhw7Kkov5L6MOLOIU3pcWeujc9W4q54Cp3Q2WV16eQkc7Bg==",
-        "dependencies": {
-          "acorn": "acorn@8.12.0",
-          "acorn-import-attributes": "acorn-import-attributes@1.9.5_acorn@8.12.0",
-          "cjs-module-lexer": "cjs-module-lexer@1.3.1",
-          "module-details-from-path": "module-details-from-path@1.0.3"
-        }
-      },
-      "import-in-the-middle@1.8.0_acorn@8.12.0": {
-        "integrity": "sha512-/xQjze8szLNnJ5rvHSzn+dcVXqCAU6Plbk4P24U/jwPmg1wy7IIp9OjKIO5tYue8GSPhDpPDiApQjvBUmWwhsQ==",
-        "dependencies": {
-          "acorn": "acorn@8.12.0",
-          "acorn-import-attributes": "acorn-import-attributes@1.9.5_acorn@8.12.0",
           "cjs-module-lexer": "cjs-module-lexer@1.3.1",
           "module-details-from-path": "module-details-from-path@1.0.3"
         }
@@ -2576,8 +2511,8 @@
         "integrity": "sha512-2Fgx1Ycm599x+WGpIYwJOvsjmXFzTSc34IwDWALRA/8AopUKAVPwfJ+h5+f85BCp0PWmmJcWzEpxOpoXycMpdA==",
         "dependencies": {}
       },
-      "lru-cache@10.2.2": {
-        "integrity": "sha512-9hp3Vp2/hFQUiIwKo8XCeFVnrg8Pk3TYNPIR7tJADKi5YfcF7vEaK7avFHTlSy3kOKYaJQaalfEo6YuXdceBOQ==",
+      "lru-cache@10.3.0": {
+        "integrity": "sha512-CQl19J/g+Hbjbv4Y3mFNNXFEL/5t/KCg8POCuUqd4rMKjGG+j1ybER83hxV58zL+dFI1PTkt3GNFSHRt+d8qEQ==",
         "dependencies": {}
       },
       "luxon@3.4.4": {
@@ -2669,8 +2604,8 @@
           "brace-expansion": "brace-expansion@2.0.1"
         }
       },
-      "minimatch@9.0.4": {
-        "integrity": "sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==",
+      "minimatch@9.0.5": {
+        "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
         "dependencies": {
           "brace-expansion": "brace-expansion@2.0.1"
         }
@@ -2724,7 +2659,7 @@
           "html-minifier": "html-minifier@4.0.0",
           "js-beautify": "js-beautify@1.15.1",
           "lodash": "lodash@4.17.21",
-          "minimatch": "minimatch@9.0.4",
+          "minimatch": "minimatch@9.0.5",
           "mjml-core": "mjml-core@4.15.3",
           "mjml-migrate": "mjml-migrate@4.15.3",
           "mjml-parser-xml": "mjml-parser-xml@4.15.3",
@@ -3111,8 +3046,8 @@
         "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
         "dependencies": {}
       },
-      "object-inspect@1.13.1": {
-        "integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==",
+      "object-inspect@1.13.2": {
+        "integrity": "sha512-IRZSRuzJiynemAXPYtPe5BoI/RESNYR7TYm50MC5Mqbd3Jmw5y790sErYw3V6SryFJD64b74qQQs9wn5Bg/k3g==",
         "dependencies": {}
       },
       "object-is@1.1.6": {
@@ -3219,7 +3154,7 @@
       "path-scurry@1.11.1": {
         "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
         "dependencies": {
-          "lru-cache": "lru-cache@10.2.2",
+          "lru-cache": "lru-cache@10.3.0",
           "minipass": "minipass@7.1.2"
         }
       },
@@ -3371,8 +3306,8 @@
         "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
         "dependencies": {}
       },
-      "prom-client@15.1.2": {
-        "integrity": "sha512-on3h1iXb04QFLLThrmVYg1SChBQ9N1c+nKAjebBjokBqipddH3uxmOUcEkTnzmJ8Jh/5TSUnUqS40i2QB2dJHQ==",
+      "prom-client@15.1.3": {
+        "integrity": "sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==",
         "dependencies": {
           "@opentelemetry/api": "@opentelemetry/api@1.9.0",
           "tdigest": "tdigest@0.1.2"
@@ -3641,7 +3576,7 @@
           "call-bind": "call-bind@1.0.7",
           "es-errors": "es-errors@1.3.0",
           "get-intrinsic": "get-intrinsic@1.2.4",
-          "object-inspect": "object-inspect@1.13.1"
+          "object-inspect": "object-inspect@1.13.2"
         }
       },
       "signal-exit@4.1.0": {
@@ -4262,9 +4197,28 @@
     "https://deno.land/std@0.224.0/encoding/base64.ts": "dd59695391584c8ffc5a296ba82bcdba6dd8a84d41a6a539fbee8e5075286eaf",
     "https://deno.land/std@0.224.0/encoding/base64url.ts": "ef40e0f18315ab539f17cebcc32839779e018d86dea9df39d94d302f342a1713",
     "https://deno.land/std@0.224.0/fmt/colors.ts": "508563c0659dd7198ba4bbf87e97f654af3c34eb56ba790260f252ad8012e1c5",
+    "https://deno.land/std@0.224.0/fs/exists.ts": "3d38cb7dcbca3cf313be343a7b8af18a87bddb4b5ca1bd2314be12d06533b50f",
     "https://deno.land/std@0.224.0/internal/diff.ts": "6234a4b493ebe65dc67a18a0eb97ef683626a1166a1906232ce186ae9f65f4e6",
     "https://deno.land/std@0.224.0/internal/format.ts": "0a98ee226fd3d43450245b1844b47003419d34d210fa989900861c79820d21c2",
     "https://deno.land/std@0.224.0/internal/mod.ts": "534125398c8e7426183e12dc255bb635d94e06d0f93c60a297723abe69d3b22e",
+    "https://deno.land/std@0.224.0/io/write_all.ts": "24aac2312bb21096ae3ae0b102b22c26164d3249dff96dbac130958aa736f038",
+    "https://deno.land/std@0.224.0/log/_config.ts": "489e11b6d3c917bf5fc954c5e914c095d3480efd924d1e85f2fc576468581c54",
+    "https://deno.land/std@0.224.0/log/_state.ts": "314c0c31ab9c8f4fb33326ad446757d35f75e5bb21746b7720ed4e3f3a939da1",
+    "https://deno.land/std@0.224.0/log/base_handler.ts": "f03f013dac9c1a226aab60c6f5751b3131cc4f2808720715285e0dab5697a54e",
+    "https://deno.land/std@0.224.0/log/console_handler.ts": "9b17b9025c7d94eab950a25eccca81fd9dd71d063b9f458f149e52db52ab0295",
+    "https://deno.land/std@0.224.0/log/critical.ts": "a8b44a4c6768629d2a506ffe1a1a048da7ae76d3146000f8a492008eac4ecba0",
+    "https://deno.land/std@0.224.0/log/debug.ts": "ddd63a549fedc3061deba47e41cd2170263831fc266e503a12b610b77439333b",
+    "https://deno.land/std@0.224.0/log/error.ts": "3979ee3aadc962345ad50eff8a5470ad3fe07c70370808ddc178ee08c3d6c89c",
+    "https://deno.land/std@0.224.0/log/file_handler.ts": "68d6d81ec53bdd6ba61eaceec19d12de59a8ad12ace0d7980a592a51f924a242",
+    "https://deno.land/std@0.224.0/log/formatters.ts": "29e0325902c3b1cbb3b9ffc1f9d77ac2d2e5af35d27b9bdfe4fdbbd83588d4a8",
+    "https://deno.land/std@0.224.0/log/get_logger.ts": "36a5febf5338f68aadafaf23bbe38a208e2a3150ec02ca2ec5d3c6bbaf840641",
+    "https://deno.land/std@0.224.0/log/info.ts": "e6c4971e35092d85cd3241fe7eccdb42999083d14db6aadc5e741f6231e275ad",
+    "https://deno.land/std@0.224.0/log/levels.ts": "632ba12baa2600750d004cc5cb4eabe10e410f3f2bdfcb9f7142b6d767f2fee6",
+    "https://deno.land/std@0.224.0/log/logger.ts": "57109848fb587fb3843a7b893f22f1a86c1b78c289172627a6305906738f238a",
+    "https://deno.land/std@0.224.0/log/mod.ts": "650c53c2c5d9eb05210c4ec54184ecb5bd24fb32ce28e65fad039853978f53f3",
+    "https://deno.land/std@0.224.0/log/rotating_file_handler.ts": "a6e7c712e568b618303273ff95483f6ab86dec0a485c73c2e399765f752b5aa8",
+    "https://deno.land/std@0.224.0/log/setup.ts": "42425c550da52c7def7f63a4fcc1ac01a4aec6c73336697a640978d6a324e7a6",
+    "https://deno.land/std@0.224.0/log/warn.ts": "f1a6bc33a481f231a0257e6d66e26c2e695b931d5e917d8de4f2b825778dfd4e",
     "https://deno.land/std@0.224.0/path/_common/assert_path.ts": "dbdd757a465b690b2cc72fc5fb7698c51507dec6bfafce4ca500c46b76ff7bd8",
     "https://deno.land/std@0.224.0/path/_common/basename.ts": "569744855bc8445f3a56087fd2aed56bdad39da971a8d92b138c9913aecc5fa2",
     "https://deno.land/std@0.224.0/path/_common/common.ts": "ef73c2860694775fe8ffcbcdd387f9f97c7a656febf0daa8c73b56f4d8a7bd4c",
@@ -4307,6 +4261,7 @@
     "https://deno.land/x/bcrypt@v0.4.1/src/bcrypt/base64.ts": "b8266450a4f1eb6960f60f2f7986afc4dde6b45bd2d7ee7ba10789e67e17b9f7",
     "https://deno.land/x/bcrypt@v0.4.1/src/bcrypt/bcrypt.ts": "ec221648cc6453ea5e3803bc817c01157dada06aa6f7a0ba6b9f87aae32b21e2",
     "https://deno.land/x/bcrypt@v0.4.1/src/main.ts": "08d201b289c8d9c46f8839c69cd6625b213863db29775c7a200afc3b540e64f8",
+    "https://deno.land/x/bcrypt@v0.4.1/src/worker.ts": "5a73bdfee9c9e622f47c9733d374b627dce52fb3ec1e74c8226698b3fc57ffac",
     "https://deno.land/x/port@1.0.0/mod.ts": "2dc04ce1ccf133ae09205e30b550044c4c6f64a1a7d00ea91c66dbb9f6cc00f5",
     "https://deno.land/x/port@1.0.0/types.ts": "42d6ae4147d5d67408d60209da070ddfa79ec8389c6cab1b8002df0cf6c03af6",
     "https://deno.land/x/postgres@v0.19.3/client.ts": "d141c65c20484c545a1119c9af7a52dcc24f75c1a5633de2b9617b0f4b2ed5c1",

--- a/api/src/pdc/proxy/HttpTransport.ts
+++ b/api/src/pdc/proxy/HttpTransport.ts
@@ -51,7 +51,6 @@ import {
 import {
   dataWrapMiddleware,
   errorHandlerMiddleware,
-  signResponseMiddleware,
 } from "./middlewares/index.ts";
 import { metricsMiddleware } from "./middlewares/metricsMiddleware.ts";
 import {
@@ -254,7 +253,8 @@ export class HttpTransport implements TransportInterface {
       next();
     });
 
-    this.app.use(signResponseMiddleware);
+    // FIXME : expressMung.jsonAsync makes the response body undefined
+    // this.app.use(signResponseMiddleware);
     this.app.use(dataWrapMiddleware);
   }
 


### PR DESCRIPTION
Désactivation du middleware `signResponse` qui fait planter le body des réponses.
Lié à `expressMung` et `jsonAsync`. A fixer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Temporarily disabled the `signResponseMiddleware` to address an issue causing undefined response bodies.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->