### PR TITLE
Mise à jour d'elementary et ajouts des modèles relatifs aux statistiques de campagnes

### DIFF
--- a/dbt/models/metrics/_monthly_stats_acceptability_rules.yml
+++ b/dbt/models/metrics/_monthly_stats_acceptability_rules.yml
@@ -2,13 +2,15 @@ version: 2
 models:
   - name: monthly_stats_acceptability_rules
     description: >
-      Estimation du nombre de journeys ne respectant pas les règles d'acceptabilité et du montant d'incitation estimé associé.
-      Les paramètres pris pour l'estimation sont 4% des trajets ne respectant pas les règles pour un montant moyen de 1,045€.
-      Le montant moyen correspond à la moyenne entre l'incitation moyenne des trajets capturés en S1 2024 (avec Ynstant) 
-      et celle des trajets capturés en S2 2023 (Sans Ynstant).
+      Estimation du nombre de journeys ne respectant pas les règles d'acceptabilité et du montant d'incitation
+      estimé associé.
+      Les paramètres pris pour l'estimation sont 4% des trajets ne respectant pas les règles pour un montant
+      moyen de 1,045€.
+      Le montant moyen correspond à la moyenne entre l'incitation moyenne des trajets capturés en S1 2024
+      (avec Ynstant)  et celle des trajets capturés en S2 2023 (Sans Ynstant).
       Voir https://www.notion.so/KPIs-r-gle-acceptabilit-191994bec93180c38b76e8560ad1f891?pvs=4.
     columns:
-      - name: mois
+      - name: month
         data_type: timestamp with time zone
       - name: journeys_count
         data_type: numeric

--- a/dbt/models/metrics/_monthly_stats_campaigns_revenues.yml
+++ b/dbt/models/metrics/_monthly_stats_campaigns_revenues.yml
@@ -1,0 +1,42 @@
+version: 2
+models:
+  - name: monthly_stats_campaigns_revenues
+    columns:
+      - name: month
+        data_type: timestamp with time zone
+      - name: siret
+        data_type: character varying
+      - name: legal_name
+        data_type: character varying
+      - name: journeys_count
+        data_type: bigint
+      - name: avg_driver_revenue
+        data_type: numeric
+      - name: avg_distance
+        data_type: numeric
+      - name: min_revenue
+        data_type: integer
+      - name: avg_driver_revenue_per_km
+        data_type: numeric
+      - name: avg_driver_revenue_per_km_18_30
+        data_type: numeric
+      - name: avg_driver_revenue_per_km_filtered
+        data_type: numeric
+      - name: avg_driver_revenue_per_km_filtered_18_30
+        data_type: numeric
+      - name: avg_passenger_contribution_per_km
+        data_type: numeric
+      - name: avg_passenger_contribution_per_km_18_30
+        data_type: numeric
+      - name: avg_passenger_contribution_per_km_filtered
+        data_type: numeric
+      - name: avg_passenger_contribution_per_km_filtered_18_30
+        data_type: numeric
+      - name: avg_incentive_per_km
+        data_type: numeric
+      - name: avg_incentive_per_km_18_30
+        data_type: numeric
+      - name: avg_incentive_per_km_filtered
+        data_type: numeric
+      - name: avg_incentive_per_km_filtered_18_30
+        data_type: numeric

--- a/dbt/models/metrics/_monthly_stats_campaigns_revenues_by_operator.yml
+++ b/dbt/models/metrics/_monthly_stats_campaigns_revenues_by_operator.yml
@@ -1,0 +1,46 @@
+version: 2
+models:
+  - name: monthly_stats_campaigns_revenues_by_operator
+    columns:
+      - name: month
+        data_type: timestamp with time zone
+      - name: operator_id
+        data_type: integer
+      - name: operator_name
+        data_type: character varying
+      - name: siret
+        data_type: character varying
+      - name: legal_name
+        data_type: character varying
+      - name: journeys_count
+        data_type: bigint
+      - name: avg_driver_revenue
+        data_type: numeric
+      - name: avg_distance
+        data_type: numeric
+      - name: min_revenue
+        data_type: integer
+      - name: avg_driver_revenue_per_km
+        data_type: numeric
+      - name: avg_driver_revenue_per_km_18_30
+        data_type: numeric
+      - name: avg_driver_revenue_per_km_filtered
+        data_type: numeric
+      - name: avg_driver_revenue_per_km_filtered_18_30
+        data_type: numeric
+      - name: avg_passenger_contribution_per_km
+        data_type: numeric
+      - name: avg_passenger_contribution_per_km_18_30
+        data_type: numeric
+      - name: avg_passenger_contribution_per_km_filtered
+        data_type: numeric
+      - name: avg_passenger_contribution_per_km_filtered_18_30
+        data_type: numeric
+      - name: avg_incentive_per_km
+        data_type: numeric
+      - name: avg_incentive_per_km_18_30
+        data_type: numeric
+      - name: avg_incentive_per_km_filtered
+        data_type: numeric
+      - name: avg_incentive_per_km_filtered_18_30
+        data_type: numeric

