### PR TITLE
feat: disable v3

### DIFF
--- a/api/src/pdc/proxy/helpers/registerExpressRoute.ts
+++ b/api/src/pdc/proxy/helpers/registerExpressRoute.ts
@@ -23,7 +23,7 @@ export interface RouteParams {
   rpcAnswerOnFailure?: boolean;
 }
 
-const SUPPORTED_VERSIONS = ["3.0.0", "3.1.0"].map((v) => semver.parse(v));
+const SUPPORTED_VERSIONS = ["3.1.0"].map((v) => semver.parse(v));
 const defaultParams: Required<Pick<RouteParams, "successHttpCode" | "rateLimiter">> = {
   successHttpCode: 200,
   rateLimiter: {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the supported API versions for route registration, now supporting only version `3.1.0`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->