### PR TITLE
add Mobicoop to IDFM description

### DIFF
--- a/api/src/pdc/services/policy/engine/policies/20210520_IDFM.html.ts
+++ b/api/src/pdc/services/policy/engine/policies/20210520_IDFM.html.ts
@@ -37,7 +37,7 @@ export const description = `<p id="summary">
     <li><b>Le 25/10/2024</b></li>
   </ul>
   <p>
-  La campagne est limitée aux opérateurs BlaBlaCar Daily, Karos, Ynstant proposant des preuves de classe C</b>.
+  La campagne est limitée aux opérateurs BlaBlaCar Daily, Karos, Ynstant et Mobicoop proposant des preuves de classe C</b>.
   <p>
   <p>
   Klaxit ne fait plus partie des opérateurs partenaires depuis le juillet 2024


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the carpooling incentive campaign description to include "Mobicoop" as an operator.
  
- **Bug Fixes**
	- Clarified that "Klaxit" is no longer a partner operator as of July 2024.
	- Reiterated that class B trips have not been eligible since September 1, 2022.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->