### PR TITLE
Remplacement de l'URL de statistiques du RPC

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Le Registre de preuve de covoiturage est un produit [beta.gouv.fr](https://beta.
 - [Espace partenaire (territoires/opérateurs)](https://partenaire.covoiturage.beta.gouv.fr)
 - [Documentation générale](https://doc.covoiturage.beta.gouv.fr)
 - [Documentation technique](https://tech.covoiturage.beta.gouv.fr)
-- [Statistiques publiques](https://stats.covoiturage.beta.gouv.fr/public/dashboard/2084d346-8e3b-495e-9b10-b4870a35632a)
+- [Statistiques publiques](https://covoiturage.beta.gouv.fr/statistiques)
 - [Metabase (interne)](https://stats.covoiturage.beta.gouv.fr)
 - [Matomo (interne)](https://matomo.covoiturage.beta.gouv.fr)
 - [Page de statut des services](https://status.covoiturage.beta.gouv.fr)
@@ -57,7 +57,7 @@ Les différents fichiers `docker-compose.*.yml` sont utilisés en _overlay_ pour
 - Afficher les logs des services: `just logs [<service>] [-f]`
 - Stopper les services: `just stop | just down`
 
-#### Misc.
+#### Misc
 
 - Se connecter à la DB avec pgcli: `just db`
 - Lancer un REPL avec le kernel de l'API: `just debug`

--- a/api/specs/api-v3.3.yaml
+++ b/api/specs/api-v3.3.yaml
@@ -38,7 +38,7 @@ info:
     - [Le site vitrine](https://covoiturage.beta.gouv.fr/) présente le produit ;
     - [La documentation générale](https://doc.covoiturage.beta.gouv.fr/) ;
     - [Espace partenaire](https://partenaire.covoiturage.beta.gouv.fr/) permet aux opérateurs et aux territoires de gérer les campagnes ;
-    - [Les statistiques](https://stats.covoiturage.beta.gouv.fr/public/dashboard/2084d346-8e3b-495e-9b10-b4870a35632a) des chiffres clés de la Startup d'État ;
+    - [Les statistiques](https://covoiturage.beta.gouv.fr/statistiques) des chiffres clés de la Startup d'État ;
     - [Le statut des applications](https://status.covoiturage.beta.gouv.fr/) pour suivre les incidents et l'accessibilité des services ;
     - [Le générateur d'attestations sur l'honneur](https://attestation.covoiturage.beta.gouv.fr/) permet aux personnes qui covoiturent de produire facilement un document pour leur employeur dans le but de profiter du Forfait Mobilités Durables.
 

--- a/app-attestation/src/app/app.component.html
+++ b/app-attestation/src/app/app.component.html
@@ -119,7 +119,7 @@
         <p>
           Le nombre d'attestations est comptabilisé de manière anonyme sur la
           page de
-          <a href="https://stats.covoiturage.beta.gouv.fr/public/dashboard/2084d346-8e3b-495e-9b10-b4870a35632a"
+          <a href="https://covoiturage.beta.gouv.fr/statistiques"
             target="_blank" rel="noopener noreferrer">statistiques</a>
           du
           <a href="http://covoiturage.beta.gouv.fr/" target="_blank" rel="noopener noreferrer">Registre de preuve de

--- a/app-observatory/src/components/vitrine/VitrineFooter.tsx
+++ b/app-observatory/src/components/vitrine/VitrineFooter.tsx
@@ -29,7 +29,7 @@ export function VitrineFooter() {
             },
             {
               linkProps: {
-                href: "https://stats.covoiturage.beta.gouv.fr/public/dashboard/2084d346-8e3b-495e-9b10-b4870a35632a",
+                href: "https://covoiturage.beta.gouv.fr/statistiques",
                 target: "_blank",
                 title: "Notre impact | nouvelle fenêtre",
                 "aria-label": "Notre impact | nouvelle fenêtre",

--- a/app-observatory/src/components/vitrine/VitrineHeader.tsx
+++ b/app-observatory/src/components/vitrine/VitrineHeader.tsx
@@ -43,7 +43,7 @@ export function VitrineHeader() {
         {
           iconId: "fr-icon-car-line",
           linkProps: {
-            href: "https://stats.covoiturage.beta.gouv.fr/public/dashboard/2084d346-8e3b-495e-9b10-b4870a35632a",
+            href: "https://covoiturage.beta.gouv.fr/statistiques",
             target: "_blank",
           },
           text: "Notre impact",

--- a/app-partners/src/components/layout/AppFooter.tsx
+++ b/app-partners/src/components/layout/AppFooter.tsx
@@ -29,7 +29,7 @@ export function AppFooter() {
             },
             {
               linkProps: {
-                href: "https://stats.covoiturage.beta.gouv.fr/public/dashboard/2084d346-8e3b-495e-9b10-b4870a35632a",
+                href: "https://covoiturage.beta.gouv.fr/statistiques",
                 target: "_blank",
                 title: "Notre impact | nouvelle fenêtre",
                 "aria-label": "Notre impact | nouvelle fenêtre",


### PR DESCRIPTION
Utilisation de l'URL `/statistiques` redirigée vers Metabase