### PR TITLE
fix: update Cotentin campaign

### DIFF
--- a/api/src/pdc/services/policy/engine/policies/20230101_Cotentin.html.ts
+++ b/api/src/pdc/services/policy/engine/policies/20230101_Cotentin.html.ts
@@ -24,5 +24,9 @@ export const description =
   <li><b>12 trajets maximum pour le conducteur par jour.</b></li>
 </ul>
 
-<p>La campagne est limitée à l'opérateur <b>Klaxit</b> proposant des preuves de classe <b>B ou C</b>.</p>
+<p>
+  La campagne est limitée à l'opérateur <b>Blablacar Daily</b> depuis le 11 mars 2024
+  à la suite de Klaxit.<br />
+  Les preuves de classe <b>B ou C</b> sont autorisées.
+</p>
 `;

--- a/api/src/pdc/services/policy/engine/policies/20230101_Cotentin.ts
+++ b/api/src/pdc/services/policy/engine/policies/20230101_Cotentin.ts
@@ -55,7 +55,7 @@ export const Cotentin2023: PolicyHandlerStaticInterface = class
       operators: [OperatorsEnum.KLAXIT],
     },
     {
-      date: new Date("2024-04-01T00:00:00+0200"),
+      date: new Date("2024-03-11T00:00:00+0200"),
       operators: [OperatorsEnum.BLABLACAR_DAILY],
     },
   ];


### PR DESCRIPTION
- Modification de la description de Cotentin pour ajouter la date d'arrivée de BBCD sur la campagne.
- Modification de la date de début du 01/04 au 11/03/2024

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated campaign restrictions to "Blablacar Daily" starting March 11, 2024.
	- Allowed proofs of class "B or C" for the campaign.

- **Changes**
	- Adjusted policy entry date from April 1, 2024, to March 11, 2024.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->