### PR TITLE
CLI company:fetch

### DIFF
--- a/api/src/ilos/common/types/validator/ValidatorInterface.ts
+++ b/api/src/ilos/common/types/validator/ValidatorInterface.ts
@@ -1,7 +1,9 @@
-import { NewableType } from "../shared/index.ts";
+import { ErrorObject } from "@/deps.ts";
 import { ProviderInterface } from "../core/index.ts";
+import { NewableType } from "../shared/index.ts";
 
 export interface ValidatorInterface extends ProviderInterface {
+  errors: ErrorObject[];
   registerValidator(
     definition: any,
     target?: NewableType<any> | string,
@@ -11,6 +13,7 @@ export interface ValidatorInterface extends ProviderInterface {
 }
 
 export abstract class ValidatorInterfaceResolver implements ValidatorInterface {
+  errors: ErrorObject[] = [];
   boot(): void {
     return;
   }

--- a/api/src/ilos/validator/AjvValidator.ts
+++ b/api/src/ilos/validator/AjvValidator.ts
@@ -24,6 +24,11 @@ export class AjvValidator implements ValidatorInterface {
   protected ajv: Ajv | null = null;
   protected bindings: Map<any, ValidateFunction> = new Map();
   protected isSchemaSecure: ValidateFunction | null = null;
+  protected validationErrors: ErrorObject[] = [];
+
+  get errors(): ErrorObject[] {
+    return this.validationErrors || [];
+  }
 
   constructor(protected config: ConfigInterfaceResolver) {}
 
@@ -141,6 +146,8 @@ export class AjvValidator implements ValidatorInterface {
       if (!validator || !validator?.errors) {
         throw new Error("No validator found");
       }
+
+      this.validationErrors = [...validator.errors];
 
       throw new InvalidParamsException(this.mapErrors(validator.errors));
     }

--- a/api/src/pdc/services/company/ServiceProvider.ts
+++ b/api/src/pdc/services/company/ServiceProvider.ts
@@ -1,22 +1,23 @@
-import { ServiceProvider as AbstractServiceProvider } from "@/ilos/core/index.ts";
 import {
   ExtensionInterface,
   NewableType,
   serviceProvider,
 } from "@/ilos/common/index.ts";
+import { ServiceProvider as AbstractServiceProvider } from "@/ilos/core/index.ts";
 import { defaultMiddlewareBindings } from "@/pdc/providers/middleware/index.ts";
 import {
   ValidatorExtension,
   ValidatorMiddleware,
 } from "@/pdc/providers/validator/index.ts";
 
-import { config } from "./config/index.ts";
+import { FetchCommand } from "@/pdc/services/company/commands/FetchCommand.ts";
 import { binding as fetchBinding } from "@/shared/company/fetch.schema.ts";
 import { binding as findBinding } from "@/shared/company/find.schema.ts";
-import { CompanyRepositoryProvider } from "./providers/CompanyRepositoryProvider.ts";
-import { CompanyDataSourceProvider } from "./providers/CompanyDataSourceProvider.ts";
 import { FetchAction } from "./actions/FetchAction.ts";
 import { FindAction } from "./actions/FindAction.ts";
+import { config } from "./config/index.ts";
+import { CompanyDataSourceProvider } from "./providers/CompanyDataSourceProvider.ts";
+import { CompanyRepositoryProvider } from "./providers/CompanyRepositoryProvider.ts";
 
 @serviceProvider({
   config,
@@ -27,6 +28,7 @@ import { FindAction } from "./actions/FindAction.ts";
     ValidatorMiddleware,
   ]],
   handlers: [FetchAction, FindAction],
+  commands: [FetchCommand],
 })
 export class ServiceProvider extends AbstractServiceProvider {
   readonly extensions: NewableType<ExtensionInterface>[] = [ValidatorExtension];

--- a/api/src/pdc/services/company/commands/FetchCommand.ts
+++ b/api/src/pdc/services/company/commands/FetchCommand.ts
@@ -1,0 +1,68 @@
+import { command } from "@/ilos/common/Decorators.ts";
+import {
+  CommandInterface,
+  CommandOptionType,
+  ValidatorInterfaceResolver,
+} from "@/ilos/common/index.ts";
+import { logger } from "@/lib/logger/index.ts";
+import { CompanyDataSourceProviderInterfaceResolver } from "@/pdc/services/company/interfaces/CompanyDataSourceProviderInterface.ts";
+import { CompanyRepositoryProviderInterfaceResolver } from "@/pdc/services/company/interfaces/CompanyRepositoryProviderInterface.ts";
+import { alias } from "@/shared/company/fetch.schema.ts";
+
+export type Options = {
+  save: boolean;
+};
+
+@command()
+export class FetchCommand implements CommandInterface {
+  static readonly signature: string = "company:fetch <siret>";
+  static readonly description: string = "Fetch company data";
+  static readonly options: CommandOptionType[] = [
+    {
+      signature: "-s, --save",
+      description: "Save the fetched data to the database",
+      default: false,
+    },
+  ];
+
+  constructor(
+    private datasource: CompanyDataSourceProviderInterfaceResolver,
+    private repository: CompanyRepositoryProviderInterfaceResolver,
+    private validator: ValidatorInterfaceResolver,
+  ) {}
+
+  public async call(siret: string, options: Options): Promise<void> {
+    // Validate SIRET format
+    try {
+      logger.info("Validating SIRET format...");
+      this.validator.registerValidator({
+        $schema: "http://json-schema.org/draft-07/schema#",
+        $id: "siret",
+        type: "object",
+        properties: { siret: { macro: "siret" } },
+        required: ["siret"],
+      });
+
+      await this.validator.validate(siret, alias);
+    } catch (error) {
+      logger.error(error.message);
+      logger.error(this.validator.errors);
+    }
+
+    // Fetch company data from the INSEE SIRENE API
+    logger.log(`Fetching company data for SIRET ${siret}...`);
+
+    try {
+      const data = await this.datasource.find(siret);
+
+      if (options.save) {
+        logger.info("Saving fetched data to the database...");
+        await this.repository.updateOrCreate(data);
+      }
+
+      logger.info(data);
+    } catch (error) {
+      logger.error(error.message);
+    }
+  }
+}

--- a/api/src/pdc/services/company/config/dataSource.ts
+++ b/api/src/pdc/services/company/config/dataSource.ts
@@ -2,7 +2,7 @@ import { env_or_fail, env_or_int } from "@/lib/env/index.ts";
 
 export const url = env_or_fail(
   "APP_INSEE_API_URL",
-  "https://api.insee.fr/entreprises/sirene/V3",
+  "https://api.insee.fr/entreprises/sirene",
 );
 export const token = env_or_fail("APP_INSEE_API_KEY", "");
 export const timeout = env_or_int("APP_INSEE_TIMEOUT", 5000);

--- a/api/src/pdc/services/company/interfaces/CompanyDataSourceProviderInterface.ts
+++ b/api/src/pdc/services/company/interfaces/CompanyDataSourceProviderInterface.ts
@@ -2,22 +2,11 @@ import { CompanyInterface } from "@/shared/common/interfaces/CompanyInterface2.t
 
 export interface CompanyDataSourceProviderInterface {
   find(siret: string): Promise<CompanyInterface>;
-  find_many(
-    sirets: string[],
-    parallelCall?: number,
-  ): Promise<CompanyInterface[]>;
 }
 
 export abstract class CompanyDataSourceProviderInterfaceResolver
   implements CompanyDataSourceProviderInterface {
   async find(siret: string): Promise<CompanyInterface> {
-    throw new Error();
-  }
-
-  async find_many(
-    sirets: string[],
-    parallelCall = 4,
-  ): Promise<CompanyInterface[]> {
     throw new Error();
   }
 }

--- a/api/src/pdc/services/company/providers/CompanyDataSourceProvider.ts
+++ b/api/src/pdc/services/company/providers/CompanyDataSourceProvider.ts
@@ -10,6 +10,7 @@ import {
   CompanyDataSourceProviderInterfaceResolver,
 } from "../interfaces/CompanyDataSourceProviderInterface.ts";
 
+import { logger } from "@/lib/logger/index.ts";
 import { get } from "@/lib/object/index.ts";
 import { CompanyInterface } from "@/shared/common/interfaces/CompanyInterface2.ts";
 
@@ -113,6 +114,7 @@ export class CompanyDataSourceProvider
         updated_at: updated_at ? new Date(updated_at) : null,
       };
     } catch (e) {
+      logger.error(`[CompanyDataSourceProvider] ${e.message}`);
       if (e.isAxiosError && e.response && e.response.status === 404) {
         throw new NotFoundException(`Company not found (${siret})`);
       }

--- a/api/src/pdc/services/company/providers/CompanyDataSourceProvider.ts
+++ b/api/src/pdc/services/company/providers/CompanyDataSourceProvider.ts
@@ -120,25 +120,6 @@ export class CompanyDataSourceProvider
     }
   }
 
