### PR TITLE
Update de campagne : PBA 2023-2025

### DIFF
--- a/api/src/pdc/services/policy/engine/policies/20230401_PaysBasqueAdour.html.ts
+++ b/api/src/pdc/services/policy/engine/policies/20230401_PaysBasqueAdour.html.ts
@@ -1,33 +1,35 @@
 /* eslint-disable */
 
-export const description =
-  `<div _ngcontent-pmm-c231="" id="summary" class="campaignSummaryText-content-text">
+export const description = `<div _ngcontent-pmm-c231="" id="summary" class="campaignSummaryText-content-text">
 
-  <p>Campagne d'incitation au covoiturage du <b> 1 avril 2023 au 31 décembre 2024</b>, toute la semaine</p>
-  <p>Cette campagne est limitée à <b>265 000 euros</b>.</p>
+  <p>Campagne d'incitation au covoiturage du <b> 1 avril 2023 au 31 décembre 2025</b>, toute la semaine</p>
+  <p>Cette campagne est limitée à <b>325 000 euros</b>.</p>
   <p>Les trajets de + de 80km sont exclus à partir du 1er janvier 2024</p>
   <p>Les <b> conducteurs et passagers </b> effectuant un trajet d'au moins 5 km sont incités selon les règles suivantes :</p>
 
   <ul>
-    <li><b>De 5 à 20 km : 2 euros par trajet par passager </b></li>
-    <li><b>De 20 à 30 km : 0.1 euro par trajet par km par passager </b></li>
+    <li><b>De 5 à 20 km : 2,00 € par trajet par passager </b></li>
+    <li><b>De 20 à 30 km : 0,10 € euro par trajet par km par passager </b></li>
   </ul>
   
   <p>Les <b> passagers </b> effectuant un trajet d'au moins 5 km sont incités selon les règles suivantes :</p>
   
   <ul>
-    <li><b>Les trajets sont gratuits s'il a une origine ou une destination sur le territoire du 
-    Pays Basque Adour</b></li> (la contrepartie n'est pas prise en compte par le RPC)
+    <li>
+      <b>Les trajets sont gratuits s'il a une origine ou une destination sur le territoire du Pays Basque Adour</b><br>
+      <em>(la contrepartie n'est pas prise en compte par le RPC)</em>
+    </li>
   </ul>
   
   <p>Les restrictions suivantes seront appliquées :</p>
   
   <ul>
     <li><b>6 trajets maximum pour le conducteur par jour.</b></li>
-    <li><b>150 euros maximum pour le conducteur par mois.</b></li>
+    <li><b>100,00 € maximum pour le conducteur par mois.</b></li>
   </ul>
   
-  <p>La campagne est limitée à aux opérateurs Klaxit, Karos et Blablacar Daily proposant des preuves de classe <b>C</b>.</p>
+  <p>La campagne est limitée à l'opérateur Blablacar Daily proposant des preuves de classe <b>C</b>.</p>
   <p><em>Mobicoop ne fait plus partie des opérateurs éligibles depuis le 1 Janvier 2024</em></p>
+  <p><em>Klaxit et Karos ne font plus partie des opérateurs éligibles depuis le 1 Janvier 2025</em></p>
 
 </div>`;

--- a/api/src/pdc/services/policy/engine/policies/20230401_PaysBasqueAdour.ts
+++ b/api/src/pdc/services/policy/engine/policies/20230401_PaysBasqueAdour.ts
@@ -1,7 +1,4 @@
-import {
-  getOperatorsAt,
-  TimestampedOperators,
-} from "@/pdc/services/policy/engine/helpers/getOperatorsAt.ts";
+import { getOperatorsAt, TimestampedOperators } from "@/pdc/services/policy/engine/helpers/getOperatorsAt.ts";
 import { isAdultOrThrow } from "@/pdc/services/policy/engine/helpers/isAdultOrThrow.ts";
 import { isOperatorClassOrThrow } from "@/pdc/services/policy/engine/helpers/isOperatorClassOrThrow.ts";
 import { isOperatorOrThrow } from "@/pdc/services/policy/engine/helpers/isOperatorOrThrow.ts";
@@ -11,10 +8,7 @@ import {
   watchForPersonMaxAmountByMonth,
   watchForPersonMaxTripByDay,
 } from "@/pdc/services/policy/engine/helpers/limits.ts";
-import {
-  onDistanceRange,
-  onDistanceRangeOrThrow,
-} from "@/pdc/services/policy/engine/helpers/onDistanceRange.ts";
+import { onDistanceRange, onDistanceRangeOrThrow } from "@/pdc/services/policy/engine/helpers/onDistanceRange.ts";
 import { perKm, perSeat } from "@/pdc/services/policy/engine/helpers/per.ts";
 import { AbstractPolicyHandler } from "@/pdc/services/policy/engine/policies/AbstractPolicyHandler.ts";
 import { RunnableSlices } from "@/pdc/services/policy/interfaces/engine/PolicyInterface.ts";
@@ -28,8 +22,7 @@ import {
 import { description } from "./20230401_PaysBasqueAdour.html.ts";
 
 // Pays Basque Adour
-export const PaysBasque20232024: PolicyHandlerStaticInterface = class
-  extends AbstractPolicyHandler
+export const PaysBasque20232024: PolicyHandlerStaticInterface = class extends AbstractPolicyHandler
   implements PolicyHandlerInterface {
   static readonly id = "pays_basque_2023";
 
@@ -51,6 +44,12 @@ export const PaysBasque20232024: PolicyHandlerStaticInterface = class
         OperatorsEnum.KAROS,
       ],
     },
+    {
+      date: new Date("2025-01-01T00:00:00+0100"),
+      operators: [
+        OperatorsEnum.BLABLACAR_DAILY,
+      ],
+    },
   ];
 
   protected slices: RunnableSlices = [
@@ -62,8 +61,7 @@ export const PaysBasque20232024: PolicyHandlerStaticInterface = class
     {
       start: 20_000,
       end: 30_000,
-      fn: (ctx: StatelessContextInterface) =>
-        perSeat(ctx, perKm(ctx, { amount: 10, offset: 20_000, limit: 30_000 })),
+      fn: (ctx: StatelessContextInterface) => perSeat(ctx, perKm(ctx, { amount: 10, offset: 20_000, limit: 30_000 })),
     },
   ];
 
@@ -78,7 +76,7 @@ export const PaysBasque20232024: PolicyHandlerStaticInterface = class
       ],
       [
         "ECDE3CD4-96FF-C9D2-BA88-45754205A798",
-        150_00,
+        100_00,
         watchForPersonMaxAmountByMonth,
         LimitTargetEnum.Driver,
       ],


### PR DESCRIPTION
https://covoiturage-betagouv.zammad.com/#ticket/zoom/4848

Mise à jour de la campagne :
- enveloppe de 325 000,00 €
- Suppression de Karos au 01/01/2025
- Changement du plafond mensuel à 100,00 €

```sql
UPDATE policy.policies
SET name = 'Pays Basque Adour 2025',
    max_amount = 32500000,
    end_date = '2025-01-01T00:00:00+0200',
    status = 'active'
WHERE _id = 946
```