### PR TITLE
chore: remove 3.1 compat

### DIFF
--- a/api/src/pdc/providers/carpool/repositories/CarpoolLabelRepository.integration.spec.ts
+++ b/api/src/pdc/providers/carpool/repositories/CarpoolLabelRepository.integration.spec.ts
@@ -110,17 +110,6 @@ describe("Carpool Label Repository", () => {
     assertEquals(result, []);
   });
 
-  it("Should read carpool fraud label and returns single entry with 2 labels for api v3", async () => {
-    const result = await labelRepository.findFraudByOperatorJourneyId(
-      "v3.0",
-      insertableCarpool.operator_id,
-      insertableCarpool.operator_journey_id,
-    );
-    assertEquals(result, [{
-      label: fraud_label_1_V3,
-    }]);
-  });
-
   // fraud V3.1
   it("Should read carpool fraud label and returns 2 labels for api v3.1", async () => {
     const result = await labelRepository.findFraudByOperatorJourneyId(

--- a/api/src/pdc/providers/carpool/repositories/CarpoolLabelRepository.ts
+++ b/api/src/pdc/providers/carpool/repositories/CarpoolLabelRepository.ts
@@ -1,7 +1,6 @@
 import { provider } from "@/ilos/common/index.ts";
 import { PoolClient, PostgresConnection } from "@/ilos/connection-postgres/index.ts";
 import sql, { raw } from "@/lib/pg/sql.ts";
-import { parse, parseRange, satisfies } from "dep:semver";
 import { CarpoolLabel } from "../interfaces/database/label.ts";
 
 @provider()
@@ -51,10 +50,6 @@ export class CarpoolLabelRepository {
     const result = await cclient.query(query);
     if (result.rowCount == 0) {
       return [];
-    }
-    // = "3.0.0" or "3.0" or "3"
-    if (satisfies(parse("3.0.0"), parseRange(api_version))) {
-      return [{ label: "interoperator_fraud" }];
     }
     // >= "3.1" or "3.1.0"
     return result.rows.map(({ label }) => ({ label: label }));

--- a/api/src/pdc/proxy/helpers/registerExpressRoute.ts
+++ b/api/src/pdc/proxy/helpers/registerExpressRoute.ts
@@ -7,7 +7,7 @@ import { serverTokenMiddleware } from "@/pdc/proxy/middlewares/serverTokenMiddle
 import { express, NextFunction, Request, Response } from "dep:express";
 import { formatRange, parse, satisfies, tryParseRange } from "dep:semver";
 
-const SUPPORTED_VERSIONS = ["3.1.0", "3.2.0"].map((v) => parse(v));
+const SUPPORTED_VERSIONS = ["3.2.0"].map((v) => parse(v));
 const defaultParams: Required<Pick<RouteParams, "successHttpCode" | "rateLimiter">> = {
   successHttpCode: 200,
   rateLimiter: {

--- a/api/src/pdc/services/acquisition/actions/CreateJourneyAction.ts
+++ b/api/src/pdc/services/acquisition/actions/CreateJourneyAction.ts
@@ -12,7 +12,6 @@ import { get } from "@/lib/object/index.ts";
 import { CarpoolAcquisitionService } from "@/pdc/providers/carpool/index.ts";
 import { RegisterRequest, RegisterResponse } from "@/pdc/providers/carpool/interfaces/acquisition.ts";
 import { copyGroupIdAndApplyGroupPermissionMiddlewares } from "@/pdc/providers/middleware/index.ts";
-import { parseRange, rangeIntersects } from "dep:semver";
 import { handlerConfig, ParamsInterface, PayloadV3, ResultInterface } from "../contracts/create.contract.ts";
 import { v3alias } from "../contracts/create.schema.ts";
 
@@ -80,15 +79,9 @@ export class CreateJourneyAction extends AbstractAction {
 
   protected validateResults(context: ContextType, result: RegisterResponse): void {
     if (result.terms_violation_error_labels.length) {
-      if (
-        rangeIntersects(parseRange(">=3.1"), parseRange(context.call?.api_version_range || "3.0"))
-      ) {
-        throw new UnprocessableRequestException({
-          terms_violation_labels: result.terms_violation_error_labels,
-        });
-      }
-
-      throw new InvalidRequestException(result.terms_violation_error_labels);
+      throw new UnprocessableRequestException({
+        terms_violation_labels: result.terms_violation_error_labels,
+      });
     }
   }
 

--- a/api/src/pdc/services/acquisition/actions/StatusJourneyAction.ts
+++ b/api/src/pdc/services/acquisition/actions/StatusJourneyAction.ts
@@ -4,7 +4,6 @@ import { copyGroupIdAndApplyGroupPermissionMiddlewares } from "@/pdc/providers/m
 
 import { castToStatusEnum } from "@/pdc/providers/carpool/helpers/castStatus.ts";
 import { CarpoolStatusService } from "@/pdc/providers/carpool/providers/CarpoolStatusService.ts";
-import { parseRange, rangeIntersects } from "dep:semver";
 import { handlerConfig, ParamsInterface, ResultInterface } from "../contracts/status.contract.ts";
 import { alias } from "../contracts/status.schema.ts";
 
@@ -45,12 +44,7 @@ export class StatusJourneyAction extends AbstractAction {
       ),
       anomaly_error_details: result.anomaly as any,
       terms_violation_details: result.terms.map((f) => f.label),
-      ...(rangeIntersects(
-          parseRange(">=3.2"),
-          parseRange(context.call?.api_version_range || "3.0"),
-        )
-        ? { journey_id: result.legacy_id }
-        : {}),
+      journey_id: result.legacy_id,
     };
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Streamlined API response handling so that journey actions consistently include identifiers and errors are thrown uniformly.
  - Simplified fraud response logic by removing unnecessary version-specific conditions.

- **Chores**
  - Adjusted supported API versions to accept only version "3.2.0", meaning requests specifying an earlier version may now result in a 404 response.
  - Removed a test case related to API version "3.0" from the Carpool Label Repository test suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->