### PR TITLE
fix: suppression de la période booster Nantes Métropole 2024

### DIFF
--- a/api/src/pdc/services/policy/engine/policies/20240101_NantesMetropole.html.ts
+++ b/api/src/pdc/services/policy/engine/policies/20240101_NantesMetropole.html.ts
@@ -41,7 +41,7 @@ export const description = `<div _ngcontent-fyn-c231="" id="summary" class="camp
   </p>
 
   <ul>
-    <li>Décembre 2024</li>
+    <!--<li>Décembre 2024</li>-->
   </ul>
 
   <p>Les restrictions suivantes seront appliquées :</p>

--- a/api/src/pdc/services/policy/engine/policies/20240101_NantesMetropole.ts
+++ b/api/src/pdc/services/policy/engine/policies/20240101_NantesMetropole.ts
@@ -1,6 +1,5 @@
 import { Timezone } from "@/pdc/providers/validator/types.ts";
 import { NotEligibleTargetException } from "@/pdc/services/policy/engine/exceptions/NotEligibleTargetException.ts";
-import { dateRange } from "@/pdc/services/policy/engine/helpers/dateRange.ts";
 import { getOperatorsAt, TimestampedOperators } from "@/pdc/services/policy/engine/helpers/getOperatorsAt.ts";
 import { isAdultOrThrow } from "@/pdc/services/policy/engine/helpers/isAdultOrThrow.ts";
 import { isOperatorClassOrThrow } from "@/pdc/services/policy/engine/helpers/isOperatorClassOrThrow.ts";
@@ -54,7 +53,7 @@ export const NantesMetropole2024: PolicyHandlerStaticInterface = class extends A
   // Liste de dates au format YYYY-MM-DD dans la zone Europe/Paris
   // pour lesquelles les règles de booster s'appliquent
   protected static boosterDates: string[] = [
-    ...dateRange("2024-12-01", "2024-12-31"),
+    // ...dateRange("2024-12-01", "2024-12-31"),
   ];
 
   protected operators: TimestampedOperators = [

--- a/api/src/pdc/services/policy/engine/policies/20240101_NantesMetropole.unit.spec.ts
+++ b/api/src/pdc/services/policy/engine/policies/20240101_NantesMetropole.unit.spec.ts
@@ -1,8 +1,11 @@
-import { it } from "@/dev_deps.ts";
+import { it, sinon } from "@/dev_deps.ts";
 import { v4 as uuidV4 } from "@/lib/uuid/index.ts";
+import { dateRange } from "@/pdc/services/policy/engine/helpers/dateRange.ts";
 import { OperatorsEnum } from "../../interfaces/index.ts";
 import { makeProcessHelper } from "../tests/macro.ts";
 import { NantesMetropole2024 as Handler } from "./20240101_NantesMetropole.ts";
+
+sinon.stub(Handler, "boosterDates").get(() => [...dateRange("2024-12-01", "2024-12-31")]);
 
 const defaultPosition = {
   arr: "44109",

--- a/api/src/pdc/services/policy/engine/policies/20240101_PaysDeLaLoire.unit.spec.ts
+++ b/api/src/pdc/services/policy/engine/policies/20240101_PaysDeLaLoire.unit.spec.ts
@@ -1,6 +1,5 @@
 import { describe, it, sinon } from "@/dev_deps.ts";
 import { v4 as uuidV4 } from "@/lib/uuid/index.ts";
-import { RunnableSlices } from "@/pdc/services/policy/interfaces/engine/PolicyInterface.ts";
 import { OperatorsEnum, TerritoryCodeInterface } from "../../interfaces/index.ts";
 import { makeProcessHelper } from "../tests/macro.ts";
 import { PaysDeLaLoire2024 as Handler } from "./20240101_PaysDeLaLoire.ts";
@@ -44,16 +43,7 @@ describe("PaysDeLaLoire2024", () => {
     end_lon: defaultLon,
   };
 
-  /**
-   * Stub the mode method while the PaysDeLaLoire2024 class has no booster dates.
-   */
-  const boosterDates: string[] = ["2024-04-16"];
-  sinon.stub(Handler, "mode").callsFake(
-    (date: Date, regular: RunnableSlices, booster: RunnableSlices) => {
-      const ymd = date.toISOString().slice(0, 10);
-      return boosterDates.includes(ymd) ? booster : regular;
-    },
-  );
+  sinon.stub(Handler, "boosterDates").get(() => ["2024-04-16"]);
 
   const process = makeProcessHelper(defaultCarpool);
 

--- a/api/src/pdc/services/policy/engine/policies/index.ts
+++ b/api/src/pdc/services/policy/engine/policies/index.ts
@@ -52,6 +52,7 @@ export const policies: Map<string, PolicyHandlerStaticInterface> = new Map(
     Lannion202305,
     LannionTregor2024,
     LaRochelle20232024,
+    LaRochelle2024,
     LavalAgglo2022,
     MetropoleRouenNormandie2022,
     MetropoleSavoie,
@@ -79,6 +80,5 @@ export const policies: Map<string, PolicyHandlerStaticInterface> = new Map(
     SMTC2024Passenger,
     TerresTouloises2024,
     Vitre2023,
-    LaRochelle2024,
   ].map((h) => [h.id, h]),
 );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated policy handling for Nantes Metropole, removing December 2024 from booster dates.
  - Added `LaRochelle2024` policy handler to the policies list.

- **Bug Fixes**
  - Enhanced error handling in the `processStateless` method to ensure proper checks for the `mode` method.

- **Tests**
  - Expanded test coverage for Nantes Metropole policy, including various scenarios and edge cases.
  - Simplified testing logic for Pays De La Loire policy by using a getter for booster dates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->