### PR TITLE
migration: remove hidden column in auth.users

### DIFF
--- a/api/src/db/migrations/20260127100000-remove-hidden-user.sql
+++ b/api/src/db/migrations/20260127100000-remove-hidden-user.sql
@@ -1,0 +1,1 @@
+ALTER TABLE auth.users DROP COLUMN IF EXISTS hidden;


### PR DESCRIPTION
Suppression de la colonne `hidden` dans la table `auth.users`