### PR TITLE
Correction du profil dbt pour pouvoir utiliser la CLI elementary

### DIFF
--- a/dbt/profiles/profiles.yml
+++ b/dbt/profiles/profiles.yml
@@ -28,5 +28,5 @@ elementary:
       password: "{{ env_var('DBT_PASSWORD', 'password') }}"
       port: "{{ env_var('DBT_PORT', 5432) | int }}"
       dbname: "{{ env_var('DBT_DBNAME', 'covoiturage_production') }}" # or database instead of dbname
-      schema: "{{ env_var('DBT_SCHEMA', '') }}"
+      schema: "{{ env_var('DBT_SCHEMA_ELEMENTARY', 'elementary') }}"
       threads: 6


### PR DESCRIPTION
Le schéma pour elementary était vide en prod ce qui entrainait un bug lors de la génération du rapport avec la CLI elementary.