### PR TITLE
fix(session): prevent storing stateless user in redis session store

### DIFF
--- a/api/src/pdc/proxy/helpers/registerExpressRoute.ts
+++ b/api/src/pdc/proxy/helpers/registerExpressRoute.ts
@@ -39,7 +39,7 @@ export function registerExpressRoute(
   app[params.method.toLocaleLowerCase()](path, [
     ...middlewares,
     asyncHandler(async (req: Request, res: Response, _next: NextFunction) => {
-      const user = req.session?.user || {};
+      const user = req.session?.user || req.stateless?.user || {};
       setSentryUser(req);
       const { api_version, ...rparams } = req.params;
 

--- a/api/src/pdc/proxy/middlewares/accessTokenMiddleware.ts
+++ b/api/src/pdc/proxy/middlewares/accessTokenMiddleware.ts
@@ -3,7 +3,7 @@ import { logger } from "@/lib/logger/index.ts";
 import { get, set } from "@/lib/object/index.ts";
 import { TokenProviderInterfaceResolver } from "@/pdc/providers/token/index.ts";
 import { DexOIDCProvider } from "@/pdc/services/auth/providers/DexOIDCProvider.ts";
-import { NextFunction, Request as ExpressRequest, Response } from "dep:express";
+import { Request as ExpressRequest, NextFunction, Response } from "dep:express";
 import { ApplicationInterface } from "../../services/application/contracts/common/interfaces/ApplicationInterface.ts";
 import { TokenPayloadInterface } from "../../services/application/contracts/common/interfaces/TokenPayloadInterface.ts";
 import { getPermissions } from "../../services/auth/config/permissions.ts";
@@ -69,7 +69,7 @@ export function dexMiddleware(kernel: KernelInterface) {
         throw new UnauthorizedException("User not found");
       }
 
-      req.session.user = {
+      req.stateless.user = {
         operator_id: data.operator_id,
         role: data.role,
         email: data.token_id,
@@ -159,7 +159,7 @@ export function legacyTokenMiddleware(kernel: KernelInterface) {
       const app = await checkApplication(kernel, payload);
 
       // inject the operator ID and permissions in the request
-      set(req, "session.user", {
+      set(req, "stateless.user", {
         application_id: app._id,
         operator_id: app.owner_id,
         permissions: app.permissions,


### PR DESCRIPTION
#fixes (issues)

Related to : 

- https://github.com/betagouv/preuve-covoiturage/pull/2887/files#diff-12cdc7a2a652acdf6a4775913f41a712bbe1df6d0a25d55036b4f28032157fd9R75
- https://github.com/betagouv/preuve-covoiturage/pull/2916/files

## Description

<!-- compléter ici -->

## Checklist

- [ ] [j'ai suivi les guidelines du "clean code"](https://gist.github.com/wojteklu/73c6914cc446146b8b533c0988cf8d29)
- [ ] j'ai mis à jour la documentation technique dans `/api/specs`
- [ ] ajout ou mise à jour des tests unitaires
- [ ] ajout ou mise à jour des tests d'intégration

## Merge

Je squash la PR et vérifie que le message de commit utilise [la convention d'Angular](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#-commit-message-format) :

<details>
<summary>Voir la convention de message de commit...</summary>

```
<type>(<scope>): <short summary>
  │       │             │
  │       │             └─⫸ Summary in present tense. Not capitalized. No period at the end.
  │       │
  │       └─⫸ Commit Scope: proxy|acquisition|export|...
  │
  └─⫸ Commit Type: build|ci|docs|feat|fix|perf|refactor|test
```
Types de commit

 - build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
 - ci: Changes to our CI configuration files and scripts (examples: Github Actions)
 - docs: Documentation only changes
 - feat: A new feature (Minor bump)
 - fix: A bug fix (Patch bump)
 - perf: A code change that improves performance
 - refactor: A code change that neither fixes a bug nor adds a feature
 - test: Adding missing tests or correcting existing tests

Le _scope_ (optionnel) précise le module ou le composant impacté par le commit.
</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated how user information is stored and retrieved during request handling to support both session-based and stateless user contexts. This may improve compatibility with stateless authentication flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->