-  async find_many(
-    sirets: string[],
-    parallelCall = 4,
-  ): Promise<CompanyInterface[]> {
-    let company_count = -1;
-    const res: CompanyInterface[] = [];
-
-    const apiCall = async (): Promise<boolean> => {
-      company_count++;
-      if (company_count >= sirets.length) return Promise.resolve(true);
-      res.push(await this.find(sirets[company_count]));
-      return apiCall();
-    };
-
-    const parallelCalls = new Array(parallelCall).map(() => apiCall());
-
-    return Promise.all(parallelCalls).then(() => res);
-  }
-
   private cleanNaf(str: string | null): string | null {
     if (str === null) return null;
     return str.replace(/[^A-Z0-9]/g, "");

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
       context: ./docker/postgres
     shm_size: 2g
     ports:
-      - 5432:5432
+      - "${DC_POSTGRES_PORT:-5432}:5432"
     networks:
       - back
     environment:
@@ -19,7 +19,7 @@ services:
   redis:
     build: './docker/redis'
     ports:
-      - 6379:6379
+      - "${DC_REDIS_PORT:-6379}:6379"
     networks:
       - back
 


### PR DESCRIPTION
- Ajoute une entreprise dans la table `company.companies` en passant le n° de SIRET.
- Correction de l'URL de l'API SIRENE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new command for fetching company data using SIRET identifiers, allowing users to retrieve and optionally save this data.
	- Enhanced error management capabilities across validation processes, improving the overall user experience.
  
- **Bug Fixes**
	- Improved error logging for company data retrieval, providing better visibility into issues.

- **Chores**
	- Updated API endpoint configurations to streamline data retrieval processes.
	- Modified Docker configurations to support dynamic port mapping for services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->