### PR TITLE
Clean up exports

### DIFF
--- a/api/src/pdc/services/export/ExportServiceProvider.ts
+++ b/api/src/pdc/services/export/ExportServiceProvider.ts
@@ -18,11 +18,11 @@ import { CarpoolRepository } from "./repositories/CarpoolRepository.ts";
 import { ExportRepository } from "./repositories/ExportRepository.ts";
 import { LogRepository } from "./repositories/LogRepository.ts";
 import { RecipientRepository } from "./repositories/RecipientRepository.ts";
+import { DataGouvFileCreatorService } from "./services/DataGouvFileCreatorService.ts";
 import { FieldService } from "./services/FieldService.ts";
 import { FileCreatorService } from "./services/FileCreatorService.ts";
 import { LogService } from "./services/LogService.ts";
 import { NameService } from "./services/NameService.ts";
-import { OpenDataFileCreatorService } from "./services/OpenDataFileCreatorService.ts";
 import { RecipientService } from "./services/RecipientService.ts";
 import { TerritoryService } from "./services/TerritoryService.ts";
 
@@ -32,7 +32,7 @@ import { TerritoryService } from "./services/TerritoryService.ts";
 const services = [
   FieldService,
   FileCreatorService,
-  OpenDataFileCreatorService,
+  DataGouvFileCreatorService,
   LogService,
   NameService,
   RecipientService,

--- a/api/src/pdc/services/export/commands/CreateCommand.ts
+++ b/api/src/pdc/services/export/commands/CreateCommand.ts
@@ -45,15 +45,15 @@ export type Options = {
     },
     {
       signature: "--target <target>",
-      description: "Select which fields to export (opendata*, operator, territory)",
-      default: ExportTarget.OPENDATA,
+      description: "Select which fields to export (territory*, operator)",
+      default: ExportTarget.TERRITORY,
       coerce(value: string): ExportTarget {
         if (Object.values(ExportTarget).includes(value as ExportTarget)) {
           return value as ExportTarget;
         }
 
-        logger.warn(`Invalid target: ${value}, using default: ${ExportTarget.OPENDATA}`);
-        return ExportTarget.OPENDATA;
+        logger.warn(`Invalid target: ${value}, using default: ${ExportTarget.TERRITORY}`);
+        return ExportTarget.TERRITORY;
       },
     },
     {

--- a/api/src/pdc/services/export/commands/ProcessCommand.ts
+++ b/api/src/pdc/services/export/commands/ProcessCommand.ts
@@ -70,7 +70,7 @@ export class ProcessCommand implements CommandInterface {
 
       const key = await this.storage.upload(filepath);
       const url = await this.storage.getPublicUrl(key);
-      await this.storage.cleanup(filepath);
+      // await this.storage.cleanup(filepath);
 
       await this.exportRepository.status(_id, ExportStatus.UPLOADED);
 

--- a/api/src/pdc/services/export/config/datagouv.ts
+++ b/api/src/pdc/services/export/config/datagouv.ts
@@ -1,6 +1,6 @@
 import { env } from "@/lib/env/index.ts";
 import { FieldFilter, Fields } from "@/pdc/services/export/models/CSVWriter.ts";
-import { CarpoolOpenDataListType } from "@/pdc/services/export/repositories/queries/CarpoolOpenDataQuery.ts";
+import { CarpoolDataGouvListType } from "../repositories/queries/CarpoolDataGouvQuery.ts";
 
 export const datagouv = {
   enabled: env("APP_DATAGOUV_ENABLED") === "true",
@@ -14,7 +14,7 @@ export const datagouv = {
  * @required
  * used by the FieldService
  */
-export const fields: Fields<CarpoolOpenDataListType> = [
+export const fields: Fields<CarpoolDataGouvListType> = [
   "journey_id",
   "trip_id",
   "journey_start_datetime",
@@ -48,4 +48,4 @@ export const fields: Fields<CarpoolOpenDataListType> = [
  * @required
  * used by the FieldService
  */
-export const filters: Array<FieldFilter<CarpoolOpenDataListType>> = [];
+export const filters: Array<FieldFilter<CarpoolDataGouvListType>> = [];

--- a/api/src/pdc/services/export/config/export.ts
+++ b/api/src/pdc/services/export/config/export.ts
@@ -132,7 +132,7 @@ export const fields: Fields<CarpoolListType> = [
  */
 export const filters: Array<FieldFilter<CarpoolListType>> = [
   {
-    target: ExportTarget.OPENDATA,
+    target: ExportTarget.DATAGOUV,
     exclusions: [
       "operator_trip_id",
       "operator_journey_id",

--- a/api/src/pdc/services/export/models/Export.ts
+++ b/api/src/pdc/services/export/models/Export.ts
@@ -11,7 +11,7 @@ export enum ExportStatus {
   FAILURE = "failure",
 }
 export enum ExportTarget {
-  OPENDATA = "opendata",
+  DATAGOUV = "datagouv",
   OPERATOR = "operator",
   TERRITORY = "territory",
 }
@@ -86,6 +86,6 @@ export class Export {
       return ExportTarget.TERRITORY;
     }
 
-    return ExportTarget.OPENDATA;
+    return ExportTarget.DATAGOUV;
   }
 }

--- a/api/src/pdc/services/export/models/Export.unit.spec.ts
+++ b/api/src/pdc/services/export/models/Export.unit.spec.ts
@@ -10,13 +10,13 @@ describe("Export", () => {
     };
   }
 
-  it("Export.setTarget() defaults to OPENDATA", () => {
-    assert(Export.target(context({})), ExportTarget.OPENDATA);
-    assert(Export.target(context({}), null), ExportTarget.OPENDATA);
-    assert(Export.target(context({}), undefined), ExportTarget.OPENDATA);
+  it("Export.setTarget() defaults to DATAGOUV", () => {
+    assert(Export.target(context({})), ExportTarget.DATAGOUV);
+    assert(Export.target(context({}), null), ExportTarget.DATAGOUV);
+    assert(Export.target(context({}), undefined), ExportTarget.DATAGOUV);
     assert(
       Export.target({ channel: { service: "missing_user" } }),
-      ExportTarget.OPENDATA,
+      ExportTarget.DATAGOUV,
     );
   });
 
@@ -24,15 +24,15 @@ describe("Export", () => {
     assert(Export.target(context({ territory_id: 1 })), ExportTarget.TERRITORY);
     assert(
       Export.target(context({ territory_id: null })),
-      ExportTarget.OPENDATA,
+      ExportTarget.DATAGOUV,
     );
     assert(
       Export.target(context({ territory_id: undefined })),
-      ExportTarget.OPENDATA,
+      ExportTarget.DATAGOUV,
     );
     assert(
       Export.target(context({ territory_id: "asdasd" })),
-      ExportTarget.OPENDATA,
+      ExportTarget.DATAGOUV,
     );
   });
 
@@ -40,15 +40,15 @@ describe("Export", () => {
     assert(Export.target(context({ operator_id: 1 })), ExportTarget.OPERATOR);
     assert(
       Export.target(context({ operator_id: null })),
-      ExportTarget.OPENDATA,
+      ExportTarget.DATAGOUV,
     );
     assert(
       Export.target(context({ operator_id: undefined })),
-      ExportTarget.OPENDATA,
+      ExportTarget.DATAGOUV,
     );
     assert(
       Export.target(context({ operator_id: "asdasd" })),
-      ExportTarget.OPENDATA,
+      ExportTarget.DATAGOUV,
     );
   });
 });

--- a/api/src/pdc/services/export/models/ExportParams.ts
+++ b/api/src/pdc/services/export/models/ExportParams.ts
@@ -32,7 +32,7 @@ export class ExportParams {
     operator_id: [],
     geo_selector: null,
     tz: this.tz,
-    target: ExportTarget.OPENDATA,
+    target: ExportTarget.DATAGOUV,
   };
 
   constructor(protected config: Config) {

--- a/api/src/pdc/services/export/repositories/CarpoolRepository.ts
+++ b/api/src/pdc/services/export/repositories/CarpoolRepository.ts
@@ -12,10 +12,7 @@ import {
   CarpoolListType,
   TemplateKeys,
 } from "@/pdc/services/export/repositories/queries/CarpoolListQuery.ts";
-import {
-  CarpoolOpenDataListType,
-  CarpoolOpenDataQuery,
-} from "@/pdc/services/export/repositories/queries/CarpoolOpenDataQuery.ts";
+import { CarpoolDataGouvListType, CarpoolDataGouvQuery } from "./queries/CarpoolDataGouvQuery.ts";
 
 export abstract class CarpoolRepositoryInterfaceResolver {
   public async list(params: ExportParams, fileWriter: CSVWriter<CarpoolListType>): Promise<void> {
@@ -24,7 +21,7 @@ export abstract class CarpoolRepositoryInterfaceResolver {
   public async listCount(params: ExportParams): Promise<number> {
     throw new Error("Not implemented");
   }
-  public async openDataList(params: ExportParams, fileWriter: CSVWriter<CarpoolOpenDataListType>): Promise<void> {
+  public async dataGouvList(params: ExportParams, fileWriter: CSVWriter<CarpoolDataGouvListType>): Promise<void> {
     throw new Error("Not implemented");
   }
 }
@@ -113,9 +110,9 @@ export class CarpoolRepository {
   /**
    * List carpools with specific filtering for the open data requirements
    */
-  public async openDataList(params: ExportParams, fileWriter: CSVWriter<CarpoolOpenDataListType>): Promise<void> {
+  public async dataGouvList(params: ExportParams, fileWriter: CSVWriter<CarpoolDataGouvListType>): Promise<void> {
     let cursor: any; // FIXME type PostgresConnection['getCursor'] fails
-    const query = CarpoolOpenDataQuery(params);
+    const query = CarpoolDataGouvQuery(params);
 
     try {
       let count = 0;
@@ -126,7 +123,7 @@ export class CarpoolRepository {
         count = results.length;
 
         for (const row of results) {
-          await fileWriter.append(new CarpoolRow<CarpoolOpenDataListType>(row));
+          await fileWriter.append(new CarpoolRow<CarpoolDataGouvListType>(row));
         }
       } while (count !== 0);
 

--- a/api/src/pdc/services/export/services/DataGouvFileCreatorService.ts
+++ b/api/src/pdc/services/export/services/DataGouvFileCreatorService.ts
@@ -1,13 +1,13 @@
 import { provider } from "@/ilos/common/index.ts";
 import { logger } from "@/lib/logger/index.ts";
-import { CarpoolOpenDataListType } from "@/pdc/services/export/repositories/queries/CarpoolOpenDataQuery.ts";
 import { CSVWriter } from "../models/CSVWriter.ts";
 import { ExportParams } from "../models/ExportParams.ts";
 import { CampaignRepository } from "../repositories/CampaignRepository.ts";
 import { CarpoolRepository } from "../repositories/CarpoolRepository.ts";
+import { CarpoolDataGouvListType } from "../repositories/queries/CarpoolDataGouvQuery.ts";
 
-export abstract class OpenDataFileCreatorServiceInterfaceResolver {
-  protected async configure(params: ExportParams, fileWriter: CSVWriter<CarpoolOpenDataListType>): Promise<void> {
+export abstract class DataGouvFileCreatorServiceInterfaceResolver {
+  protected async configure(params: ExportParams, fileWriter: CSVWriter<CarpoolDataGouvListType>): Promise<void> {
     throw new Error("Not implemented");
   }
   protected async initialize(): Promise<void> {
@@ -16,16 +16,16 @@ export abstract class OpenDataFileCreatorServiceInterfaceResolver {
   protected async data(): Promise<void> {
     throw new Error("Not implemented");
   }
-  public async write(params: ExportParams, fileWriter: CSVWriter<CarpoolOpenDataListType>): Promise<string> {
+  public async write(params: ExportParams, fileWriter: CSVWriter<CarpoolDataGouvListType>): Promise<string> {
     throw new Error("Not implemented");
   }
 }
 
 @provider({
-  identifier: OpenDataFileCreatorServiceInterfaceResolver,
+  identifier: DataGouvFileCreatorServiceInterfaceResolver,
 })
-export class OpenDataFileCreatorService {
-  protected fileWriter: CSVWriter<CarpoolOpenDataListType>;
+export class DataGouvFileCreatorService {
+  protected fileWriter: CSVWriter<CarpoolDataGouvListType>;
   protected params: ExportParams;
 
   constructor(
@@ -33,7 +33,7 @@ export class OpenDataFileCreatorService {
     protected campaignRepository: CampaignRepository,
   ) {}
 
-  protected async configure(params: ExportParams, fileWriter: CSVWriter<CarpoolOpenDataListType>): Promise<void> {
+  protected async configure(params: ExportParams, fileWriter: CSVWriter<CarpoolDataGouvListType>): Promise<void> {
     this.params = params;
     this.fileWriter = fileWriter;
   }
@@ -48,10 +48,10 @@ export class OpenDataFileCreatorService {
     this.fileWriter.addDatasource("campaigns", campaigns);
 
     // loop through the carpool data and append rows to the file
-    await this.carpoolRepository.openDataList(this.params, this.fileWriter);
+    await this.carpoolRepository.dataGouvList(this.params, this.fileWriter);
   }
 
-  public async write(params: ExportParams, fileWriter: CSVWriter<CarpoolOpenDataListType>): Promise<string> {
+  public async write(params: ExportParams, fileWriter: CSVWriter<CarpoolDataGouvListType>): Promise<string> {
     try {
       await this.configure(params, fileWriter);
       await this.initialize();

--- a/api/src/pdc/services/export/services/FieldService.ts
+++ b/api/src/pdc/services/export/services/FieldService.ts
@@ -16,7 +16,7 @@ export class FieldService {
   constructor(protected config: ConfigInterfaceResolver) {}
 
   public byTarget<T extends { [k: string]: unknown }>(target: ExportTarget): Partial<Fields<T>> {
-    const source = target === ExportTarget.OPENDATA ? "datagouv" : "export";
+    const source = target === ExportTarget.DATAGOUV ? "datagouv" : "export";
     const fields = this.config.get(`${source}.fields`, []) as Fields<T>;
     const filter = this.config.get<Array<FieldFilter<T>>>(`${source}.filters`, [])
       .find((filter: FieldFilter<T>) => filter.target === target);

--- a/api/src/pdc/services/export/services/NameService.ts
+++ b/api/src/pdc/services/export/services/NameService.ts
@@ -13,7 +13,7 @@ export abstract class NameServiceInterfaceResolver {
   public get(config: Partial<Options>): string {
     throw new Error("Not implemented");
   }
-  public opendata(datetime: Date, tz?: string): string {
+  public datagouv(datetime: Date, tz?: string): string {
     throw new Error("Not implemented");
   }
 }
@@ -24,7 +24,7 @@ export abstract class NameServiceInterfaceResolver {
 export class NameService {
   protected options: Options = {
     uuid: "",
-    target: ExportTarget.OPENDATA,
+    target: ExportTarget.DATAGOUV,
     territory: null,
   };
 
@@ -52,7 +52,7 @@ export class NameService {
       .join("-");
   }
 
-  public opendata(datetime: Date, tz = defaultTimezone): string {
+  public datagouv(datetime: Date, tz = defaultTimezone): string {
     return toTzString(datetime, tz, "yyyy-MM");
   }
 }


### PR DESCRIPTION
## Description

- renommage de `opendata` en `datagouv` pour préciser l'usage (utilisé par la commande `export:datagouv`
- utilisation de `territory` et `operator` uniquement pour la création d'exports (`export:create --target={territory|operator}`
- fix de `start_datetime` et `end_datetime` en time zone `Europe/Paris` comme spécifié dans la doc

## Checklist

- [x] [j'ai suivi les guidelines du "clean code"](https://gist.github.com/wojteklu/73c6914cc446146b8b533c0988cf8d29)
- [ ] j'ai mis à jour la documentation technique dans `/api/specs`
- [ ] ajout ou mise à jour des tests unitaires
- [ ] ajout ou mise à jour des tests d'intégration

## Merge

Je squash la PR et vérifie que le message de commit utilise [la convention d'Angular](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#-commit-message-format) :

<details>
<summary>Voir la convention de message de commit...</summary>

```
<type>(<scope>): <short summary>
  │       │             │
  │       │             └─⫸ Summary in present tense. Not capitalized. No period at the end.
  │       │
  │       └─⫸ Commit Scope: proxy|acquisition|export|...
  │
  └─⫸ Commit Type: build|ci|docs|feat|fix|perf|refactor|test
```
Types de commit

 - build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
 - ci: Changes to our CI configuration files and scripts (examples: Github Actions)
 - docs: Documentation only changes
 - feat: A new feature (Minor bump)
 - fix: A bug fix (Patch bump)
 - perf: A code change that improves performance
 - refactor: A code change that neither fixes a bug nor adds a feature
 - test: Adding missing tests or correcting existing tests

Le _scope_ (optionnel) précise le module ou le composant impacté par le commit.
</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Rebranded the export functionality so that export commands and help texts now highlight integration with data.gouv.fr with updated default targets and options.
- **Refactor**
	- Improved time zone handling in exports for more accurate data grouping and output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->