### PR TITLE
fix: MAJ Campagne Nantes Métropole

### DIFF
--- a/api/src/pdc/services/policy/engine/helpers/dateRange.ts
+++ b/api/src/pdc/services/policy/engine/helpers/dateRange.ts
@@ -1,0 +1,25 @@
+/**
+ * Generate a list of dates between two dates
+ *
+ * @example
+ * const boosterDates = [
+ *  ...dateRange("2022-01-01", "2022-01-03"),
+ * ];
+ *
+ * @param r
+ * @returns
+ */
+export function dateRange(...r: Array<Date | string>): string[] {
+  const range = r
+    .map((d) => (typeof d === "string" ? new Date(d) : d))
+    .sort((a, b) => a.getTime() - b.getTime());
+  const dates: string[] = [];
+
+  const currentDate = range[0];
+  while (currentDate <= range[range.length - 1]) {
+    dates.push(currentDate.toISOString().split("T")[0]);
+    currentDate.setDate(currentDate.getDate() + 1);
+  }
+
+  return dates.map((date) => date.slice(0, 10));
+}

--- a/api/src/pdc/services/policy/engine/helpers/dateRange.ts
+++ b/api/src/pdc/services/policy/engine/helpers/dateRange.ts
@@ -6,35 +6,50 @@
  *  ...dateRange("2022-01-01", "2022-01-03"),
  * ];
  *
- * @param r
+ * @param dates
  * @returns
  */
