### PR TITLE
fix(aquisition) Fix interoperator_overlap naming

### DIFF
--- a/api/src/pdc/providers/carpool/repositories/CarpoolLabelRepository.integration.spec.ts
+++ b/api/src/pdc/providers/carpool/repositories/CarpoolLabelRepository.integration.spec.ts
@@ -20,7 +20,7 @@ describe("Carpool Label Repository", () => {
   // frauds
   const fraud_label_1_V3 = "interoperator_fraud";
 
-  const fraud_label_1_V3_1 = "interoperator_overlap_trip";
+  const fraud_label_1_V3_1 = "interoperator_overlap";
   const fraud_label_2_V3_1 = "interoperator_too_many_trips_by_day";
 
   const { before, after } = makeDbBeforeAfter();

--- a/notebooks/src/interoperators_overlap_trip.ipynb
+++ b/notebooks/src/interoperators_overlap_trip.ipynb
@@ -382,7 +382,7 @@
    "source": [
     "df_labels = pd.DataFrame(df_final_result['_id'])\n",
     "df_labels.columns = ['carpool_id']\n",
-    "df_labels = df_labels.assign(label='interoperator_overlap_trip')"
+    "df_labels = df_labels.assign(label='interoperator_overlap')"
    ]
   },
   {


### PR DESCRIPTION
#fixes (issues)

## Description

Fix for `interoperator_overlap` naming because [API v3.2](https://github.com/betagouv/preuve-covoiturage/blob/883b4e21c649e784bf190d539c21fd78205c0c66/api/specs/api-v3.2.yaml#L1737) specify that's the fraud fraudcheck label for interoperator overlap is an enum `interoperator_overlap` and not `interoperator_overlap_trip`

## Checklist

- [x] [j'ai suivi les guidelines du "clean code"](https://gist.github.com/wojteklu/73c6914cc446146b8b533c0988cf8d29)
- ~[ ] j'ai mis à jour la documentation technique dans `/api/specs`~
- [ ] ajout ou mise à jour des tests unitaires
- [ ] ajout ou mise à jour des tests d'intégration

## Merge

Je squash la PR et vérifie que le message de commit utilise [la convention d'Angular](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#-commit-message-format) :

<details>
<summary>Voir la convention de message de commit...</summary>

```
<type>(<scope>): <short summary>
  │       │             │
  │       │             └─⫸ Summary in present tense. Not capitalized. No period at the end.
  │       │
  │       └─⫸ Commit Scope: proxy|acquisition|export|...
  │
  └─⫸ Commit Type: build|ci|docs|feat|fix|perf|refactor|test
```
Types de commit

 - build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
 - ci: Changes to our CI configuration files and scripts (examples: Github Actions)
 - docs: Documentation only changes
 - feat: A new feature (Minor bump)
 - fix: A bug fix (Patch bump)
 - perf: A code change that improves performance
 - refactor: A code change that neither fixes a bug nor adds a feature
 - test: Adding missing tests or correcting existing tests

Le _scope_ (optionnel) précise le module ou le composant impacté par le commit.
</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated fraud label from "interoperator_overlap_trip" to "interoperator_overlap" in test and notebook environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->