### PR TITLE
fix: MAJ des campagnes SMTC

### DIFF
--- a/api/src/pdc/services/policy/engine/policies/20240101_SMTC2024Passenger.html.ts
+++ b/api/src/pdc/services/policy/engine/policies/20240101_SMTC2024Passenger.html.ts
@@ -2,7 +2,7 @@ export const description =
   `<p _ngcontent-pmm-c231="" id="summary" class="campaignSummaryText-content-text">
 
 <p>
-  Campagne d’incitation au covoiturage du <b>01 janvier 2024 au 31 décembre 2025</b>
+  Campagne d’incitation au covoiturage du <b>01 janvier 2024 au 31 décembre 2024</b>
 </p>
 
 <p>

--- a/api/src/pdc/services/policy/engine/policies/20240101_SMTCDriver.html.ts
+++ b/api/src/pdc/services/policy/engine/policies/20240101_SMTCDriver.html.ts
@@ -2,7 +2,7 @@ export const description =
   `<p _ngcontent-pmm-c231="" id="summary" class="campaignSummaryText-content-text">
 
 <p>
-  Campagne d’incitation au covoiturage du <b> 01 janvier 2024 au 31 décembre 2025</b>
+  Campagne d’incitation au covoiturage du <b>01 janvier 2024 au 31 décembre 2024</b>
 </p>
 
 <p>


### PR DESCRIPTION
Modification de la fin de la campagne du 31/12/2025 au 31/12/2024

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated campaign duration for both passenger and driver policies to end on "31 décembre 2024."
  
- **Bug Fixes**
	- Corrected the end date for campaign descriptions to reflect the new duration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->