-export function dateRange(...r: Array<Date | string>): string[] {
-  if (r.length === 0) {
+export function dateRange(...dates: Array<Date | string>): string[] {
+  if (dates.length === 0) {
     throw new Error("At least one date is required");
   }
 
-  const range = r
+  const [first, ...rest] = castAndSort(dates);
+  const last = rest.pop();
+
+  return last ? fill(first, last) : [format(first)];
+}
+
+function castAndSort(range: Array<Date | string>): Set<Date> {
+  return range
     .map((d) => {
       const date = typeof d === "string" ? new Date(d) : d;
-      if (isNaN(date.getTime())) {
-        throw new Error("Invalid Date");
+      if (Number.isNaN(date.getTime())) {
+        throw new Error(`Invalid Date`);
       }
       date.setHours(0, 0, 0, 0);
       return date;
     })
-    .sort((a, b) => a.getTime() - b.getTime());
+    .sort((a, b) => a.getTime() - b.getTime())
+    .reduce((acc, d) => {
+      acc.add(d);
+      return acc;
+    }, new Set<Date>());
+}
 
-  const start = new Date(range[0]);
-  const end = range[range.length - 1];
-  const dates: string[] = [];
+function format(d: Date): string {
+  const year = d.getFullYear();
+  const month = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
 
-  for (let d = start; d <= end; d.setDate(d.getDate() + 1)) {
-    const year = d.getFullYear();
-    const month = String(d.getMonth() + 1).padStart(2, "0");
-    const day = String(d.getDate()).padStart(2, "0");
-    dates.push(`${year}-${month}-${day}`);
+function fill(first: Date, last: Date): Array<string> {
+  const dates = new Set<string>();
+  let d;
+  for (d = first; d <= last; d.setDate(d.getDate() + 1)) {
+    dates.add(format(d));
   }
 
-  return dates;
+  return [...dates];
 }

--- a/api/src/pdc/services/policy/engine/helpers/dateRange.ts
+++ b/api/src/pdc/services/policy/engine/helpers/dateRange.ts
@@ -46,9 +46,10 @@ function format(d: Date): string {
 
 function fill(first: Date, last: Date): Array<string> {
   const dates = new Set<string>();
-  let d;
-  for (d = first; d <= last; d.setDate(d.getDate() + 1)) {
-    dates.add(format(d));
+  const current = new Date(first);
+  while (current <= last) {
+    dates.add(format(current));
+    current.setDate(current.getDate() + 1);
   }
 
   return [...dates];

--- a/api/src/pdc/services/policy/engine/helpers/dateRange.ts
+++ b/api/src/pdc/services/policy/engine/helpers/dateRange.ts
@@ -10,16 +10,31 @@
  * @returns
  */
 export function dateRange(...r: Array<Date | string>): string[] {
-  const range = r
-    .map((d) => (typeof d === "string" ? new Date(d) : d))
-    .sort((a, b) => a.getTime() - b.getTime());
-  const dates: string[] = [];
-
-  const currentDate = range[0];
-  while (currentDate <= range[range.length - 1]) {
-    dates.push(currentDate.toISOString().split("T")[0]);
-    currentDate.setDate(currentDate.getDate() + 1);
+  if (r.length === 0) {
+    throw new Error("At least one date is required");
   }
 
-  return dates.map((date) => date.slice(0, 10));
+  const range = r
+    .map((d) => {
+      const date = typeof d === "string" ? new Date(d) : d;
+      if (isNaN(date.getTime())) {
+        throw new Error("Invalid Date");
+      }
+      date.setHours(0, 0, 0, 0);
+      return date;
+    })
+    .sort((a, b) => a.getTime() - b.getTime());
+
+  const start = new Date(range[0]);
+  const end = range[range.length - 1];
+  const dates: string[] = [];
+
+  for (let d = start; d <= end; d.setDate(d.getDate() + 1)) {
+    const year = d.getFullYear();
+    const month = String(d.getMonth() + 1).padStart(2, "0");
+    const day = String(d.getDate()).padStart(2, "0");
+    dates.push(`${year}-${month}-${day}`);
+  }
+
+  return dates;
 }

--- a/api/src/pdc/services/policy/engine/helpers/dateRange.unit.spec.ts
+++ b/api/src/pdc/services/policy/engine/helpers/dateRange.unit.spec.ts
@@ -1,0 +1,40 @@
+import { assertEquals, describe, it } from "@/dev_deps.ts";
+import { dateRange } from "./dateRange.ts";
+
+describe("dateRange", () => {
+  it("should return a range of dates", () => {
+    const start = new Date("2022-01-01");
+    const end = new Date("2022-01-03");
+    const result = dateRange(start, end);
+    assertEquals(result, ["2022-01-01", "2022-01-02", "2022-01-03"]);
+  });
+
+  it("should return a range of dates when given strings", () => {
+    const start = "2022-01-01";
+    const end = "2022-01-03";
+    const result = dateRange(start, end);
+    assertEquals(result, ["2022-01-01", "2022-01-02", "2022-01-03"]);
+  });
+
+  it("should return a range over several months", () => {
+    const start = "2022-01-30";
+    const end = "2022-02-02";
+    const result = dateRange(start, end);
+    assertEquals(result, ["2022-01-30", "2022-01-31", "2022-02-01", "2022-02-02"]);
+  });
+
+  it("should sort input dates", () => {
+    const start = "2022-01-03";
+    const end = "2022-01-01";
+    const result = dateRange(start, end);
+    assertEquals(result, ["2022-01-01", "2022-01-02", "2022-01-03"]);
+  });
+
+  it("should sort more than two dates", () => {
+    const start = "2022-01-03";
+    const middle = "2022-01-02";
+    const end = "2022-01-01";
+    const result = dateRange(start, middle, end);
+    assertEquals(result, ["2022-01-01", "2022-01-02", "2022-01-03"]);
+  });
+});

--- a/api/src/pdc/services/policy/engine/helpers/dateRange.unit.spec.ts
+++ b/api/src/pdc/services/policy/engine/helpers/dateRange.unit.spec.ts
@@ -37,4 +37,34 @@ describe("dateRange", () => {
     const result = dateRange(start, middle, end);
     assertEquals(result, ["2022-01-01", "2022-01-02", "2022-01-03"]);
   });
+
+  it("should handle invalid date format", () => {
+    const start = "2022-13-45";
+    const end = "2022-01-03";
+    try {
+      dateRange(start, end);
+    } catch (e) {
+      assertEquals(e.message, "Invalid Date");
+    }
+  });
+
+  it("should handle malformed date strings", () => {
+    const start = "not-a-date";
+    const end = "2022-01-03";
+    try {
+      dateRange(start, end);
+    } catch (e) {
+      assertEquals(e.message, "Invalid Date");
+    }
+  });
+
+  it("should handle empty string input", () => {
+    const start = "";
+    const end = "2022-01-03";
+    try {
+      dateRange(start, end);
+    } catch (e) {
+      assertEquals(e.message, "Invalid Date");
+    }
+  });
 });

--- a/api/src/pdc/services/policy/engine/helpers/dateRange.unit.spec.ts
+++ b/api/src/pdc/services/policy/engine/helpers/dateRange.unit.spec.ts
@@ -38,6 +38,14 @@ describe("dateRange", () => {
     assertEquals(result, ["2022-01-01", "2022-01-02", "2022-01-03"]);
   });
 
+  it("should handle no input", () => {
+    try {
+      dateRange();
+    } catch (e) {
+      assertEquals(e.message, "At least one date is required");
+    }
+  });
+
   it("should handle invalid date format", () => {
     const start = "2022-13-45";
     const end = "2022-01-03";

--- a/api/src/pdc/services/policy/engine/helpers/dateRange.unit.spec.ts
+++ b/api/src/pdc/services/policy/engine/helpers/dateRange.unit.spec.ts
@@ -67,4 +67,24 @@ describe("dateRange", () => {
       assertEquals(e.message, "Invalid Date");
     }
   });
+
+  it("should handle single date input", () => {
+    const date = "2022-01-01";
+    const result = dateRange(date);
+    assertEquals(result, ["2022-01-01"]);
+  });
+
+  it("should handle same date for start and end", () => {
+    const start = "2022-01-01";
+    const end = "2022-01-01";
+    const result = dateRange(start, end);
+    assertEquals(result, ["2022-01-01"]);
+  });
+
+  it("should handle large date ranges", () => {
+    const start = "2022-01-01";
+    const end = "2022-12-31";
+    const result = dateRange(start, end);
+    assertEquals(result.length, 365);
+  });
 });

--- a/api/src/pdc/services/policy/engine/policies/20240101_NantesMetropole.html.ts
+++ b/api/src/pdc/services/policy/engine/policies/20240101_NantesMetropole.html.ts
@@ -1,5 +1,4 @@
-export const description =
-  `<div _ngcontent-fyn-c231="" id="summary" class="campaignSummaryText-content-text">
+export const description = `<div _ngcontent-fyn-c231="" id="summary" class="campaignSummaryText-content-text">
 
   <p>Campagne d'incitation au covoiturage du <b> 01 janvier 2024 au 31 Décembre 2025</b></p>
   
@@ -26,7 +25,25 @@ export const description =
     <li><b>De 17 à 29,5 km : 0.10 € par trajet par km par passager avec un maximum de 2,90 €</b></li>
     <li><b>De 29,5 à 60 km : 2,90 € par passager transporté</b></li>
   </ul>
-  
+
+  <p>
+    Les trajets au départ OU à l'arrivée dans Nantes Métropôle effectués au sein
+    des Pays de la Loire sont incités selon les règles suivantes dans les conditions
+    "booster" uniquement :
+  </p>
+
+  <ul>
+    <li><b>De 5 à 60 km : 0,90 € par passager transporté</b></li>
+  </ul>
+
+  <p>
+    Les mois déclarés comme <b>"booster"</b> sont les suivants :
+  </p>
+
+  <ul>
+    <li>Décembre 2024</li>
+  </ul>
+
   <p>Les restrictions suivantes seront appliquées :</p>
   
   <ul>

--- a/api/src/pdc/services/policy/engine/policies/20240101_NantesMetropole.ts
+++ b/api/src/pdc/services/policy/engine/policies/20240101_NantesMetropole.ts
@@ -1,9 +1,7 @@
 import { Timezone } from "@/pdc/providers/validator/types.ts";
 import { NotEligibleTargetException } from "@/pdc/services/policy/engine/exceptions/NotEligibleTargetException.ts";
-import {
-  getOperatorsAt,
-  TimestampedOperators,
-} from "@/pdc/services/policy/engine/helpers/getOperatorsAt.ts";
+import { dateRange } from "@/pdc/services/policy/engine/helpers/dateRange.ts";
+import { getOperatorsAt, TimestampedOperators } from "@/pdc/services/policy/engine/helpers/getOperatorsAt.ts";
 import { isAdultOrThrow } from "@/pdc/services/policy/engine/helpers/isAdultOrThrow.ts";
 import { isOperatorClassOrThrow } from "@/pdc/services/policy/engine/helpers/isOperatorClassOrThrow.ts";
 import { isOperatorOrThrow } from "@/pdc/services/policy/engine/helpers/isOperatorOrThrow.ts";
@@ -14,15 +12,9 @@ import {
   watchForPersonMaxAmountByYear,
   watchForPersonMaxTripByDay,
 } from "@/pdc/services/policy/engine/helpers/limits.ts";
-import {
-  onDistanceRange,
-  onDistanceRangeOrThrow,
-} from "@/pdc/services/policy/engine/helpers/onDistanceRange.ts";
+import { onDistanceRange, onDistanceRangeOrThrow } from "@/pdc/services/policy/engine/helpers/onDistanceRange.ts";
 import { perKm, perSeat } from "@/pdc/services/policy/engine/helpers/per.ts";
-import {
-  endsAt,
-  startsAt,
-} from "@/pdc/services/policy/engine/helpers/position.ts";
+import { endsAt, startsAt } from "@/pdc/services/policy/engine/helpers/position.ts";
 import { AbstractPolicyHandler } from "@/pdc/services/policy/engine/policies/AbstractPolicyHandler.ts";
 import { toTzString } from "@/pdc/services/policy/helpers/index.ts";
 import { RunnableSlices } from "@/pdc/services/policy/interfaces/engine/PolicyInterface.ts";
@@ -36,23 +28,33 @@ import {
 import { description } from "./20240101_NantesMetropole.html.ts";
 
 // Politique de Pays de la Loire 2024
-/* eslint-disable-next-line */
-export const NantesMetropole2024: PolicyHandlerStaticInterface = class
-  extends AbstractPolicyHandler
+export const NantesMetropole2024: PolicyHandlerStaticInterface = class extends AbstractPolicyHandler
   implements PolicyHandlerInterface {
   static readonly id = "nantes_metropole_2024";
   static readonly tz: Timezone = "Europe/Paris";
 
-  public static mode<T>(date: Date, regular: T, booster: T): T {
-    if (!NantesMetropole2024.boosterDates) return regular;
+  public static mode<T>(
+    date: Date,
+    isInside: boolean,
+    regularInside: T,
+    regularOutside: T,
+    boosterInside: T,
+    boosterOutside: T,
+  ): T {
+    if (!NantesMetropole2024.boosterDates) return isInside ? regularInside : regularOutside;
+
     const ymd = toTzString(date).slice(0, 10);
-    return NantesMetropole2024.boosterDates.includes(ymd) ? booster : regular;
+    if (NantesMetropole2024.boosterDates.includes(ymd)) {
+      return isInside ? boosterInside : boosterOutside;
+    } else {
+      return isInside ? regularInside : regularOutside;
+    }
   }
 
   // Liste de dates au format YYYY-MM-DD dans la zone Europe/Paris
   // pour lesquelles les règles de booster s'appliquent
-  protected boosterDates: string[] = [
-    // Configure the booster dates here!
+  protected static boosterDates: string[] = [
+    ...dateRange("2024-12-01", "2024-12-31"),
   ];
 
   protected operators: TimestampedOperators = [
@@ -75,7 +77,7 @@ export const NantesMetropole2024: PolicyHandlerStaticInterface = class
     },
   ];
 
-  protected regularSlices: RunnableSlices = [
+  protected regularInsideSlices: RunnableSlices = [
     {
       start: 5_000,
       end: 17_000,
@@ -86,13 +88,7 @@ export const NantesMetropole2024: PolicyHandlerStaticInterface = class
       end: 29_500,
       fn: (ctx: StatelessContextInterface) => {
         // 0,10 euro par trajet par km par passager avec un maximum de 2,00 euros
-        return perSeat(
-          ctx,
-          Math.min(
-            perKm(ctx, { amount: 10, offset: 17_000, limit: 29_500 }),
-            200 - 75,
-          ),
-        );
+        return perSeat(ctx, Math.min(perKm(ctx, { amount: 10, offset: 17_000, limit: 29_500 }), 200 - 75));
       },
     },
     {
@@ -102,7 +98,25 @@ export const NantesMetropole2024: PolicyHandlerStaticInterface = class
     },
   ];
 
-  protected boosterSlices: RunnableSlices = [
+  protected regularOutsideSlices: RunnableSlices = [
+    {
+      start: 5_000,
+      end: 17_000,
+      fn: () => 0,
+    },
+    {
+      start: 17_000,
+      end: 29_500,
+      fn: () => 0,
+    },
+    {
+      start: 29_500,
+      end: 60_000,
+      fn: () => 0,
+    },
+  ];
+
+  protected boosterInsideSlices: RunnableSlices = [
     {
       start: 5_000,
       end: 17_000,
@@ -113,14 +127,26 @@ export const NantesMetropole2024: PolicyHandlerStaticInterface = class
       end: 29_500,
       fn: (ctx: StatelessContextInterface) => {
         // 0,10 euro par trajet par km par passager avec un maximum de 2,90 euros
-        return perSeat(
-          ctx,
-          Math.min(
-            perKm(ctx, { amount: 10, offset: 17_000, limit: 29_500 }),
-            290 - 165,
-          ),
-        );
+        return perSeat(ctx, Math.min(perKm(ctx, { amount: 10, offset: 17_000, limit: 29_500 }), 290 - 165));
       },
+    },
+    {
+      start: 29_500,
+      end: 60_000,
+      fn: () => 0,
+    },
+  ];
+
+  protected boosterOutsideSlices: RunnableSlices = [
+    {
+      start: 5_000,
+      end: 17_000,
+      fn: (ctx: StatelessContextInterface) => perSeat(ctx, 90),
+    },
+    {
+      start: 17_000,
+      end: 29_500,
+      fn: () => 0,
     },
     {
       start: 29_500,
@@ -158,31 +184,8 @@ export const NantesMetropole2024: PolicyHandlerStaticInterface = class
     ];
   }
 
-  protected processExclusion(ctx: StatelessContextInterface) {
-    isOperatorOrThrow(
-      ctx,
-      getOperatorsAt(this.operators, ctx.carpool.datetime),
-    );
-    onDistanceRangeOrThrow(ctx, { min: 5_000, max: 60_001 });
-    isOperatorClassOrThrow(ctx, ["C"]);
-    isAdultOrThrow(ctx);
-
-    // Exclusion des OD des autres régions
-    if (!startsAt(ctx, { reg: ["52"] }) || !endsAt(ctx, { reg: ["52"] })) {
-      throw new NotEligibleTargetException();
-    }
-
-    // Exclusion des OD des autres AOM
-    if (
-      !startsAt(ctx, { aom: ["244400404"] }) ||
-      !endsAt(ctx, { aom: ["244400404"] })
-    ) {
-      throw new NotEligibleTargetException();
-    }
-  }
-
-  processStateless(ctx: StatelessContextInterface): void {
-    this.processExclusion(ctx);
+  public processStateless(ctx: StatelessContextInterface): void {
+    this.processExclusions(ctx);
     super.processStateless(ctx);
 
     if (!NantesMetropole2024.mode) {
@@ -190,11 +193,15 @@ export const NantesMetropole2024: PolicyHandlerStaticInterface = class
     }
 
     let amount = 0;
-    const slices = NantesMetropole2024.mode(
+    const slices = NantesMetropole2024.mode<RunnableSlices>(
       ctx.carpool.datetime,
-      this.regularSlices,
-      this.boosterSlices,
+      this.isInsideNantesMetropole(ctx),
+      this.regularInsideSlices,
+      this.regularOutsideSlices,
+      this.boosterInsideSlices,
+      this.boosterOutsideSlices,
     );
+
     for (const { start, fn } of slices) {
       if (onDistanceRange(ctx, { min: start })) {
         amount += fn(ctx);
@@ -204,28 +211,61 @@ export const NantesMetropole2024: PolicyHandlerStaticInterface = class
     ctx.incentive.set(amount);
   }
 
-  params(date?: Date): PolicyHandlerParamsInterface {
+  public params(date?: Date): PolicyHandlerParamsInterface {
     if (!NantesMetropole2024.mode) {
       throw new Error("NantesMetropole2024.mode is not defined");
     }
 
+    const slices = date
+      ? NantesMetropole2024.mode<RunnableSlices>(
+        date,
+        true,
+        this.regularInsideSlices,
+        this.regularOutsideSlices,
+        this.boosterInsideSlices,
+        this.boosterOutsideSlices,
+      )
+      : this.regularInsideSlices;
+
     return {
       tz: NantesMetropole2024.tz,
-      slices: date
-        ? NantesMetropole2024.mode(date, this.regularSlices, this.boosterSlices)
-        : this.regularSlices,
-      booster_dates: this.boosterDates,
+      slices,
+      booster_dates: NantesMetropole2024.boosterDates,
       operators: getOperatorsAt(this.operators),
-      allTimeOperators: Array.from(
-        new Set(this.operators.flatMap((entry) => entry.operators)),
-      ),
+      allTimeOperators: Array.from(new Set(this.operators.flatMap((entry) => entry.operators))),
       limits: {
         glob: this.max_amount,
       },
     };
   }
 
-  describe(): string {
+  public describe(): string {
     return description;
+  }
+
+  protected processExclusions(ctx: StatelessContextInterface) {
+    isOperatorOrThrow(ctx, getOperatorsAt(this.operators, ctx.carpool.datetime));
+    onDistanceRangeOrThrow(ctx, { min: 5_000, max: 60_001 });
+    isOperatorClassOrThrow(ctx, ["C"]);
+    isAdultOrThrow(ctx);
+
+    this.isInsideTheRegion(ctx);
+    this.startsOrEndsInNantesMetropole(ctx);
+  }
+
+  protected startsOrEndsInNantesMetropole(ctx: StatelessContextInterface) {
+    if (!startsAt(ctx, { aom: ["244400404"] }) && !endsAt(ctx, { aom: ["244400404"] })) {
+      throw new NotEligibleTargetException();
+    }
+  }
+
+  protected isInsideTheRegion(ctx: StatelessContextInterface) {
+    if (!startsAt(ctx, { reg: ["52"] }) || !endsAt(ctx, { reg: ["52"] })) {
+      throw new NotEligibleTargetException();
+    }
+  }
+
+  protected isInsideNantesMetropole(ctx: StatelessContextInterface): boolean {
+    return startsAt(ctx, { aom: ["244400404"] }) && endsAt(ctx, { aom: ["244400404"] });
   }
 };

--- a/api/src/pdc/services/policy/engine/policies/20240101_NantesMetropole.unit.spec.ts
+++ b/api/src/pdc/services/policy/engine/policies/20240101_NantesMetropole.unit.spec.ts
@@ -1,4 +1,4 @@
-import { it, sinon } from "@/dev_deps.ts";
+import { it } from "@/dev_deps.ts";
 import { v4 as uuidV4 } from "@/lib/uuid/index.ts";
 import { OperatorsEnum } from "../../interfaces/index.ts";
 import { makeProcessHelper } from "../tests/macro.ts";
@@ -43,324 +43,348 @@ const defaultCarpool = {
 
 const process = makeProcessHelper(defaultCarpool);
 
-// Stub the mode method to control the booster date in tests
-const boosterDates: string[] = ["2024-04-16"];
-sinon.stub(Handler, "mode").callsFake(
-  (date: Date, regular: any, booster: any) => {
-    const ymd = date.toISOString().slice(0, 10);
-    return boosterDates.includes(ymd) ? booster : regular;
-  },
-);
+it("should work with exclusions", async () =>
+  await process(
+    {
+      policy: { handler: Handler.id },
+      carpool: [
+        { distance: 4_999 },
+        { distance: 60_001 },
+        { operator_class: "A" },
 
-it(
-  "should work with exclusions",
-  async () =>
-    await process(
-      {
-        policy: { handler: Handler.id },
-        carpool: [
-          { distance: 4_999 },
-          { distance: 60_001 },
-          { operator_class: "A" },
+        // // OD hors AOM
+        {
+          start: { ...defaultPosition, aom: "244900015" },
+          end: { ...defaultPosition, aom: "244900015" },
+        },
 
-          // // OD hors AOM
-          {
-            start: { ...defaultPosition, aom: "244900015" },
-            end: { ...defaultPosition, aom: "244900015" },
-          },
+        // O dans l'AOM et D hors AOM
+        {
+          start: { ...defaultPosition, aom: "244400404" },
+          end: { ...defaultPosition, aom: "247200132" },
+        },
 
-          // O dans l'AOM et D hors AOM
-          {
-            start: { ...defaultPosition, aom: "244400404" },
-            end: { ...defaultPosition, aom: "247200132" },
-          },
+        // O hors AOM et D dans l'AOM
+        {
+          start: { ...defaultPosition, aom: "200071678" },
+          end: { ...defaultPosition, aom: "244400404" },
+        },
 
-          // O hors AOM et D dans l'AOM
-          {
-            start: { ...defaultPosition, aom: "200071678" },
-            end: { ...defaultPosition, aom: "244400404" },
-          },
+        // // Région Île-de-France
+        { start: { ...defaultPosition, reg: "11" } },
+        { end: { ...defaultPosition, reg: "11" } },
+        { passenger_is_over_18: false },
+      ],
+    },
+    { incentive: [0, 0, 0, 0, 0, 0, 0, 0, 0] },
+  ));
 
-          // // Région Île-de-France
-          { start: { ...defaultPosition, reg: "11" } },
-          { end: { ...defaultPosition, reg: "11" } },
-          { passenger_is_over_18: false },
-        ],
-        meta: [],
-      },
-      { incentive: [0, 0, 0, 0, 0, 0, 0, 0, 0], meta: [] },
-    ),
-);
+it("should work basic", async () =>
+  await process(
+    {
+      policy: { handler: Handler.id },
+      carpool: [
+        { distance: 1_000, driver_identity_key: "one" },
+        { distance: 5_000, driver_identity_key: "one" },
+        { distance: 5_000, seats: 2, driver_identity_key: "one" },
+        { distance: 20_000, driver_identity_key: "two" },
+        { distance: 25_000, driver_identity_key: "two" },
+        { distance: 29_500, driver_identity_key: "two" },
+        { distance: 30_000, driver_identity_key: "two" },
+        { distance: 55_000, driver_identity_key: "two" },
+        { distance: 61_000, driver_identity_key: "two" },
+      ],
+      meta: [],
+    },
+    {
+      incentive: [0, 75, 150, 105, 155, 200, 200, 200, 0],
+      meta: [
+        {
+          key: "max_amount_restriction.global.campaign.global",
+          value: 1085,
+        },
+        {
+          key: "max_amount_restriction.0-one.month.3-2024",
+          value: 225,
+        },
+        {
+          key: "max_amount_restriction.0-one.year.2024",
+          value: 225,
+        },
+        {
+          key: "max_amount_restriction.0-two.month.3-2024",
+          value: 860,
+        },
+        {
+          key: "max_amount_restriction.0-two.year.2024",
+          value: 860,
+        },
+      ],
+    },
+  ));
 
-it(
-  "should work basic",
-  async () =>
-    await process(
-      {
-        policy: { handler: Handler.id },
-        carpool: [
-          { distance: 1_000, driver_identity_key: "one" },
-          { distance: 5_000, driver_identity_key: "one" },
-          { distance: 5_000, seats: 2, driver_identity_key: "one" },
-          { distance: 20_000, driver_identity_key: "two" },
-          { distance: 25_000, driver_identity_key: "two" },
-          { distance: 29_500, driver_identity_key: "two" },
-          { distance: 30_000, driver_identity_key: "two" },
-          { distance: 55_000, driver_identity_key: "two" },
-          { distance: 61_000, driver_identity_key: "two" },
-        ],
-        meta: [],
-      },
-      {
-        incentive: [0, 75, 150, 105, 155, 200, 200, 200, 0],
-        meta: [
-          {
-            key: "max_amount_restriction.global.campaign.global",
-            value: 1085,
-          },
-          {
-            key: "max_amount_restriction.0-one.month.3-2024",
-            value: 225,
-          },
-          {
-            key: "max_amount_restriction.0-one.year.2024",
-            value: 225,
-          },
-          {
-            key: "max_amount_restriction.0-two.month.3-2024",
-            value: 860,
-          },
-          {
-            key: "max_amount_restriction.0-two.year.2024",
-            value: 860,
-          },
-        ],
-      },
-    ),
-);
+it("should work with global limits", async () =>
+  await process(
+    {
+      policy: { handler: Handler.id, max_amount: 2_200_000_00 },
+      carpool: [{ distance: 5_000, driver_identity_key: "one" }],
+      meta: [
+        {
+          key: "max_amount_restriction.global.campaign.global",
+          value: 2_199_999_25,
+        },
+      ],
+    },
+    {
+      incentive: [75],
+      meta: [
+        {
+          key: "max_amount_restriction.global.campaign.global",
+          value: 2_200_000_00,
+        },
+        {
+          key: "max_amount_restriction.0-one.month.3-2024",
+          value: 75,
+        },
+        {
+          key: "max_amount_restriction.0-one.year.2024",
+          value: 75,
+        },
+      ],
+    },
+  ));
 
-it(
-  "should work with global limits",
-  async () =>
-    await process(
-      {
-        policy: { handler: Handler.id, max_amount: 2_200_000_00 },
-        carpool: [{ distance: 5_000, driver_identity_key: "one" }],
-        meta: [
-          {
-            key: "max_amount_restriction.global.campaign.global",
-            value: 2_199_999_25,
-          },
-        ],
-      },
-      {
-        incentive: [75],
-        meta: [
-          {
-            key: "max_amount_restriction.global.campaign.global",
-            value: 2_200_000_00,
-          },
-          {
-            key: "max_amount_restriction.0-one.month.3-2024",
-            value: 75,
-          },
-          {
-            key: "max_amount_restriction.0-one.year.2024",
-            value: 75,
-          },
-        ],
-      },
-    ),
-);
+it("should work with day limits", async () =>
+  await process(
+    {
+      policy: { handler: Handler.id },
+      carpool: [
+        { distance: 5_000, driver_identity_key: "one" },
+        { distance: 5_000, driver_identity_key: "one" },
+        { distance: 5_000, driver_identity_key: "one" },
+        { distance: 5_000, driver_identity_key: "one" },
+        { distance: 5_000, driver_identity_key: "one" },
+        { distance: 5_000, driver_identity_key: "one" },
+        { distance: 5_000, driver_identity_key: "one" },
+      ],
+      meta: [],
+    },
+    {
+      incentive: [75, 75, 75, 75, 75, 75, 0],
+      meta: [
+        {
+          key: "max_amount_restriction.global.campaign.global",
+          value: 450,
+        },
+        {
+          key: "max_amount_restriction.0-one.month.3-2024",
+          value: 450,
+        },
+        {
+          key: "max_amount_restriction.0-one.year.2024",
+          value: 450,
+        },
+      ],
+    },
+  ));
 
-it(
-  "should work with day limits",
-  async () =>
-    await process(
-      {
-        policy: { handler: Handler.id },
-        carpool: [
-          { distance: 5_000, driver_identity_key: "one" },
-          { distance: 5_000, driver_identity_key: "one" },
-          { distance: 5_000, driver_identity_key: "one" },
-          { distance: 5_000, driver_identity_key: "one" },
-          { distance: 5_000, driver_identity_key: "one" },
-          { distance: 5_000, driver_identity_key: "one" },
-          { distance: 5_000, driver_identity_key: "one" },
-        ],
-        meta: [],
-      },
-      {
-        incentive: [75, 75, 75, 75, 75, 75, 0],
-        meta: [
-          {
-            key: "max_amount_restriction.global.campaign.global",
-            value: 450,
-          },
-          {
-            key: "max_amount_restriction.0-one.month.3-2024",
-            value: 450,
-          },
-          {
-            key: "max_amount_restriction.0-one.year.2024",
-            value: 450,
-          },
-        ],
-      },
-    ),
-);
+it("should work with driver month limits of 84 €", async () =>
+  await process(
+    {
+      policy: { handler: Handler.id },
+      carpool: [
+        { distance: 6_000, driver_identity_key: "one" },
+        { distance: 6_000, driver_identity_key: "one" },
+      ],
+      meta: [
+        {
+          key: "max_amount_restriction.global.campaign.global",
+          value: 100_00,
+        },
+        {
+          key: "max_amount_restriction.0-one.month.3-2024",
+          value: 83_25,
+        },
+        {
+          key: "max_amount_restriction.0-one.year.2024",
+          value: 83_25,
+        },
+      ],
+    },
+    {
+      incentive: [75, 0],
+      meta: [
+        {
+          key: "max_amount_restriction.global.campaign.global",
+          value: 100_75,
+        },
+        {
+          key: "max_amount_restriction.0-one.month.3-2024",
+          value: 84_00,
+        },
+        {
+          key: "max_amount_restriction.0-one.year.2024",
+          value: 84_75,
+        },
+      ],
+    },
+  ));
 
-it(
-  "should work with driver month limits of 84 €",
-  async () =>
-    await process(
-      {
-        policy: { handler: Handler.id },
-        carpool: [
-          { distance: 6_000, driver_identity_key: "one" },
-          { distance: 6_000, driver_identity_key: "one" },
-        ],
-        meta: [
-          {
-            key: "max_amount_restriction.global.campaign.global",
-            value: 100_00,
-          },
-          {
-            key: "max_amount_restriction.0-one.month.3-2024",
-            value: 83_25,
-          },
-          {
-            key: "max_amount_restriction.0-one.year.2024",
-            value: 83_25,
-          },
-        ],
-      },
-      {
-        incentive: [75, 0],
-        meta: [
-          {
-            key: "max_amount_restriction.global.campaign.global",
-            value: 100_75,
-          },
-          {
-            key: "max_amount_restriction.0-one.month.3-2024",
-            value: 84_00,
-          },
-          {
-            key: "max_amount_restriction.0-one.year.2024",
-            value: 84_75,
-          },
-        ],
-      },
-    ),
-);
+it("should work with driver year limits of 1008.00 €", async () =>
+  await process(
+    {
+      policy: { handler: Handler.id },
+      carpool: [
+        { distance: 6_000, driver_identity_key: "one" },
+        { distance: 6_000, driver_identity_key: "one" },
+      ],
+      meta: [
+        {
+          key: "max_amount_restriction.global.campaign.global",
+          value: 100_00,
+        },
+        {
+          key: "max_amount_restriction.0-one.month.3-2024",
+          value: 0,
+        },
+        {
+          key: "max_amount_restriction.0-one.year.2024",
+          value: 1007_25,
+        },
+      ],
+    },
+    {
+      incentive: [75, 0],
+      meta: [
+        {
+          key: "max_amount_restriction.global.campaign.global",
+          value: 100_75,
+        },
+        {
+          key: "max_amount_restriction.0-one.month.3-2024",
+          value: 75,
+        },
+        {
+          key: "max_amount_restriction.0-one.year.2024",
+          value: 1008_00,
+        },
+      ],
+    },
+  ));
 
-it(
-  "should work with driver year limits of 1008.00 €",
-  async () =>
-    await process(
-      {
-        policy: { handler: Handler.id },
-        carpool: [
-          { distance: 6_000, driver_identity_key: "one" },
-          { distance: 6_000, driver_identity_key: "one" },
-        ],
-        meta: [
-          {
-            key: "max_amount_restriction.global.campaign.global",
-            value: 100_00,
-          },
-          {
-            key: "max_amount_restriction.0-one.month.3-2024",
-            value: 0,
-          },
-          {
-            key: "max_amount_restriction.0-one.year.2024",
-            value: 1007_25,
-          },
-        ],
-      },
-      {
-        incentive: [75, 0],
-        meta: [
-          {
-            key: "max_amount_restriction.global.campaign.global",
-            value: 100_75,
-          },
-          {
-            key: "max_amount_restriction.0-one.month.3-2024",
-            value: 75,
-          },
-          {
-            key: "max_amount_restriction.0-one.year.2024",
-            value: 1008_00,
-          },
-        ],
-      },
-    ),
-);
+it("should use boosterSlices on booster dates", async () =>
+  await process(
+    {
+      policy: { handler: Handler.id },
+      carpool: [
+        {
+          distance: 6_000,
+          driver_identity_key: "reg",
+          datetime: new Date("2024-04-15"),
+        },
+        {
+          distance: 6_000,
+          driver_identity_key: "boo",
+          datetime: new Date("2024-12-01"),
+        },
+        {
+          distance: 11_000,
+          driver_identity_key: "reg",
+          datetime: new Date("2024-04-15"),
+        },
+        {
+          distance: 11_000,
+          driver_identity_key: "boo",
+          datetime: new Date("2024-12-01"),
+        },
+        {
+          distance: 17_000,
+          driver_identity_key: "reg",
+          datetime: new Date("2024-04-15"),
+        },
+        {
+          distance: 17_000,
+          driver_identity_key: "boo",
+          datetime: new Date("2024-12-01"),
+        },
+        {
+          distance: 30_000,
+          driver_identity_key: "reg",
+          datetime: new Date("2024-04-15"),
+        },
+        {
+          distance: 30_000,
+          driver_identity_key: "boo",
+          datetime: new Date("2024-12-01"),
+        },
+        {
+          distance: 75_000,
+          driver_identity_key: "reg",
+          datetime: new Date("2024-04-15"),
+        },
+        {
+          distance: 75_000,
+          driver_identity_key: "boo",
+          datetime: new Date("2024-12-01"),
+        },
+      ],
+    },
+    {
+      incentive: [75, 165, 75, 165, 75, 165, 200, 290, 0, 0],
+    },
+  ));
 
-it(
-  "should use boosterSlices on booster dates",
-  async () =>
-    await process(
-      {
-        policy: { handler: Handler.id },
-        carpool: [
-          {
-            distance: 6_000,
-            driver_identity_key: "reg",
-            datetime: new Date("2024-04-15"),
-          },
-          {
-            distance: 6_000,
-            driver_identity_key: "boo",
-            datetime: new Date("2024-04-16"),
-          },
-          {
-            distance: 11_000,
-            driver_identity_key: "reg",
-            datetime: new Date("2024-04-15"),
-          },
-          {
-            distance: 11_000,
-            driver_identity_key: "boo",
-            datetime: new Date("2024-04-16"),
-          },
-          {
-            distance: 17_000,
-            driver_identity_key: "reg",
-            datetime: new Date("2024-04-15"),
-          },
-          {
-            distance: 17_000,
-            driver_identity_key: "boo",
-            datetime: new Date("2024-04-16"),
-          },
-          {
-            distance: 30_000,
-            driver_identity_key: "reg",
-            datetime: new Date("2024-04-15"),
-          },
-          {
-            distance: 30_000,
-            driver_identity_key: "boo",
-            datetime: new Date("2024-04-16"),
-          },
-          {
-            distance: 75_000,
-            driver_identity_key: "reg",
-            datetime: new Date("2024-04-15"),
-          },
-          {
-            distance: 75_000,
-            driver_identity_key: "boo",
-            datetime: new Date("2024-04-16"),
-          },
-        ],
-      },
-      {
-        incentive: [75, 165, 75, 165, 75, 165, 200, 290, 0, 0],
-      },
-    ),
-);
+it("should detect trips inside the AOM", async () =>
+  await process(
+    {
+      policy: { handler: Handler.id },
+      carpool: [
+        // regular - inside
+        { distance: 6_000, driver_identity_key: "one", datetime: new Date("2024-04-15") },
+
+        // // booster - inside
+        { distance: 6_000, driver_identity_key: "one", datetime: new Date("2024-12-01") },
+
+        // regular - outside
+        {
+          distance: 6_000,
+          datetime: new Date("2024-04-15"),
+          start: { ...defaultPosition, aom: "244900015" }, // Angers
+        },
+
+        // booster - outside
+        {
+          distance: 6_000,
+          datetime: new Date("2024-12-04"),
+          start: { ...defaultPosition, aom: "244900015" }, // Angers
+          seats: 1,
+        },
+
+        // booster - outside - many seats
+        {
+          distance: 6_000,
+          driver_identity_key: "one",
+          datetime: new Date("2024-12-12"),
+          start: { ...defaultPosition, aom: "244900015" }, // Angers
+          seats: 3,
+        },
+
+        // booster - outside - slice 2
+        {
+          distance: 20_000,
+          datetime: new Date("2024-12-25"),
+          start: { ...defaultPosition, aom: "244900015" }, // Angers
+        },
+
+        // booster - outside - slice 3
+        {
+          distance: 40_000,
+          datetime: new Date("2024-12-10"),
+          start: { ...defaultPosition, aom: "244900015" }, // Angers
+        },
+      ],
+    },
+    {
+      incentive: [75, 165, 0, 90, 90 * 3, 90, 90],
+    },
+  ));

--- a/api/src/pdc/services/policy/engine/policies/20240101_PaysDeLaLoire.html.ts
+++ b/api/src/pdc/services/policy/engine/policies/20240101_PaysDeLaLoire.html.ts
@@ -6,23 +6,45 @@ export const description = `<div _ngcontent-fyn-c231="" id="summary" class="camp
 
   <p>
     Les <b> conducteurs </b> effectuant un trajet entre 5 et 60 km (inclus)
-    dans la région Pays de la Loire sont incités selon les règles suivantes :
+    dans la région Pays de la Loire sont incités selon les règles suivantes
+    dans les conditions normales :
   </p>
 
   <ul>
     <li><b>De 5 à 17 km : 0,75 € par trajet par passager.</b></li>
-    <li><b>De 17 à 29,5 km : 0,10 € par trajet par km par passager avec un maximum de 2,00 €</b></li>
-    <li><b>De 29,5 à 60 km : 2,00 € par passager transporté</b></li>
+    <li><b>De 17 à 30 km : 0,10 € par trajet par km par passager avec un maximum de 2,00 €</b></li>
+    <li><b>De 30 à 60 km : 2,00 € par passager transporté</b></li>
   </ul>
 
-  <p>Les restrictions suivantes seront appliquées :</p>
+  <p>
+    Dans les conditions <em>"booster"</em>, les règles suivantes sont appliquées :
+  </p>
+
+  <ul>
+    <li><b>De 5 à 17 km : 1,65 € par trajet par passager.</b></li>
+    <li><b>De 17 à 30 km : 0,10 € par trajet par km par passager avec un maximum de 2,90 €</b></li>
+    <li><b>De 30 à 60 km : 2,90 € par passager transporté</b></li>
+  </ul>
+
+  <p>Les dates des périodes booster sont les suivantes :</p>
+
+  <ul>
+    <li><em>aucune date pour le moment</em></li>
+  </ul>
+
+  <p>Les restrictions suivantes sont appliquées :</p>
 
   <ul>
     <li><b>6 trajets maximum pour le conducteur par jour.</b></li>
     <li><b>84,00 € maximum pour le conducteur par mois.</b></li>
+    <li><b>1 008,00 € maximum pour le conducteur par an.</b></li>
   </ul>
 
-  <p>La campagne est éligible à tous les opérateurs du RPC proposant des preuves de classe <b>C</b>.</p>
+  <p>
+    La campagne est éligible aux opérateurs
+    BlablaCar Daily, Karos et Mobicoop
+    proposant des preuves de classe <b>C</b>.
+  </p>
 
   <p>Les trajets au départ et à l'arrivée des AOMs suivantes ne sont pas incités : </p>
 

--- a/api/src/pdc/services/policy/engine/policies/20240101_PaysDeLaLoire.html.ts
+++ b/api/src/pdc/services/policy/engine/policies/20240101_PaysDeLaLoire.html.ts
@@ -1,5 +1,4 @@
-export const description =
-  `<div _ngcontent-fyn-c231="" id="summary" class="campaignSummaryText-content-text">
+export const description = `<div _ngcontent-fyn-c231="" id="summary" class="campaignSummaryText-content-text">
 
   <p>Campagne d'incitation au covoiturage du <b> 01 janvier 2024 au 31 Décembre 2025</b></p>
 
@@ -12,7 +11,8 @@ export const description =
 
   <ul>
     <li><b>De 5 à 17 km : 0,75 € par trajet par passager.</b></li>
-    <li><b>De 17 à 30 km : 0,10 € par trajet par km par passager avec un maximum de 2,00 €</b></li>
+    <li><b>De 17 à 29,5 km : 0,10 € par trajet par km par passager avec un maximum de 2,00 €</b></li>
+    <li><b>De 29,5 à 60 km : 2,00 € par passager transporté</b></li>
   </ul>
 
   <p>Les restrictions suivantes seront appliquées :</p>

--- a/api/src/pdc/services/policy/engine/policies/20240101_PaysDeLaLoire.ts
+++ b/api/src/pdc/services/policy/engine/policies/20240101_PaysDeLaLoire.ts
@@ -82,7 +82,7 @@ export const PaysDeLaLoire2024: PolicyHandlerStaticInterface = class extends Abs
       },
     },
     {
-      start: 29_500,
+      start: 30_000,
       end: 60_000,
       fn: () => 0,
     },

--- a/api/src/pdc/services/policy/engine/policies/20240101_PaysDeLaLoire.ts
+++ b/api/src/pdc/services/policy/engine/policies/20240101_PaysDeLaLoire.ts
@@ -34,7 +34,6 @@ export const PaysDeLaLoire2024: PolicyHandlerStaticInterface = class extends Abs
   static readonly tz: Timezone = "Europe/Paris";
 
   public static mode<T>(date: Date, regular: T, booster: T): T {
-    console.log("PaysDeLaLoire2024.boosterDates", PaysDeLaLoire2024.boosterDates);
     if (!PaysDeLaLoire2024.boosterDates) return regular;
 
     const ymd = toTzString(date).slice(0, 10);

--- a/api/src/pdc/services/policy/engine/policies/20240101_PaysDeLaLoire.ts
+++ b/api/src/pdc/services/policy/engine/policies/20240101_PaysDeLaLoire.ts
@@ -1,3 +1,4 @@
+import { Timezone } from "@/pdc/providers/validator/types.ts";
 import { NotEligibleTargetException } from "@/pdc/services/policy/engine/exceptions/NotEligibleTargetException.ts";
 import { getOperatorsAt, TimestampedOperators } from "@/pdc/services/policy/engine/helpers/getOperatorsAt.ts";
 import { isAdultOrThrow } from "@/pdc/services/policy/engine/helpers/isAdultOrThrow.ts";
@@ -14,6 +15,7 @@ import { onDistanceRange, onDistanceRangeOrThrow } from "@/pdc/services/policy/e
 import { perKm, perSeat } from "@/pdc/services/policy/engine/helpers/per.ts";
 import { endsAt, startsAndEndsAt, startsAt } from "@/pdc/services/policy/engine/helpers/position.ts";
 import { AbstractPolicyHandler } from "@/pdc/services/policy/engine/policies/AbstractPolicyHandler.ts";
+import { toTzString } from "@/pdc/services/policy/helpers/index.ts";
 import { RunnableSlices } from "@/pdc/services/policy/interfaces/engine/PolicyInterface.ts";
 import {
   OperatorsEnum,
@@ -29,6 +31,19 @@ import { description } from "./20240101_PaysDeLaLoire.html.ts";
 export const PaysDeLaLoire2024: PolicyHandlerStaticInterface = class extends AbstractPolicyHandler
   implements PolicyHandlerInterface {
   static readonly id = "pdll_2024";
+  static readonly tz: Timezone = "Europe/Paris";
+
+  public static mode<T>(date: Date, regular: T, booster: T): T {
+    console.log("PaysDeLaLoire2024.boosterDates", PaysDeLaLoire2024.boosterDates);
+    if (!PaysDeLaLoire2024.boosterDates) return regular;
+
+    const ymd = toTzString(date).slice(0, 10);
+    return PaysDeLaLoire2024.boosterDates.includes(ymd) ? booster : regular;
+  }
+
+  // List dates in the YYYY-MM-DD format in the Europe/Paris timezone
+  // or use the dateRange() helper function for consecutive dates.
+  protected static boosterDates: string[] = [];
 
   protected operators: TimestampedOperators = [
     {
@@ -50,7 +65,7 @@ export const PaysDeLaLoire2024: PolicyHandlerStaticInterface = class extends Abs
     },
   ];
 
-  protected slices: RunnableSlices = [
+  protected regularSlices: RunnableSlices = [
     {
       start: 5_000,
       end: 17_000,
@@ -58,17 +73,38 @@ export const PaysDeLaLoire2024: PolicyHandlerStaticInterface = class extends Abs
     },
     {
       start: 17_000,
-      end: 29_500,
+      end: 30_000,
       fn: (ctx: StatelessContextInterface) => {
         // 0,10 euro par trajet par km par passager avec un maximum de 2,00 euros
         return perSeat(
           ctx,
-          Math.min(perKm(ctx, { amount: 10, offset: 17_000, limit: 29_500 }), 200 - 75),
+          Math.min(perKm(ctx, { amount: 10, offset: 17_000, limit: 30_000 }), 200 - 75),
         );
       },
     },
     {
       start: 29_500,
+      end: 60_000,
+      fn: () => 0,
+    },
+  ];
+
+  protected boosterSlices: RunnableSlices = [
+    {
+      start: 5_000,
+      end: 17_000,
+      fn: (ctx: StatelessContextInterface) => perSeat(ctx, 165),
+    },
+    {
+      start: 17_000,
+      end: 30_000,
+      fn: (ctx: StatelessContextInterface) => {
+        // 0,10 euro par trajet par km par passager avec un maximum de 2,90 euros
+        return perSeat(ctx, Math.min(perKm(ctx, { amount: 10, offset: 17_000, limit: 30_000 }), 290 - 165));
+      },
+    },
+    {
+      start: 30_000,
       end: 60_000,
       fn: () => 0,
     },
@@ -103,44 +139,18 @@ export const PaysDeLaLoire2024: PolicyHandlerStaticInterface = class extends Abs
     ];
   }
 
-  protected processExclusion(ctx: StatelessContextInterface) {
-    isOperatorOrThrow(
-      ctx,
-      getOperatorsAt(this.operators, ctx.carpool.datetime),
-    );
-    onDistanceRangeOrThrow(ctx, { min: 5_000, max: 60_001 });
-    isOperatorClassOrThrow(ctx, ["C"]);
-    isAdultOrThrow(ctx);
-
-    /*
-      Exclure les trajets :
-       - 244400404: Nantes Métropole -> Nantes Métropole,
-       - 244900015: CU Angers Loire Métropole -> CU Angers Loire Métropole,
-       - 247200132: CU Le Mans Métropole -> CU Le Mans Métropole,
-       - 200071678: CA Agglomération du Choletais -> CA Agglomération du Choletais
-     */
-    if (
-      startsAndEndsAt(ctx, { aom: ["244400404"] }) ||
-      startsAndEndsAt(ctx, { aom: ["244900015"] }) ||
-      startsAndEndsAt(ctx, { aom: ["247200132"] }) ||
-      startsAndEndsAt(ctx, { aom: ["200071678"] })
-    ) {
-      throw new NotEligibleTargetException();
-    }
-
-    // Exclure les trajets qui ne sont pas dans l'AOM
-    if (!startsAt(ctx, { reg: ["52"] }) || !endsAt(ctx, { reg: ["52"] })) {
-      throw new NotEligibleTargetException();
-    }
-  }
-
-  processStateless(ctx: StatelessContextInterface): void {
+  public processStateless(ctx: StatelessContextInterface): void {
     this.processExclusion(ctx);
     super.processStateless(ctx);
 
+    if (!PaysDeLaLoire2024.mode) {
+      throw new Error("PaysDeLaLoire2024.mode is not defined");
+    }
+
     // Par kilomètre
     let amount = 0;
-    for (const { start, fn } of this.slices) {
+    const slices = PaysDeLaLoire2024.mode(ctx.carpool.datetime, this.regularSlices, this.boosterSlices);
+    for (const { start, fn } of slices) {
       if (onDistanceRange(ctx, { min: start })) {
         amount += fn(ctx);
       }
@@ -149,21 +159,57 @@ export const PaysDeLaLoire2024: PolicyHandlerStaticInterface = class extends Abs
     ctx.incentive.set(amount);
   }
 
-  params(): PolicyHandlerParamsInterface {
+  public params(date?: Date): PolicyHandlerParamsInterface {
+    if (!PaysDeLaLoire2024.mode) {
+      throw new Error("PaysDeLaLoire2024.mode is not defined");
+    }
+
     return {
-      tz: "Europe/Paris",
-      slices: this.slices,
+      tz: PaysDeLaLoire2024.tz,
+      slices: date ? PaysDeLaLoire2024.mode(date, this.regularSlices, this.boosterSlices) : this.regularSlices,
       operators: getOperatorsAt(this.operators),
-      allTimeOperators: Array.from(
-        new Set(this.operators.flatMap((entry) => entry.operators)),
-      ),
+      allTimeOperators: Array.from(new Set(this.operators.flatMap((entry) => entry.operators))),
       limits: {
         glob: this.max_amount,
       },
     };
   }
 
-  describe(): string {
+  public describe(): string {
     return description;
+  }
+
+  protected processExclusion(ctx: StatelessContextInterface) {
+    isOperatorOrThrow(ctx, getOperatorsAt(this.operators, ctx.carpool.datetime));
+    onDistanceRangeOrThrow(ctx, { min: 5_000, max: 60_001 });
+    isOperatorClassOrThrow(ctx, ["C"]);
+    isAdultOrThrow(ctx);
+
+    this.excludeLocalAOM(ctx);
+    this.excludeOutsideOfAOM(ctx);
+  }
+
+  /**
+   * Exclure les trajets :
+   *  - 244400404: Nantes Métropole -> Nantes Métropole,
+   *  - 244900015: CU Angers Loire Métropole -> CU Angers Loire Métropole,
+   *  - 247200132: CU Le Mans Métropole -> CU Le Mans Métropole,
+   *  - 200071678: CA Agglomération du Choletais -> CA Agglomération du Choletais
+   */
+  protected excludeLocalAOM(ctx: StatelessContextInterface) {
+    if (
+      startsAndEndsAt(ctx, { aom: ["244400404"] }) ||
+      startsAndEndsAt(ctx, { aom: ["244900015"] }) ||
+      startsAndEndsAt(ctx, { aom: ["247200132"] }) ||
+      startsAndEndsAt(ctx, { aom: ["200071678"] })
+    ) {
+      throw new NotEligibleTargetException();
+    }
+  }
+
+  protected excludeOutsideOfAOM(ctx: StatelessContextInterface) {
+    if (!startsAt(ctx, { reg: ["52"] }) || !endsAt(ctx, { reg: ["52"] })) {
+      throw new NotEligibleTargetException();
+    }
   }
 };

--- a/api/src/pdc/services/policy/engine/policies/20240101_PaysDeLaLoire.unit.spec.ts
+++ b/api/src/pdc/services/policy/engine/policies/20240101_PaysDeLaLoire.unit.spec.ts
@@ -44,259 +44,237 @@ const defaultCarpool = {
 
 const process = makeProcessHelper(defaultCarpool);
 
-it(
-  "should work with regular exclusions",
-  async () =>
-    await process(
-      {
-        policy: { handler: Handler.id },
-        carpool: [
-          { distance: 4999 },
-          { operator_class: "A" },
-          { start: { ...defaultPosition, reg: "11" } },
-          { end: { ...defaultPosition, reg: "11" } },
-          { distance: 60_001 },
-          { passenger_is_over_18: false },
-        ],
-      },
-      { incentive: [0, 0, 0, 0, 0, 0] },
-    ),
-);
+it("should work with regular exclusions", async () =>
+  await process({
+    policy: { handler: Handler.id },
+    carpool: [
+      { distance: 4999 },
+      { operator_class: "A" },
+      { start: { ...defaultPosition, reg: "11" } },
+      { end: { ...defaultPosition, reg: "11" } },
+      { distance: 60_001 },
+      { passenger_is_over_18: false },
+    ],
+  }, { incentive: [0, 0, 0, 0, 0, 0] }));
 
-it(
-  "Klaxit removed on 2024-03-18",
-  async () =>
-    await process(
+it("Klaxit removed on 2024-03-18", async () =>
+  await process({
+    policy: { handler: Handler.id },
+    carpool: [
       {
-        policy: { handler: Handler.id },
-        carpool: [
-          {
-            operator_uuid: OperatorsEnum.KLAXIT,
-            datetime: new Date("2024-03-17T23:00:00+0100"),
-          },
-          {
-            operator_uuid: OperatorsEnum.KLAXIT,
-            datetime: new Date("2024-03-18T10:00:00+0100"),
-          },
-        ],
+        operator_uuid: OperatorsEnum.KLAXIT,
+        datetime: new Date("2024-03-17T23:00:00+0100"),
       },
-      { incentive: [75, 0] },
-    ),
-);
+      {
+        operator_uuid: OperatorsEnum.KLAXIT,
+        datetime: new Date("2024-03-18T10:00:00+0100"),
+      },
+    ],
+  }, { incentive: [75, 0] }));
 
-it(
-  "should work with AOM exclusions",
-  async () =>
-    await process(
+it("should work with AOM exclusions", async () =>
+  await process({
+    policy: { handler: Handler.id },
+    carpool: [
+      // Nantes Métropole (244400404)
       {
-        policy: { handler: Handler.id },
-        carpool: [
-          // Nantes Métropole (244400404)
-          {
-            driver_identity_key: "nantes",
-            start: { ...defaultPosition, aom: "244400404" },
-            end: { ...defaultPosition, aom: "244400404" },
-          },
-          {
-            driver_identity_key: "nantes",
-            start: { ...defaultPosition, aom: "244400404" },
-            end: { ...defaultPosition },
-          },
-          {
-            driver_identity_key: "nantes",
-            start: { ...defaultPosition },
-            end: { ...defaultPosition, aom: "244400404" },
-          },
+        driver_identity_key: "nantes",
+        start: { ...defaultPosition, aom: "244400404" },
+        end: { ...defaultPosition, aom: "244400404" },
+      },
+      {
+        driver_identity_key: "nantes",
+        start: { ...defaultPosition, aom: "244400404" },
+        end: { ...defaultPosition },
+      },
+      {
+        driver_identity_key: "nantes",
+        start: { ...defaultPosition },
+        end: { ...defaultPosition, aom: "244400404" },
+      },
 
-          // Angers (244900015)
-          {
-            driver_identity_key: "angers",
-            start: { ...defaultPosition, aom: "244900015" },
-            end: { ...defaultPosition, aom: "244900015" },
-          },
-          {
-            driver_identity_key: "angers",
-            start: { ...defaultPosition, aom: "244900015" },
-            end: { ...defaultPosition },
-          },
-          {
-            driver_identity_key: "angers",
-            start: { ...defaultPosition },
-            end: { ...defaultPosition, aom: "244900015" },
-          },
+      // Angers (244900015)
+      {
+        driver_identity_key: "angers",
+        start: { ...defaultPosition, aom: "244900015" },
+        end: { ...defaultPosition, aom: "244900015" },
+      },
+      {
+        driver_identity_key: "angers",
+        start: { ...defaultPosition, aom: "244900015" },
+        end: { ...defaultPosition },
+      },
+      {
+        driver_identity_key: "angers",
+        start: { ...defaultPosition },
+        end: { ...defaultPosition, aom: "244900015" },
+      },
 
-          // Le Mans (247200132)
-          {
-            driver_identity_key: "le_mans",
-            start: { ...defaultPosition, aom: "247200132" },
-            end: { ...defaultPosition, aom: "247200132" },
-          },
-          {
-            driver_identity_key: "le_mans",
-            start: { ...defaultPosition, aom: "247200132" },
-            end: { ...defaultPosition },
-          },
-          {
-            driver_identity_key: "le_mans",
-            start: { ...defaultPosition },
-            end: { ...defaultPosition, aom: "247200132" },
-          },
+      // Le Mans (247200132)
+      {
+        driver_identity_key: "le_mans",
+        start: { ...defaultPosition, aom: "247200132" },
+        end: { ...defaultPosition, aom: "247200132" },
+      },
+      {
+        driver_identity_key: "le_mans",
+        start: { ...defaultPosition, aom: "247200132" },
+        end: { ...defaultPosition },
+      },
+      {
+        driver_identity_key: "le_mans",
+        start: { ...defaultPosition },
+        end: { ...defaultPosition, aom: "247200132" },
+      },
 
-          // CA Agglomération du Choletais (200071678)
-          {
-            driver_identity_key: "cholet",
-            start: { ...defaultPosition, aom: "200071678" },
-            end: { ...defaultPosition, aom: "200071678" },
-          },
-          {
-            driver_identity_key: "cholet",
-            start: { ...defaultPosition, aom: "200071678" },
-            end: { ...defaultPosition },
-          },
-          {
-            driver_identity_key: "cholet",
-            start: { ...defaultPosition },
-            end: { ...defaultPosition, aom: "200071678" },
-          },
-        ],
+      // CA Agglomération du Choletais (200071678)
+      {
+        driver_identity_key: "cholet",
+        start: { ...defaultPosition, aom: "200071678" },
+        end: { ...defaultPosition, aom: "200071678" },
       },
-      { incentive: [0, 75, 75, 0, 75, 75, 0, 75, 75, 0, 75, 75] },
-    ),
-);
+      {
+        driver_identity_key: "cholet",
+        start: { ...defaultPosition, aom: "200071678" },
+        end: { ...defaultPosition },
+      },
+      {
+        driver_identity_key: "cholet",
+        start: { ...defaultPosition },
+        end: { ...defaultPosition, aom: "200071678" },
+      },
+    ],
+  }, { incentive: [0, 75, 75, 0, 75, 75, 0, 75, 75, 0, 75, 75] }));
 
-it(
-  "should work basic",
-  async () =>
-    await process(
+it("should work basic", async () =>
+  await process({
+    policy: { handler: Handler.id },
+    carpool: [
+      { distance: 1_000, driver_identity_key: "one" },
+      { distance: 5_000, driver_identity_key: "one" },
+      { distance: 5_000, seats: 2, driver_identity_key: "one" },
+      { distance: 20_000, driver_identity_key: "two" },
+      { distance: 25_000, driver_identity_key: "two" },
+      { distance: 55_000, driver_identity_key: "two" },
+      { distance: 61_000, driver_identity_key: "two" },
+    ],
+    meta: [],
+  }, {
+    incentive: [0, 75, 150, 105, 155, 200, 0],
+    meta: [
       {
-        policy: { handler: Handler.id },
-        carpool: [
-          { distance: 1_000, driver_identity_key: "one" },
-          { distance: 5_000, driver_identity_key: "one" },
-          { distance: 5_000, seats: 2, driver_identity_key: "one" },
-          { distance: 20_000, driver_identity_key: "two" },
-          { distance: 25_000, driver_identity_key: "two" },
-          { distance: 55_000, driver_identity_key: "two" },
-          { distance: 61_000, driver_identity_key: "two" },
-        ],
-        meta: [],
+        key: "max_amount_restriction.global.campaign.global",
+        value: 685,
       },
       {
-        incentive: [0, 75, 150, 105, 155, 200, 0],
-        meta: [
-          {
-            key: "max_amount_restriction.global.campaign.global",
-            value: 685,
-          },
-          {
-            key: "max_amount_restriction.0-one.month.3-2024",
-            value: 225,
-          },
-          {
-            key: "max_amount_restriction.0-two.month.3-2024",
-            value: 460,
-          },
-        ],
+        key: "max_amount_restriction.0-one.month.3-2024",
+        value: 225,
       },
-    ),
-);
+      {
+        key: "max_amount_restriction.0-one.year.2024",
+        value: 225,
+      },
+      {
+        key: "max_amount_restriction.0-two.month.3-2024",
+        value: 460,
+      },
+      {
+        key: "max_amount_restriction.0-two.year.2024",
+        value: 460,
+      },
+    ],
+  }));
 
-it(
-  "should work with global limits",
-  async () =>
-    await process(
+it("should work with global limits", async () =>
+  await process({
+    policy: { handler: Handler.id, max_amount: 2_200_000_00 },
+    carpool: [{ distance: 5_000, driver_identity_key: "one" }],
+    meta: [
       {
-        policy: { handler: Handler.id, max_amount: 2_200_000_00 },
-        carpool: [{ distance: 5_000, driver_identity_key: "one" }],
-        meta: [
-          {
-            key: "max_amount_restriction.global.campaign.global",
-            value: 2_199_999_25,
-          },
-        ],
+        key: "max_amount_restriction.global.campaign.global",
+        value: 2_199_999_25,
+      },
+    ],
+  }, {
+    incentive: [75],
+    meta: [
+      {
+        key: "max_amount_restriction.global.campaign.global",
+        value: 2_200_000_00,
       },
       {
-        incentive: [75],
-        meta: [
-          {
-            key: "max_amount_restriction.global.campaign.global",
-            value: 2_200_000_00,
-          },
-          {
-            key: "max_amount_restriction.0-one.month.3-2024",
-            value: 75,
-          },
-        ],
+        key: "max_amount_restriction.0-one.month.3-2024",
+        value: 75,
       },
-    ),
-);
+      {
+        key: "max_amount_restriction.0-one.year.2024",
+        value: 75,
+      },
+    ],
+  }));
 
-it(
-  "should work with day limits",
-  async () =>
-    await process(
+it("should work with day limits", async () =>
+  await process({
+    policy: { handler: Handler.id },
+    carpool: [
+      { distance: 5_000, driver_identity_key: "one" },
+      { distance: 5_000, driver_identity_key: "one" },
+      { distance: 5_000, driver_identity_key: "one" },
+      { distance: 5_000, driver_identity_key: "one" },
+      { distance: 5_000, driver_identity_key: "one" },
+      { distance: 5_000, driver_identity_key: "one" },
+      { distance: 5_000, driver_identity_key: "one" },
+    ],
+    meta: [],
+  }, {
+    incentive: [75, 75, 75, 75, 75, 75, 0],
+    meta: [
       {
-        policy: { handler: Handler.id },
-        carpool: [
-          { distance: 5_000, driver_identity_key: "one" },
-          { distance: 5_000, driver_identity_key: "one" },
-          { distance: 5_000, driver_identity_key: "one" },
-          { distance: 5_000, driver_identity_key: "one" },
-          { distance: 5_000, driver_identity_key: "one" },
-          { distance: 5_000, driver_identity_key: "one" },
-          { distance: 5_000, driver_identity_key: "one" },
-        ],
-        meta: [],
+        key: "max_amount_restriction.global.campaign.global",
+        value: 450,
       },
       {
-        incentive: [75, 75, 75, 75, 75, 75, 0],
-        meta: [
-          {
-            key: "max_amount_restriction.global.campaign.global",
-            value: 450,
-          },
-          {
-            key: "max_amount_restriction.0-one.month.3-2024",
-            value: 450,
-          },
-        ],
+        key: "max_amount_restriction.0-one.month.3-2024",
+        value: 450,
       },
-    ),
-);
+      {
+        key: "max_amount_restriction.0-one.year.2024",
+        value: 450,
+      },
+    ],
+  }));
 
-it(
-  "should work with driver month limits of 84 €",
-  async () =>
-    await process(
+it("should work with driver month limits of 84 €", async () =>
+  await process({
+    policy: { handler: Handler.id },
+    carpool: [
+      { distance: 6_000, driver_identity_key: "one" },
+      { distance: 6_000, driver_identity_key: "one" },
+    ],
+    meta: [
       {
-        policy: { handler: Handler.id },
-        carpool: [
-          { distance: 6_000, driver_identity_key: "one" },
-          { distance: 6_000, driver_identity_key: "one" },
-        ],
-        meta: [
-          {
-            key: "max_amount_restriction.0-one.month.3-2024",
-            value: 83_25,
-          },
-          {
-            key: "max_amount_restriction.global.campaign.global",
-            value: 83_25,
-          },
-        ],
+        key: "max_amount_restriction.0-one.month.3-2024",
+        value: 83_25,
       },
       {
-        incentive: [75, 0],
-        meta: [
-          {
-            key: "max_amount_restriction.global.campaign.global",
-            value: 84_00,
-          },
-          {
-            key: "max_amount_restriction.0-one.month.3-2024",
-            value: 84_00,
-          },
-        ],
+        key: "max_amount_restriction.global.campaign.global",
+        value: 83_25,
       },
-    ),
-);
+    ],
+  }, {
+    incentive: [75, 0],
+    meta: [
+      {
+        key: "max_amount_restriction.global.campaign.global",
+        value: 84_00,
+      },
+      {
+        key: "max_amount_restriction.0-one.month.3-2024",
+        value: 84_00,
+      },
+      {
+        key: "max_amount_restriction.0-one.year.2024",
+        value: 150,
+      },
+    ],
+  }));

--- a/api/src/pdc/services/policy/engine/policies/20240101_PaysDeLaLoire.unit.spec.ts
+++ b/api/src/pdc/services/policy/engine/policies/20240101_PaysDeLaLoire.unit.spec.ts
@@ -1,10 +1,10 @@
 import { it } from "@/dev_deps.ts";
 import { v4 as uuidV4 } from "@/lib/uuid/index.ts";
-import { OperatorsEnum } from "../../interfaces/index.ts";
+import { OperatorsEnum, TerritoryCodeInterface } from "../../interfaces/index.ts";
 import { makeProcessHelper } from "../tests/macro.ts";
 import { PaysDeLaLoire2024 as Handler } from "./20240101_PaysDeLaLoire.ts";
 
-const defaultPosition = {
+const defaultPosition: TerritoryCodeInterface = {
   arr: "85047",
   com: "85047",
   aom: "200071629",
@@ -12,7 +12,7 @@ const defaultPosition = {
   dep: "85",
   reg: "52",
   country: "XXXXX",
-  reseau: "430",
+  reseau: 1,
 };
 const defaultLat = 48.72565703413325;
 const defaultLon = 2.261827843187402;

--- a/api/src/pdc/services/policy/engine/policies/20240101_PaysDeLaLoire.unit.spec.ts
+++ b/api/src/pdc/services/policy/engine/policies/20240101_PaysDeLaLoire.unit.spec.ts
@@ -1,280 +1,351 @@
-import { it } from "@/dev_deps.ts";
+import { describe, it, sinon } from "@/dev_deps.ts";
 import { v4 as uuidV4 } from "@/lib/uuid/index.ts";
+import { RunnableSlices } from "@/pdc/services/policy/interfaces/engine/PolicyInterface.ts";
 import { OperatorsEnum, TerritoryCodeInterface } from "../../interfaces/index.ts";
 import { makeProcessHelper } from "../tests/macro.ts";
 import { PaysDeLaLoire2024 as Handler } from "./20240101_PaysDeLaLoire.ts";
 
-const defaultPosition: TerritoryCodeInterface = {
-  arr: "85047",
-  com: "85047",
-  aom: "200071629",
-  epci: "200071629",
-  dep: "85",
-  reg: "52",
-  country: "XXXXX",
-  reseau: 1,
-};
-const defaultLat = 48.72565703413325;
-const defaultLon = 2.261827843187402;
+describe("PaysDeLaLoire2024", () => {
+  const defaultPosition: TerritoryCodeInterface = {
+    arr: "85047",
+    com: "85047",
+    aom: "200071629",
+    epci: "200071629",
+    dep: "85",
+    reg: "52",
+    country: "XXXXX",
+    reseau: 1,
+  };
+  const defaultLat = 48.72565703413325;
+  const defaultLon = 2.261827843187402;
 
-const defaultCarpool = {
-  _id: 1,
-  operator_trip_id: uuidV4(),
-  passenger_identity_key: uuidV4(),
-  driver_identity_key: uuidV4(),
-  operator_uuid: OperatorsEnum.KAROS,
-  operator_class: "C",
-  passenger_is_over_18: true,
-  passenger_has_travel_pass: true,
-  driver_has_travel_pass: true,
-  datetime: new Date("2024-04-15"),
-  seats: 1,
-  distance: 5_000,
-  operator_journey_id: uuidV4(),
-  operator_id: 1,
-  driver_revenue: 20,
-  passenger_contribution: 20,
-  start: { ...defaultPosition },
-  end: { ...defaultPosition },
-  start_lat: defaultLat,
-  start_lon: defaultLon,
-  end_lat: defaultLat,
-  end_lon: defaultLon,
-};
+  const defaultCarpool = {
+    _id: 1,
+    operator_trip_id: uuidV4(),
+    passenger_identity_key: uuidV4(),
+    driver_identity_key: uuidV4(),
+    operator_uuid: OperatorsEnum.KAROS,
+    operator_class: "C",
+    passenger_is_over_18: true,
+    passenger_has_travel_pass: true,
+    driver_has_travel_pass: true,
+    datetime: new Date("2024-04-15"),
+    seats: 1,
+    distance: 5_000,
+    operator_journey_id: uuidV4(),
+    operator_id: 1,
+    driver_revenue: 20,
+    passenger_contribution: 20,
+    start: { ...defaultPosition },
+    end: { ...defaultPosition },
+    start_lat: defaultLat,
+    start_lon: defaultLon,
+    end_lat: defaultLat,
+    end_lon: defaultLon,
+  };
 
-const process = makeProcessHelper(defaultCarpool);
+  /**
+   * Stub the mode method while the PaysDeLaLoire2024 class has no booster dates.
+   */
+  const boosterDates: string[] = ["2024-04-16"];
+  sinon.stub(Handler, "mode").callsFake(
+    (date: Date, regular: RunnableSlices, booster: RunnableSlices) => {
+      const ymd = date.toISOString().slice(0, 10);
+      return boosterDates.includes(ymd) ? booster : regular;
+    },
+  );
 
-it("should work with regular exclusions", async () =>
-  await process({
-    policy: { handler: Handler.id },
-    carpool: [
-      { distance: 4999 },
-      { operator_class: "A" },
-      { start: { ...defaultPosition, reg: "11" } },
-      { end: { ...defaultPosition, reg: "11" } },
-      { distance: 60_001 },
-      { passenger_is_over_18: false },
-    ],
-  }, { incentive: [0, 0, 0, 0, 0, 0] }));
+  const process = makeProcessHelper(defaultCarpool);
 
-it("Klaxit removed on 2024-03-18", async () =>
-  await process({
-    policy: { handler: Handler.id },
-    carpool: [
-      {
-        operator_uuid: OperatorsEnum.KLAXIT,
-        datetime: new Date("2024-03-17T23:00:00+0100"),
-      },
-      {
-        operator_uuid: OperatorsEnum.KLAXIT,
-        datetime: new Date("2024-03-18T10:00:00+0100"),
-      },
-    ],
-  }, { incentive: [75, 0] }));
+  it("should work with regular exclusions", async () =>
+    await process({
+      policy: { handler: Handler.id },
+      carpool: [
+        { distance: 4999 },
+        { operator_class: "A" },
+        { start: { ...defaultPosition, reg: "11" } },
+        { end: { ...defaultPosition, reg: "11" } },
+        { distance: 60_001 },
+        { passenger_is_over_18: false },
+      ],
+    }, { incentive: [0, 0, 0, 0, 0, 0] }));
 
-it("should work with AOM exclusions", async () =>
-  await process({
-    policy: { handler: Handler.id },
-    carpool: [
-      // Nantes Métropole (244400404)
-      {
-        driver_identity_key: "nantes",
-        start: { ...defaultPosition, aom: "244400404" },
-        end: { ...defaultPosition, aom: "244400404" },
-      },
-      {
-        driver_identity_key: "nantes",
-        start: { ...defaultPosition, aom: "244400404" },
-        end: { ...defaultPosition },
-      },
-      {
-        driver_identity_key: "nantes",
-        start: { ...defaultPosition },
-        end: { ...defaultPosition, aom: "244400404" },
-      },
+  it("Klaxit removed on 2024-03-18", async () =>
+    await process({
+      policy: { handler: Handler.id },
+      carpool: [
+        {
+          operator_uuid: OperatorsEnum.KLAXIT,
+          datetime: new Date("2024-03-17T23:00:00+0100"),
+        },
+        {
+          operator_uuid: OperatorsEnum.KLAXIT,
+          datetime: new Date("2024-03-18T10:00:00+0100"),
+        },
+      ],
+    }, { incentive: [75, 0] }));
 
-      // Angers (244900015)
-      {
-        driver_identity_key: "angers",
-        start: { ...defaultPosition, aom: "244900015" },
-        end: { ...defaultPosition, aom: "244900015" },
-      },
-      {
-        driver_identity_key: "angers",
-        start: { ...defaultPosition, aom: "244900015" },
-        end: { ...defaultPosition },
-      },
-      {
-        driver_identity_key: "angers",
-        start: { ...defaultPosition },
-        end: { ...defaultPosition, aom: "244900015" },
-      },
+  it("should work with AOM exclusions", async () =>
+    await process({
+      policy: { handler: Handler.id },
+      carpool: [
+        // Nantes Métropole (244400404)
+        {
+          driver_identity_key: "nantes",
+          start: { ...defaultPosition, aom: "244400404" },
+          end: { ...defaultPosition, aom: "244400404" },
+        },
+        {
+          driver_identity_key: "nantes",
+          start: { ...defaultPosition, aom: "244400404" },
+          end: { ...defaultPosition },
+        },
+        {
+          driver_identity_key: "nantes",
+          start: { ...defaultPosition },
+          end: { ...defaultPosition, aom: "244400404" },
+        },
 
-      // Le Mans (247200132)
-      {
-        driver_identity_key: "le_mans",
-        start: { ...defaultPosition, aom: "247200132" },
-        end: { ...defaultPosition, aom: "247200132" },
-      },
-      {
-        driver_identity_key: "le_mans",
-        start: { ...defaultPosition, aom: "247200132" },
-        end: { ...defaultPosition },
-      },
-      {
-        driver_identity_key: "le_mans",
-        start: { ...defaultPosition },
-        end: { ...defaultPosition, aom: "247200132" },
-      },
+        // Angers (244900015)
+        {
+          driver_identity_key: "angers",
+          start: { ...defaultPosition, aom: "244900015" },
+          end: { ...defaultPosition, aom: "244900015" },
+        },
+        {
+          driver_identity_key: "angers",
+          start: { ...defaultPosition, aom: "244900015" },
+          end: { ...defaultPosition },
+        },
+        {
+          driver_identity_key: "angers",
+          start: { ...defaultPosition },
+          end: { ...defaultPosition, aom: "244900015" },
+        },
 
-      // CA Agglomération du Choletais (200071678)
-      {
-        driver_identity_key: "cholet",
-        start: { ...defaultPosition, aom: "200071678" },
-        end: { ...defaultPosition, aom: "200071678" },
-      },
-      {
-        driver_identity_key: "cholet",
-        start: { ...defaultPosition, aom: "200071678" },
-        end: { ...defaultPosition },
-      },
-      {
-        driver_identity_key: "cholet",
-        start: { ...defaultPosition },
-        end: { ...defaultPosition, aom: "200071678" },
-      },
-    ],
-  }, { incentive: [0, 75, 75, 0, 75, 75, 0, 75, 75, 0, 75, 75] }));
+        // Le Mans (247200132)
+        {
+          driver_identity_key: "le_mans",
+          start: { ...defaultPosition, aom: "247200132" },
+          end: { ...defaultPosition, aom: "247200132" },
+        },
+        {
+          driver_identity_key: "le_mans",
+          start: { ...defaultPosition, aom: "247200132" },
+          end: { ...defaultPosition },
+        },
+        {
+          driver_identity_key: "le_mans",
+          start: { ...defaultPosition },
+          end: { ...defaultPosition, aom: "247200132" },
+        },
 
-it("should work basic", async () =>
-  await process({
-    policy: { handler: Handler.id },
-    carpool: [
-      { distance: 1_000, driver_identity_key: "one" },
-      { distance: 5_000, driver_identity_key: "one" },
-      { distance: 5_000, seats: 2, driver_identity_key: "one" },
-      { distance: 20_000, driver_identity_key: "two" },
-      { distance: 25_000, driver_identity_key: "two" },
-      { distance: 55_000, driver_identity_key: "two" },
-      { distance: 61_000, driver_identity_key: "two" },
-    ],
-    meta: [],
-  }, {
-    incentive: [0, 75, 150, 105, 155, 200, 0],
-    meta: [
-      {
-        key: "max_amount_restriction.global.campaign.global",
-        value: 685,
-      },
-      {
-        key: "max_amount_restriction.0-one.month.3-2024",
-        value: 225,
-      },
-      {
-        key: "max_amount_restriction.0-one.year.2024",
-        value: 225,
-      },
-      {
-        key: "max_amount_restriction.0-two.month.3-2024",
-        value: 460,
-      },
-      {
-        key: "max_amount_restriction.0-two.year.2024",
-        value: 460,
-      },
-    ],
-  }));
+        // CA Agglomération du Choletais (200071678)
+        {
+          driver_identity_key: "cholet",
+          start: { ...defaultPosition, aom: "200071678" },
+          end: { ...defaultPosition, aom: "200071678" },
+        },
+        {
+          driver_identity_key: "cholet",
+          start: { ...defaultPosition, aom: "200071678" },
+          end: { ...defaultPosition },
+        },
+        {
+          driver_identity_key: "cholet",
+          start: { ...defaultPosition },
+          end: { ...defaultPosition, aom: "200071678" },
+        },
+      ],
+    }, { incentive: [0, 75, 75, 0, 75, 75, 0, 75, 75, 0, 75, 75] }));
 
-it("should work with global limits", async () =>
-  await process({
-    policy: { handler: Handler.id, max_amount: 2_200_000_00 },
-    carpool: [{ distance: 5_000, driver_identity_key: "one" }],
-    meta: [
-      {
-        key: "max_amount_restriction.global.campaign.global",
-        value: 2_199_999_25,
-      },
-    ],
-  }, {
-    incentive: [75],
-    meta: [
-      {
-        key: "max_amount_restriction.global.campaign.global",
-        value: 2_200_000_00,
-      },
-      {
-        key: "max_amount_restriction.0-one.month.3-2024",
-        value: 75,
-      },
-      {
-        key: "max_amount_restriction.0-one.year.2024",
-        value: 75,
-      },
-    ],
-  }));
+  it("should work basic", async () =>
+    await process({
+      policy: { handler: Handler.id },
+      carpool: [
+        { distance: 1_000, driver_identity_key: "one" },
+        { distance: 5_000, driver_identity_key: "one" },
+        { distance: 5_000, seats: 2, driver_identity_key: "one" },
+        { distance: 20_000, driver_identity_key: "two" },
+        { distance: 25_000, driver_identity_key: "two" },
+        { distance: 55_000, driver_identity_key: "two" },
+        { distance: 61_000, driver_identity_key: "two" },
+      ],
+      meta: [],
+    }, {
+      incentive: [0, 75, 150, 105, 155, 200, 0],
+      meta: [
+        {
+          key: "max_amount_restriction.global.campaign.global",
+          value: 685,
+        },
+        {
+          key: "max_amount_restriction.0-one.month.3-2024",
+          value: 225,
+        },
+        {
+          key: "max_amount_restriction.0-one.year.2024",
+          value: 225,
+        },
+        {
+          key: "max_amount_restriction.0-two.month.3-2024",
+          value: 460,
+        },
+        {
+          key: "max_amount_restriction.0-two.year.2024",
+          value: 460,
+        },
+      ],
+    }));
 
-it("should work with day limits", async () =>
-  await process({
-    policy: { handler: Handler.id },
-    carpool: [
-      { distance: 5_000, driver_identity_key: "one" },
-      { distance: 5_000, driver_identity_key: "one" },
-      { distance: 5_000, driver_identity_key: "one" },
-      { distance: 5_000, driver_identity_key: "one" },
-      { distance: 5_000, driver_identity_key: "one" },
-      { distance: 5_000, driver_identity_key: "one" },
-      { distance: 5_000, driver_identity_key: "one" },
-    ],
-    meta: [],
-  }, {
-    incentive: [75, 75, 75, 75, 75, 75, 0],
-    meta: [
-      {
-        key: "max_amount_restriction.global.campaign.global",
-        value: 450,
-      },
-      {
-        key: "max_amount_restriction.0-one.month.3-2024",
-        value: 450,
-      },
-      {
-        key: "max_amount_restriction.0-one.year.2024",
-        value: 450,
-      },
-    ],
-  }));
+  it("should apply booster rules on booster dates", async () =>
+    await process({
+      policy: { handler: Handler.id },
+      carpool: [
+        { distance: 6_000, datetime: new Date("2024-04-01") },
+        { distance: 6_000, datetime: new Date("2024-04-16") },
+        { distance: 20_000, datetime: new Date("2024-04-01") },
+        { distance: 20_000, datetime: new Date("2024-04-16") },
+        { distance: 55_000, datetime: new Date("2024-04-01") },
+        { distance: 55_000, datetime: new Date("2024-04-16") },
+        { distance: 80_000, datetime: new Date("2024-04-01") },
+        { distance: 80_000, datetime: new Date("2024-04-16") },
+      ],
+    }, {
+      incentive: [75, 165, 105, 195, 200, 290, 0, 0],
+    }));
 
-it("should work with driver month limits of 84 €", async () =>
-  await process({
-    policy: { handler: Handler.id },
-    carpool: [
-      { distance: 6_000, driver_identity_key: "one" },
-      { distance: 6_000, driver_identity_key: "one" },
-    ],
-    meta: [
-      {
-        key: "max_amount_restriction.0-one.month.3-2024",
-        value: 83_25,
-      },
-      {
-        key: "max_amount_restriction.global.campaign.global",
-        value: 83_25,
-      },
-    ],
-  }, {
-    incentive: [75, 0],
-    meta: [
-      {
-        key: "max_amount_restriction.global.campaign.global",
-        value: 84_00,
-      },
-      {
-        key: "max_amount_restriction.0-one.month.3-2024",
-        value: 84_00,
-      },
-      {
-        key: "max_amount_restriction.0-one.year.2024",
-        value: 150,
-      },
-    ],
-  }));
+  it("should work with global limits", async () =>
+    await process({
+      policy: { handler: Handler.id, max_amount: 2_200_000_00 },
+      carpool: [{ distance: 5_000, driver_identity_key: "one" }],
+      meta: [
+        {
+          key: "max_amount_restriction.global.campaign.global",
+          value: 2_199_999_25,
+        },
+      ],
+    }, {
+      incentive: [75],
+      meta: [
+        {
+          key: "max_amount_restriction.global.campaign.global",
+          value: 2_200_000_00,
+        },
+        {
+          key: "max_amount_restriction.0-one.month.3-2024",
+          value: 75,
+        },
+        {
+          key: "max_amount_restriction.0-one.year.2024",
+          value: 75,
+        },
+      ],
+    }));
+
+  it("should work with day limits", async () =>
+    await process({
+      policy: { handler: Handler.id },
+      carpool: [
+        { distance: 5_000, driver_identity_key: "one" },
+        { distance: 5_000, driver_identity_key: "one" },
+        { distance: 5_000, driver_identity_key: "one" },
+        { distance: 5_000, driver_identity_key: "one" },
+        { distance: 5_000, driver_identity_key: "one" },
+        { distance: 5_000, driver_identity_key: "one" },
+        { distance: 5_000, driver_identity_key: "one" },
+      ],
+      meta: [],
+    }, {
+      incentive: [75, 75, 75, 75, 75, 75, 0],
+      meta: [
+        {
+          key: "max_amount_restriction.global.campaign.global",
+          value: 450,
+        },
+        {
+          key: "max_amount_restriction.0-one.month.3-2024",
+          value: 450,
+        },
+        {
+          key: "max_amount_restriction.0-one.year.2024",
+          value: 450,
+        },
+      ],
+    }));
+
+  it("should work with driver month limits of 84 €", async () =>
+    await process({
+      policy: { handler: Handler.id },
+      carpool: [
+        { distance: 6_000, driver_identity_key: "one" },
+        { distance: 6_000, driver_identity_key: "one" },
+      ],
+      meta: [
+        {
+          key: "max_amount_restriction.0-one.month.3-2024",
+          value: 83_25,
+        },
+        {
+          key: "max_amount_restriction.global.campaign.global",
+          value: 83_25,
+        },
+      ],
+    }, {
+      incentive: [75, 0],
+      meta: [
+        {
+          key: "max_amount_restriction.global.campaign.global",
+          value: 84_00,
+        },
+        {
+          key: "max_amount_restriction.0-one.month.3-2024",
+          value: 84_00,
+        },
+        {
+          key: "max_amount_restriction.0-one.year.2024",
+          value: 150,
+        },
+      ],
+    }));
+
+  it("should work with driver year limits of 1008 €", async () =>
+    await process({
+      policy: { handler: Handler.id },
+      carpool: [
+        { distance: 50_000, driver_identity_key: "one" },
+        { distance: 50_000, driver_identity_key: "one" },
+        { distance: 50_000, driver_identity_key: "one" },
+      ],
+      meta: [
+        {
+          key: "max_amount_restriction.0-one.month.3-2024",
+          value: 83_25,
+        },
+        {
+          key: "max_amount_restriction.global.campaign.global",
+          value: 83_25,
+        },
+        {
+          key: "max_amount_restriction.0-one.year.2024",
+          value: 1007_99,
+        },
+      ],
+    }, {
+      incentive: [1, 0, 0],
+      meta: [
+        {
+          key: "max_amount_restriction.global.campaign.global",
+          value: 83_26,
+        },
+        {
+          key: "max_amount_restriction.0-one.month.3-2024",
+          value: 83_26,
+        },
+        {
+          key: "max_amount_restriction.0-one.year.2024",
+          value: 1008_00,
+        },
+      ],
+    }));
+});

--- a/api/src/pdc/services/policy/interfaces/engine/PolicyInterface.ts
+++ b/api/src/pdc/services/policy/interfaces/engine/PolicyInterface.ts
@@ -57,7 +57,7 @@ export interface PolicyHandlerStaticInterface {
   readonly id: string;
   readonly tz?: Timezone;
   readonly boosterDates?: string[];
-  mode?<T>(date: Date, regular: T, booster: T): T;
+  mode?<T>(date: Date, ...args: T[] | unknown[]): T;
   /**
    * Optional max amount to spend for the policy
    */


### PR DESCRIPTION
- Ajout de la prise en charge des trajets entre NM et PDLL.
- Configuration de la période booster sur décembre 2024.
- MAJ de la description de la campagne
- Ajout du helper `dateRange()` pour générer des suites de booster dates facilement

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a `dateRange` function to generate a list of date strings between two specified dates.
	- Updated incentive structures for carpooling trips in Nantes Métropole and Pays de la Loire, including new payment rules and distance ranges.

- **Bug Fixes**
	- Enhanced logic for determining eligibility based on location and updated method signatures to improve functionality.

- **Tests**
	- Comprehensive restructuring and enhancement of unit tests for both Nantes Métropole and Pays de la Loire policies, improving coverage and clarity.

- **Documentation**
	- Updated documentation for the `dateRange` function to include usage examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->