### PR TITLE
fix: make trivy vuln check continue on error

### DIFF
--- a/.github/workflows/base-build-push-docker.yml
+++ b/.github/workflows/base-build-push-docker.yml
@@ -62,6 +62,7 @@ jobs:
           cache-to: type=local,dest=/tmp/.buildx-cache
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
+        continue-on-error: true
         with:
           image-ref: betagouvpdc/${{ inputs.name }}:${{ inputs.tag }}
           format: 'template'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated GitHub Actions workflow to allow the build process to continue even if the Trivy vulnerability scanner encounters an error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->