### PR TITLE
fix: force fraud label single entry

### DIFF
--- a/api/src/pdc/providers/carpool/repositories/CarpoolLabelRepository.integration.spec.ts
+++ b/api/src/pdc/providers/carpool/repositories/CarpoolLabelRepository.integration.spec.ts
@@ -21,19 +21,13 @@ describe("Carpool Label Repository", () => {
     const data = await repository.register(insertableCarpool);
     carpool_id = data._id;
     await db.connection.getClient().query(
-      sql`INSERT INTO ${
-        raw(labelRepository.anomalyTable)
-      } (carpool_id, label) VALUES (${carpool_id}, ${label})`,
+      sql`INSERT INTO ${raw(labelRepository.anomalyTable)} (carpool_id, label) VALUES (${carpool_id}, ${label})`,
     );
     await db.connection.getClient().query(
-      sql`INSERT INTO ${
-        raw(labelRepository.fraudTable)
-      } (carpool_id, label) VALUES (${carpool_id}, ${label})`,
+      sql`INSERT INTO ${raw(labelRepository.fraudTable)} (carpool_id, label) VALUES (${carpool_id}, ${label})`,
     );
     await db.connection.getClient().query(
-      sql`INSERT INTO ${
-        raw(labelRepository.termsTable)
-      } (carpool_id, labels) VALUES (${carpool_id}, ${[label]})`,
+      sql`INSERT INTO ${raw(labelRepository.termsTable)} (carpool_id, labels) VALUES (${carpool_id}, ${[label]})`,
     );
   });
 
@@ -61,7 +55,7 @@ describe("Carpool Label Repository", () => {
       insertableCarpool.operator_journey_id,
     );
     assertEquals(result, [{
-      label,
+      label: "interoperator_fraud",
     }]);
   });
 

--- a/api/src/pdc/providers/carpool/repositories/CarpoolLabelRepository.ts
+++ b/api/src/pdc/providers/carpool/repositories/CarpoolLabelRepository.ts
@@ -47,7 +47,10 @@ export class CarpoolLabelRepository {
           AND cc.operator_journey_id = ${operator_journey_id}
     `;
     const result = await cclient.query(query);
-    return result.rows.map((_r) => ({ label: "interoperator_fraud" }));
+    if (result.rowCount == 0) {
+      return [];
+    }
+    return [{ label: "interoperator_fraud" }];
   }
 
   async findAnomalyByOperatorJourneyId(

--- a/api/src/pdc/providers/carpool/repositories/CarpoolLabelRepository.ts
+++ b/api/src/pdc/providers/carpool/repositories/CarpoolLabelRepository.ts
@@ -1,8 +1,5 @@
 import { provider } from "@/ilos/common/index.ts";
-import {
-  PoolClient,
-  PostgresConnection,
-} from "@/ilos/connection-postgres/index.ts";
+import { PoolClient, PostgresConnection } from "@/ilos/connection-postgres/index.ts";
 import sql, { raw } from "@/lib/pg/sql.ts";
 import { CarpoolLabel } from "../interfaces/database/label.ts";
 
@@ -50,7 +47,7 @@ export class CarpoolLabelRepository {
           AND cc.operator_journey_id = ${operator_journey_id}
     `;
     const result = await cclient.query(query);
-    return result.rows;
+    return result.rows.map((_r) => ({ label: "interoperator_fraud" }));
   }
 
   async findAnomalyByOperatorJourneyId(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the fraud label retrieval logic to return an empty array when no labels are present.
	- Updated the method to ensure it returns a consistent response structure.

- **Tests**
	- Enhanced test cases for fraud label retrieval, including scenarios for empty labels and updated descriptions for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->