### PR TITLE
Corrige le modèle dbt de fraude trajets

### DIFF
--- a/dbt/models/fraud/trips/simultaneous_group_trips.sql
+++ b/dbt/models/fraud/trips/simultaneous_group_trips.sql
@@ -49,7 +49,7 @@ groups as (
     g.start_geo_code,
     g.end_geo_code,
     c.start_datetime,
-    (
+    ROUND(
       c.distance / 50
     )::int as distance_50m,
     count(

--- a/dbt/package-lock.yml
+++ b/dbt/package-lock.yml
@@ -1,6 +1,6 @@
 packages:
   - package: elementary-data/elementary
-    version: 0.16.1
+    version: 0.17.0
   - package: dbt-labs/dbt_utils
     version: 1.3.0
-sha1_hash: 5e34e6ad84a5aeba0c5cf59f980a54f3bb224048
+sha1_hash: 1defbed272dfe7eb54581dced4837ebf05070123


### PR DESCRIPTION
La fonction d'arrondi était manquante.