### PR TITLE
MAJ Campagne : IDFM

### DIFF
--- a/api/src/db/migrations/20250117_idfm_update.sql
+++ b/api/src/db/migrations/20250117_idfm_update.sql
@@ -1,0 +1,42 @@
+-- drop dependent materialized views
+DROP MATERIALIZED VIEW IF EXISTS stats.weekly_active_campaigns;
+
+-- set max_amount to bigint as int maxes out at 2147483647
+ALTER TABLE policy.policies ALTER COLUMN max_amount TYPE bigint USING max_amount::bigint;
+
+-- recreate dependent materialized views
+CREATE MATERIALIZED VIEW stats.weekly_active_campaigns AS (
+  WITH list AS (
+         SELECT pp._id,
+            pp.name,
+            tt.name AS territory,
+            pp.start_date,
+            pp.end_date,
+            sum(pi.amount) FILTER (WHERE pi.status = 'validated'::policy.incentive_status_enum) AS validated,
+            sum(pi.amount) FILTER (WHERE pi.status = 'draft'::policy.incentive_status_enum) AS draft,
+            pp.max_amount AS enveloppe
+           FROM policy.policies pp
+             LEFT JOIN policy.incentives pi ON pp._id = pi.policy_id
+             LEFT JOIN territory.territory_group tt ON pp.territory_id = tt._id
+          WHERE pp.status = 'active'::policy.policy_status_enum AND pp.end_date > now()
+          GROUP BY pp._id, pp.name, tt.name, pp.start_date, pp.end_date, pp.max_amount
+          ORDER BY (sum(pi.amount) FILTER (WHERE pi.status = 'validated'::policy.incentive_status_enum)) DESC
+        )
+ SELECT list._id,
+    list.territory,
+    list.start_date,
+    list.end_date,
+    list.validated,
+    list.draft,
+    list.enveloppe,
+    list.validated + list.draft AS total_encours,
+    date_part('day'::text, now() - list.start_date) / date_part('day'::text, list.end_date - list.start_date) AS conso_jours,
+    list.name
+   FROM list
+);
+
+ -- grant access to the new materialized view
+GRANT SELECT ON stats.weekly_active_campaigns TO metabase;
+
+-- set IDFM max_amount value to 23 300 000 €
+UPDATE policy.policies SET max_amount = 2330000000 WHERE _id = 459;

--- a/api/src/pdc/services/policy/engine/policies/20210520_IDFM.html.ts
+++ b/api/src/pdc/services/policy/engine/policies/20210520_IDFM.html.ts
@@ -1,13 +1,13 @@
 export const description = `<p id="summary">
-  <p>Campagne d’incitation au covoiturage du <b> jeudi 20 mai 2021 au samedi 31 décembre 2024</b>, toute la semaine
+  <p>Campagne d’incitation au covoiturage du <b> jeudi 20 mai 2021 au samedi 31 décembre 2025</b>, toute la semaine
   </p>
   <p>Cette campagne est limitée à
-    <b>16 800 000 euros </b>.
+    <b>23 300 000 euros </b>.
   </p>
   <p>Les <b> conducteurs </b> effectuant un trajet d'au moins 2 km sont incités selon les règles suivantes : </p>
   <ul>
-    <li><b>De 2 à 15 km : 1.5 euros par trajet par passager.</b></li>
-    <li><b>De 15 à 30 km : 0.1 euro par trajet par km par passager.</b></li>
+    <li><b>De 2 à 15 km : 1,50 € par trajet par passager.</b></li>
+    <li><b>De 15 à 30 km : 0,10 € par trajet par km par passager.</b></li>
   </ul>
   <p>Les restrictions suivantes seront appliquées :</p>
   <ul>


### PR DESCRIPTION
- Ajout de 6,5M€ à l'enveloppe IDFM pour passer de 16,8M€ à 23,3M€
- Passage du champ `max_amount` en `bigint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Extended carpooling incentive campaign end date to December 31, 2025
  - Increased campaign budget from 16,800,000 to 23,300,000 euros

- **Bug Fixes**
  - Updated monetary values to use comma decimal separator for better readability

- **Database Changes**
  - Expanded maximum amount column to support larger budget values
  - Updated materialized view for campaign statistics
  - Granted data access to reporting tool

<!-- end of auto-generated comment: release notes by coderabbit.ai -->