--- a/dbt/models/metrics/_monthly_stats_interoperator_rules.yml
+++ b/dbt/models/metrics/_monthly_stats_interoperator_rules.yml
@@ -2,11 +2,13 @@ version: 2
 models:
   - name: monthly_stats_interoperator_rules
     description: >
-      Estimation du nombre de journeys ne respectant pas les règles antifraudes interopérateurs et du montant d'incitation estimé associé.
-      Les paramètres pris pour l'estimation sont 7% des trajets ne respectant pas les règles ce qui conerne également 7% des incitations.
+      Estimation du nombre de journeys ne respectant pas les règles antifraudes interopérateurs et du
+      montant d'incitation estimé associé.
+      Les paramètres pris pour l'estimation sont 7% des trajets ne respectant pas les règles ce qui conerne
+      également 7% des incitations.
       Voir https://www.notion.so/Calculer-le-montant-de-Fraude-inter-op-rateur-vit-1ca994bec93180ae817bee35f00a847c?pvs=4.
     columns:
-      - name: mois
+      - name: month
         data_type: timestamp with time zone
       - name: journeys_count
         data_type: numeric

--- a/dbt/models/metrics/monthly_stats_campaigns_revenues.sql
+++ b/dbt/models/metrics/monthly_stats_campaigns_revenues.sql
@@ -39,6 +39,24 @@ agg_data as (
     count(
       distinct _id
     ) as journeys_count,
+    count(
+      distinct _id
+    ) filter (
+      where distance between 18000 and 30000
+    )
+    as journeys_count_18_30,
+    count(
+      distinct _id
+    ) filter (
+      where amount > 0
+    )
+    as journeys_count_filtered,
+    count(
+      distinct _id
+    ) filter (
+      where (distance between 18000 and 30000) and amount > 0
+    )
+    as journeys_count_filtered_18_30,
     avg(
       driver_revenue / 100
     ) as avg_driver_revenue,
@@ -107,6 +125,9 @@ select
   a.siret,
   c.legal_name,
   a.journeys_count,
+  a.journeys_count_18_30,
+  a.journeys_count_filtered,
+  a.journeys_count_filtered_18_30,
   a.avg_driver_revenue,
   a.avg_distance,
   a.min_revenue,

--- a/dbt/models/metrics/monthly_stats_campaigns_revenues.sql
+++ b/dbt/models/metrics/monthly_stats_campaigns_revenues.sql
@@ -3,7 +3,7 @@
     materialized = 'incremental',
     unique_key = ['month',"siret"],
     incremental_strategy = "delete+insert",
-    indexes = [{"columns":['month',"siret"],"unique":true}]
+    indexes = [{"columns":['month',"siret"],"unique":True}]
     )
 }}
 with trips as (

--- a/dbt/models/metrics/monthly_stats_campaigns_revenues.sql
+++ b/dbt/models/metrics/monthly_stats_campaigns_revenues.sql
@@ -1,0 +1,125 @@
+{{
+  config(
+    materialized = 'incremental',
+    unique_key = ['month',"siret"],
+    incremental_strategy = "delete+insert",
+    indexes = [{"columns":['month',"siret"],"unique":true}]
+    )
+}}
+with trips as (
+  select
+    c._id,
+    oi.siret,
+    max(c.start_datetime)         as start_datetime,
+    max(c.distance)               as distance,
+    max(c.driver_revenue)         as driver_revenue,
+    max(c.passenger_contribution) as passenger_contribution,
+    sum(oi.amount)                as amount
+  from carpool_v2.carpools as c
+  left join carpool_v2.operator_incentives as oi
+    on
+      c._id = oi.carpool_id
+      {% if is_incremental() %}
+        and c.start_datetime
+        >= coalesce((select max(month) from {{ this }}), '1900-01-01')
+      {% else %}
+  where c.start_datetime >= '2022-01-01'
+{% endif %}
+  -- account for multiple incentives amounts for the same siret on the same trip
+  group by 1, 2
+),
+
+agg_data as (
+  select
+    date_trunc(
+      'month', start_datetime
+    ) as month,
+    siret,
+    count(
+      distinct _id
+    ) as journeys_count,
+    avg(
+      driver_revenue / 100
+    ) as avg_driver_revenue,
+    avg(
+      distance / 1000
+    ) as avg_distance,
+    min(
+      driver_revenue / 100
+    ) as min_revenue,
+    10
+    * avg(
+      driver_revenue::numeric / distance
+    ) as avg_driver_revenue_per_km,
+    10
+    * avg(driver_revenue::numeric / distance) filter (
+      where distance between 18000 and 30000
+    ) as avg_driver_revenue_per_km_18_30,
+    10
+    * avg(driver_revenue::numeric / distance) filter (
+      where amount > 0
+    ) as avg_driver_revenue_per_km_filtered,
+    10
+    * avg(driver_revenue::numeric / distance) filter (
+      where (distance between 18000 and 30000) and amount > 0
+    ) as avg_driver_revenue_per_km_filtered_18_30,
+    10
+    * avg(
+      passenger_contribution::numeric / distance
+    ) as avg_passenger_contribution_per_km,
+    10
+    * avg(passenger_contribution::numeric / distance) filter (
+      where distance between 18000 and 30000
+    ) as avg_passenger_contribution_per_km_18_30,
+    10
+    * avg(passenger_contribution::numeric / distance) filter (
+      where amount > 0
+    ) as avg_passenger_contribution_per_km_filtered,
+    10
+    * avg(passenger_contribution::numeric / distance) filter (
+      where (distance between 18000 and 30000) and amount > 0
+    ) as avg_passenger_contribution_per_km_filtered_18_30,
+    10
+    * avg(
+      amount::numeric / distance
+    ) as avg_incentive_per_km,
+    10
+    * avg(amount::numeric / distance) filter (
+      where distance between 18000 and 30000
+    ) as avg_incentive_per_km_18_30,
+    10
+    * avg(amount::numeric / distance) filter (
+      where amount > 0
+    ) as avg_incentive_per_km_filtered,
+    10
+    * avg(amount::numeric / distance) filter (
+      where (distance between 18000 and 30000) and amount > 0
+    ) as avg_incentive_per_km_filtered_18_30
+  from trips
+  where distance > 0
+  group by 1, 2
+  order by 1
+)
+
+select
+  a.month,
+  a.siret,
+  c.legal_name,
+  a.journeys_count,
+  a.avg_driver_revenue,
+  a.avg_distance,
+  a.min_revenue,
+  a.avg_driver_revenue_per_km,
+  a.avg_driver_revenue_per_km_18_30,
+  a.avg_driver_revenue_per_km_filtered,
+  a.avg_driver_revenue_per_km_filtered_18_30,
+  a.avg_passenger_contribution_per_km,
+  a.avg_passenger_contribution_per_km_18_30,
+  a.avg_passenger_contribution_per_km_filtered,
+  a.avg_passenger_contribution_per_km_filtered_18_30,
+  a.avg_incentive_per_km,
+  a.avg_incentive_per_km_18_30,
+  a.avg_incentive_per_km_filtered,
+  a.avg_incentive_per_km_filtered_18_30
+from agg_data as a
+left join company.companies as c on a.siret = c.siret

--- a/dbt/models/metrics/monthly_stats_campaigns_revenues.sql
+++ b/dbt/models/metrics/monthly_stats_campaigns_revenues.sql
@@ -19,10 +19,11 @@ with trips as (
   left join carpool_v2.operator_incentives as oi
     on
       c._id = oi.carpool_id
-      {% if is_incremental() %}
-        and c.start_datetime
-        >= coalesce((select max(month) from {{ this }}), '1900-01-01')
-      {% else %}
+  {% if is_incremental() %}
+    where
+      c.start_datetime
+      >= coalesce((select max(month) from {{ this }}), '1900-01-01')
+  {% else %}
   where c.start_datetime >= '2022-01-01'
 {% endif %}
   -- account for multiple incentives amounts for the same siret on the same trip

--- a/dbt/models/metrics/monthly_stats_campaigns_revenues_by_operator.sql
+++ b/dbt/models/metrics/monthly_stats_campaigns_revenues_by_operator.sql
@@ -1,0 +1,130 @@
+{{
+  config(
+    materialized = 'incremental',
+    unique_key = ['month',"operator_id","siret"],
+    incremental_strategy = "delete+insert",
+    indexes = [{"columns":['month',"operator_id","siret"],"unique":true}]
+    )
+}}
+with trips as (
+  select
+    c._id,
+    oi.siret,
+    max(c.start_datetime)         as start_datetime,
+    max(c.distance)               as distance,
+    max(operator_id)              as operator_id,
+    max(c.driver_revenue)         as driver_revenue,
+    max(c.passenger_contribution) as passenger_contribution,
+    sum(oi.amount)                as amount
+  from carpool_v2.carpools as c
+  left join carpool_v2.operator_incentives as oi
+    on
+      c._id = oi.carpool_id
+      {% if is_incremental() %}
+        and c.start_datetime
+        >= coalesce((select max(month) from {{ this }}), '1900-01-01')
+      {% else %}
+  where c.start_datetime >= '2022-01-01'
+{% endif %}
+  -- account for multiple incentives amounts for the same siret on the same trip
+  group by 1, 2
+),
+
+agg_data as (
+  select
+    date_trunc(
+      'month', start_datetime
+    ) as month,
+    operator_id,
+    siret,
+    count(
+      distinct _id
+    ) as journeys_count,
+    avg(
+      driver_revenue / 100
+    ) as avg_driver_revenue,
+    avg(
+      distance / 1000
+    ) as avg_distance,
+    min(
+      driver_revenue / 100
+    ) as min_revenue,
+    10
+    * avg(
+      driver_revenue::numeric / distance
+    ) as avg_driver_revenue_per_km,
+    10
+    * avg(driver_revenue::numeric / distance) filter (
+      where distance between 18000 and 30000
+    ) as avg_driver_revenue_per_km_18_30,
+    10
+    * avg(driver_revenue::numeric / distance) filter (
+      where amount > 0
+    ) as avg_driver_revenue_per_km_filtered,
+    10
+    * avg(driver_revenue::numeric / distance) filter (
+      where (distance between 18000 and 30000) and amount > 0
+    ) as avg_driver_revenue_per_km_filtered_18_30,
+    10
+    * avg(
+      passenger_contribution::numeric / distance
+    ) as avg_passenger_contribution_per_km,
+    10
+    * avg(passenger_contribution::numeric / distance) filter (
+      where distance between 18000 and 30000
+    ) as avg_passenger_contribution_per_km_18_30,
+    10
+    * avg(passenger_contribution::numeric / distance) filter (
+      where amount > 0
+    ) as avg_passenger_contribution_per_km_filtered,
+    10
+    * avg(passenger_contribution::numeric / distance) filter (
+      where (distance between 18000 and 30000) and amount > 0
+    ) as avg_passenger_contribution_per_km_filtered_18_30,
+    10
+    * avg(
+      amount::numeric / distance
+    ) as avg_incentive_per_km,
+    10
+    * avg(amount::numeric / distance) filter (
+      where distance between 18000 and 30000
+    ) as avg_incentive_per_km_18_30,
+    10
+    * avg(amount::numeric / distance) filter (
+      where amount > 0
+    ) as avg_incentive_per_km_filtered,
+    10
+    * avg(amount::numeric / distance) filter (
+      where (distance between 18000 and 30000) and amount > 0
+    ) as avg_incentive_per_km_filtered_18_30
+  from trips
+  where distance > 0
+  group by 1, 2, 3
+  order by 1
+)
+
+select
+  a.month,
+  a.operator_id,
+  o.name as operator_name,
+  a.siret,
+  c.legal_name,
+  a.journeys_count,
+  a.avg_driver_revenue,
+  a.avg_distance,
+  a.min_revenue,
+  a.avg_driver_revenue_per_km,
+  a.avg_driver_revenue_per_km_18_30,
+  a.avg_driver_revenue_per_km_filtered,
+  a.avg_driver_revenue_per_km_filtered_18_30,
+  a.avg_passenger_contribution_per_km,
+  a.avg_passenger_contribution_per_km_18_30,
+  a.avg_passenger_contribution_per_km_filtered,
+  a.avg_passenger_contribution_per_km_filtered_18_30,
+  a.avg_incentive_per_km,
+  a.avg_incentive_per_km_18_30,
+  a.avg_incentive_per_km_filtered,
+  a.avg_incentive_per_km_filtered_18_30
+from agg_data as a
+left join company.companies as c on a.siret = c.siret
+left join operator.operators as o on a.operator_id = o._id

--- a/dbt/models/metrics/monthly_stats_campaigns_revenues_by_operator.sql
+++ b/dbt/models/metrics/monthly_stats_campaigns_revenues_by_operator.sql
@@ -20,12 +20,13 @@ with trips as (
   left join carpool_v2.operator_incentives as oi
     on
       c._id = oi.carpool_id
-      {% if is_incremental() %}
-        and c.start_datetime
-        >= coalesce((select max(month) from {{ this }}), '1900-01-01')
-      {% else %}
-  where c.start_datetime >= '2022-01-01'
-{% endif %}
+  {% if is_incremental() %}
+    where
+      c.start_datetime
+      >= coalesce((select max(month) from {{ this }}), '1900-01-01')
+  {% else %}
+    where c.start_datetime >= '2022-01-01'
+  {% endif %}
   -- account for multiple incentives amounts for the same siret on the same trip
   group by 1, 2
 ),

--- a/dbt/models/metrics/monthly_stats_campaigns_revenues_by_operator.sql
+++ b/dbt/models/metrics/monthly_stats_campaigns_revenues_by_operator.sql
@@ -3,7 +3,7 @@
     materialized = 'incremental',
     unique_key = ['month',"operator_id","siret"],
     incremental_strategy = "delete+insert",
-    indexes = [{"columns":['month',"operator_id","siret"],"unique":true}]
+    indexes = [{"columns":['month',"operator_id","siret"],"unique":True}]
     )
 }}
 with trips as (

--- a/dbt/models/metrics/monthly_stats_campaigns_revenues_by_operator.sql
+++ b/dbt/models/metrics/monthly_stats_campaigns_revenues_by_operator.sql
@@ -41,6 +41,24 @@ agg_data as (
     count(
       distinct _id
     ) as journeys_count,
+    count(
+      distinct _id
+    ) filter (
+      where distance between 18000 and 30000
+    )
+    as journeys_count_18_30,
+    count(
+      distinct _id
+    ) filter (
+      where amount > 0
+    )
+    as journeys_count_filtered,
+    count(
+      distinct _id
+    ) filter (
+      where (distance between 18000 and 30000) and amount > 0
+    )
+    as journeys_count_filtered_18_30,
     avg(
       driver_revenue / 100
     ) as avg_driver_revenue,
@@ -111,6 +129,9 @@ select
   a.siret,
   c.legal_name,
   a.journeys_count,
+  a.journeys_count_18_30,
+  a.journeys_count_filtered,
+  a.journeys_count_filtered_18_30,
   a.avg_driver_revenue,
   a.avg_distance,
   a.min_revenue,

--- a/dbt/package-lock.yml
+++ b/dbt/package-lock.yml
@@ -1,6 +1,6 @@
 packages:
   - package: elementary-data/elementary
-    version: 0.18.1
+    version: 0.18.3
   - package: dbt-labs/dbt_utils
     version: 1.3.0
-sha1_hash: 0c6a7d8495568b692e13f43ead482b9845840663
+sha1_hash: 5f6c6fa2872bddddbaa9d5a9acba65275d4dcc9c

--- a/dbt/packages.yml
+++ b/dbt/packages.yml
@@ -1,4 +1,4 @@
 packages:
   - package: elementary-data/elementary
-    version: 0.18.1
+    version: 0.18.3
     ## Docs: https://docs.elementary-data.com

--- a/docker/dbt/prod/Dockerfile
+++ b/docker/dbt/prod/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/dbt-labs/dbt-postgres:1.9.0
+FROM ghcr.io/dbt-labs/dbt-postgres:1.9.latest
 RUN addgroup --gid 1000 dbt \
   && adduser --uid 1000 --disabled-password dbt --ingroup dbt \
   && mkdir /data/ \
@@ -7,5 +7,5 @@ RUN addgroup --gid 1000 dbt \
 WORKDIR /data
 USER dbt
 COPY --chown=dbt:dbt . /data
-RUN pip install --no-cache-dir elementary-data==0.18.0
+RUN pip install --no-cache-dir elementary-data==0.18.3
 RUN dbt deps


### PR DESCRIPTION
Mise à jour d'elementary sur la dernière version qui inclue mon changement permettant de changer les permissions S3 pour le rapport.

Ajout de deux modèles de suivis des campagnes par opérateur et SIRET.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added new monthly metrics for campaign revenues and revenues by operator, providing detailed segmentation by month, siret, and operator details.

- **Improvements**
  - Enhanced schema clarity with renamed columns (`mois` to `month`) and added new columns like `incentives_amount_sum`.
  - Updated package lock and package dependencies to version 0.18.3.
  - Upgraded Docker base image and installed package to version 0.18.3 for improved stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->