### PR TITLE
doc: add 409 doc

### DIFF
--- a/doc/docs/.vuepress/public/specs/operateurs-api-v3.yaml
+++ b/doc/docs/.vuepress/public/specs/operateurs-api-v3.yaml
@@ -574,6 +574,9 @@ paths:
               example:
                 code: 403
                 error: Forbidden
+        '409':
+          description: |
+            Un trajet similaire a déjà enregistré.
     get:
       tags:
       - Trajets


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new HTTP status code `409` for the API response to indicate when a similar trip is already registered. This will help users understand why their trip registration request was conflicted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->