### PR TITLE
Tranches Nantes Métropole 2024

### DIFF
--- a/api/src/pdc/services/policy/engine/policies/20240101_NantesMetropole.html.ts
+++ b/api/src/pdc/services/policy/engine/policies/20240101_NantesMetropole.html.ts
@@ -3,7 +3,7 @@ export const description =
 
   <p>Campagne d'incitation au covoiturage du <b> 01 janvier 2024 au 31 Décembre 2025</b></p>
   
-  <p>Cette campagne est limitée à <b>500 000 euros</b>.</p>
+  <p>Cette campagne est limitée à <b>500 000,00 €</b>.</p>
 
   <p>
     Les <b> conducteurs </b> effectuant un trajet entre 5 et 60 km (inclus)
@@ -12,9 +12,9 @@ export const description =
   </p>
 
   <ul>
-    <li><b>De 5 à 17 km : 0.75 euro par trajet par passager.</b></li>
-    <li><b>De 17 à 29,5 km : 0.10 euro par trajet par km par passager avec un maximum de 2 euros</b></li>
-    <li><b>De 29,5 à 60 km : 2 euros par passager transporté</b></li>
+    <li><b>De 5 à 17 km : 0,75 € par trajet par passager.</b></li>
+    <li><b>De 17 à 29,5 km : 0,10 € par trajet par km par passager avec un maximum de 2,00 €</b></li>
+    <li><b>De 29,5 à 60 km : 2,00 € par passager transporté</b></li>
   </ul>
 
   <p>
@@ -22,9 +22,9 @@ export const description =
   </p>
 
   <ul>
-    <li><b>De 5 à 17 km : 1.65 euro par trajet par passager.</b></li>
-    <li><b>De 17 à 29,5 km : 0.10 euro par trajet par km par passager avec un maximum de 2.90 euros</b></li>
-    <li><b>De 29,5 à 60 km : 2.90 euros par passager transporté</b></li>
+    <li><b>De 5 à 17 km : 1.65 € par trajet par passager.</b></li>
+    <li><b>De 17 à 29,5 km : 0.10 € par trajet par km par passager avec un maximum de 2,90 €</b></li>
+    <li><b>De 29,5 à 60 km : 2,90 € par passager transporté</b></li>
   </ul>
   
   <p>Les restrictions suivantes seront appliquées :</p>

--- a/api/src/pdc/services/policy/engine/policies/20240101_NantesMetropole.ts
+++ b/api/src/pdc/services/policy/engine/policies/20240101_NantesMetropole.ts
@@ -51,7 +51,9 @@ export const NantesMetropole2024: PolicyHandlerStaticInterface = class
 
   // Liste de dates au format YYYY-MM-DD dans la zone Europe/Paris
   // pour lesquelles les règles de booster s'appliquent
-  protected boosterDates: string[] = [];
+  protected boosterDates: string[] = [
+    // Configure the booster dates here!
+  ];
 
   protected operators: TimestampedOperators = [
     {
@@ -81,17 +83,22 @@ export const NantesMetropole2024: PolicyHandlerStaticInterface = class
     },
     {
       start: 17_000,
-      end: 60_000,
+      end: 29_500,
       fn: (ctx: StatelessContextInterface) => {
         // 0,10 euro par trajet par km par passager avec un maximum de 2,00 euros
         return perSeat(
           ctx,
           Math.min(
-            perKm(ctx, { amount: 10, offset: 17_000, limit: 60_000 }),
+            perKm(ctx, { amount: 10, offset: 17_000, limit: 29_500 }),
             200 - 75,
           ),
         );
       },
+    },
+    {
+      start: 29_500,
+      end: 60_000,
+      fn: () => 0,
     },
   ];
 
@@ -103,17 +110,22 @@ export const NantesMetropole2024: PolicyHandlerStaticInterface = class
     },
     {
       start: 17_000,
-      end: 60_000,
+      end: 29_500,
       fn: (ctx: StatelessContextInterface) => {
         // 0,10 euro par trajet par km par passager avec un maximum de 2,90 euros
         return perSeat(
           ctx,
           Math.min(
-            perKm(ctx, { amount: 10, offset: 17_000, limit: 60_000 }),
+            perKm(ctx, { amount: 10, offset: 17_000, limit: 29_500 }),
             290 - 165,
           ),
         );
       },
+    },
+    {
+      start: 29_500,
+      end: 60_000,
+      fn: () => 0,
     },
   ];
 

--- a/api/src/pdc/services/policy/engine/policies/20240101_NantesMetropole.unit.spec.ts
+++ b/api/src/pdc/services/policy/engine/policies/20240101_NantesMetropole.unit.spec.ts
@@ -53,7 +53,7 @@ sinon.stub(Handler, "mode").callsFake(
 );
 
 it(
-  "should work with exclusion",
+  "should work with exclusions",
   async () =>
     await process(
       {
@@ -104,17 +104,19 @@ it(
           { distance: 5_000, seats: 2, driver_identity_key: "one" },
           { distance: 20_000, driver_identity_key: "two" },
           { distance: 25_000, driver_identity_key: "two" },
+          { distance: 29_500, driver_identity_key: "two" },
+          { distance: 30_000, driver_identity_key: "two" },
           { distance: 55_000, driver_identity_key: "two" },
           { distance: 61_000, driver_identity_key: "two" },
         ],
         meta: [],
       },
       {
-        incentive: [0, 75, 150, 105, 155, 200, 0],
+        incentive: [0, 75, 150, 105, 155, 200, 200, 200, 0],
         meta: [
           {
             key: "max_amount_restriction.global.campaign.global",
-            value: 685,
+            value: 1085,
           },
           {
             key: "max_amount_restriction.0-one.month.3-2024",
@@ -126,11 +128,11 @@ it(
           },
           {
             key: "max_amount_restriction.0-two.month.3-2024",
-            value: 460,
+            value: 860,
           },
           {
             key: "max_amount_restriction.0-two.year.2024",
-            value: 460,
+            value: 860,
           },
         ],
       },


### PR DESCRIPTION
https://covoiturage-betagouv.zammad.com/#ticket/zoom/3874

Configuration de la tranche supérieure (29,5 km à 60 km) pour l'affichage des APDF.
! Les montants d'incitation restent inchangés pour tous les trajets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated monetary formatting in policy descriptions to include the euro symbol (€) and use commas as decimal separators.
	- Adjusted pricing structure for the Nantes Metropole policy, narrowing the distance range for charges and introducing new operational parameters.

- **Bug Fixes**
	- Enhanced test cases to better reflect the intended functionality of the policy engine, particularly regarding exclusions and incentive calculations. 

These changes improve clarity in financial information and refine the pricing model for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->