### PR TITLE
Corrections description de campagnes

### DIFF
--- a/api/src/pdc/services/policy/engine/policies/20240401_LannionTregor.html.ts
+++ b/api/src/pdc/services/policy/engine/policies/20240401_LannionTregor.html.ts
@@ -1,8 +1,7 @@
-/* eslint-disable max-len */
-export const description =
-  `<div _ngcontent-fyn-c231="" id="summary" class="campaignSummaryText-content-text">
+export const description = `<div _ngcontent-fyn-c231="" id="summary" class="campaignSummaryText-content-text">
 
-  <p>Campagne d'incitation au covoiturage du <b> 01 avril 2024 au 31 décembre 2024</b></p>
+  <p>Campagne d'incitation au covoiturage du <b> 01 avril 2024 au 31 décembre 2025</b></p>
+
   
   <p>Cette campagne est limitée à <b>144 906,00 €</b>.</p>
 

--- a/api/src/pdc/services/policy/engine/policies/20250101_GrandChatellerault.html.ts
+++ b/api/src/pdc/services/policy/engine/policies/20250101_GrandChatellerault.html.ts
@@ -1,6 +1,6 @@
 export const description = `<div _ngcontent-fyn-c231="" id="summary" class="campaignSummaryText-content-text">
 
-  <p>Campagne d'incitation au covoiturage à partir du <b>1er janvier 2025</b></p>
+  <p>Campagne d'incitation au covoiturage du <b>1er janvier 2025</b> au <b>31 décembre 2025</b></p>
   
   <p>Cette campagne est limitée à <b>10 000,00 €</b>.</p>
 


### PR DESCRIPTION
## Description

Corrections sur les dates


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the displayed campaign dates for the Lannion-Trégor policy: extended through 31 décembre 2025 (previously ended 31 décembre 2024).
  * Clarified the Grand Châtellerault policy text to show an explicit date range: du 1er janvier 2025 au 31 décembre 2025.
  * These changes adjust the visible policy descriptions shown to end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->