### PR TITLE
Mise à jour du modèle monthly_stats_campaigns_revenues_by_operator

### DIFF
--- a/dbt/models/metrics/_monthly_stats_campaigns_revenues.yml
+++ b/dbt/models/metrics/_monthly_stats_campaigns_revenues.yml
@@ -10,6 +10,12 @@ models:
         data_type: character varying
       - name: journeys_count
         data_type: bigint
+      - name: journeys_count_18_30
+        data_type: bigint
+      - name: journeys_count_filtered
+        data_type: bigint
+      - name: journeys_count_filtered_18_30
+        data_type: bigint
       - name: avg_driver_revenue
         data_type: numeric
       - name: avg_distance

--- a/dbt/models/metrics/_monthly_stats_campaigns_revenues_by_operator.yml
+++ b/dbt/models/metrics/_monthly_stats_campaigns_revenues_by_operator.yml
@@ -10,9 +10,23 @@ models:
         data_type: character varying
       - name: siret
         data_type: character varying
-      - name: legal_name
+      - name: siret_name
         data_type: character varying
+      - name: siret_is_aom
+        data_type: boolean
+      - name: aom_name
+        data_type: text
       - name: journeys_count
+        data_type: bigint
+      - name: journeys_count_18_30
+        data_type: bigint
+      - name: journeys_count_with_operator_incentive
+        data_type: bigint
+      - name: journeys_count_with_policy_incentive
+        data_type: bigint
+      - name: journeys_count_with_operator_incentive_18_30
+        data_type: bigint
+      - name: journeys_count_with_policy_incentive_18_30
         data_type: bigint
       - name: avg_driver_revenue
         data_type: numeric
@@ -22,25 +36,33 @@ models:
         data_type: integer
       - name: avg_driver_revenue_per_km
         data_type: numeric
+      - name: avg_driver_revenue_per_km_journeys_with_operator_incentive
+        data_type: numeric
+      - name: avg_driver_revenue_per_km_journeys_with_policy_incentive
+        data_type: numeric
       - name: avg_driver_revenue_per_km_18_30
         data_type: numeric
-      - name: avg_driver_revenue_per_km_filtered
+      - name: avg_driver_revenue_per_km_18_30_journeys_with_operator_incentiv
         data_type: numeric
-      - name: avg_driver_revenue_per_km_filtered_18_30
+      - name: avg_driver_revenue_per_km_18_30_journeys_with_policy_incentive
         data_type: numeric
       - name: avg_passenger_contribution_per_km
         data_type: numeric
+      - name: avg_passenger_contribution_per_km_journeys_with_operator_incent
+        data_type: numeric
+      - name: avg_passenger_contribution_per_km_journeys_with_policy_incentiv
+        data_type: numeric
       - name: avg_passenger_contribution_per_km_18_30
         data_type: numeric
-      - name: avg_passenger_contribution_per_km_filtered
+      - name: avg_passenger_contribution_per_km_18_30_journeys_with_operator_
         data_type: numeric
-      - name: avg_passenger_contribution_per_km_filtered_18_30
+      - name: avg_passenger_contribution_per_km_18_30_journeys_with_policy_in
         data_type: numeric
-      - name: avg_incentive_per_km
+      - name: avg_operator_incentive_per_km
         data_type: numeric
-      - name: avg_incentive_per_km_18_30
+      - name: avg_policy_incentive_per_km
         data_type: numeric
-      - name: avg_incentive_per_km_filtered
+      - name: avg_operator_incentive_per_km_18_30
         data_type: numeric
-      - name: avg_incentive_per_km_filtered_18_30
+      - name: avg_policy_incentive_per_km_18_30
         data_type: numeric


### PR DESCRIPTION
Mise à jour du modèle pour prendre en compte les données de `policy` ainsi qu'ajout d'information sur les aoms.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new journey count metrics segmented by age group (18-30) and filtering criteria in monthly campaign revenue statistics.
  * Introduced detailed journey and revenue metrics by operator, including breakdowns for operator and policy incentives, and averages per kilometer for both drivers and passengers, with specific focus on the 18-30 age group.

* **Improvements**
  * Renamed and clarified certain columns for better identification and granularity in operator-based revenue statistics.
  * Enhanced reporting with additional fields for AOM identification and names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->