### PR TITLE
Contrôle de la publication des données de l'observatoire

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ dbt/edr_target
 .claude/settings.local.json
 .claude/settings.json
 .claude/worktrees
+.claude/superpowers
 .mcp.json
 .worktrees
 

--- a/api/.env.example
+++ b/api/.env.example
@@ -158,3 +158,16 @@ DEX_GRPC_PORT=
 BREVO_API_KEY=your-brevo-api-key                                                                                                                                                     
 BREVO_WELCOME_TEMPLATE_ID=123  
 BREVO_API_URL=https://api.brevo.com/v3/smtp/email
+
+##
+# Observatory Service
+#
+# Cutoff date for observatory endpoint data. (format: YYYY-MM-DD)
+# Default: null (displays all data)
+# - month     : exclusive (current month is hidden)
+# - trimester : inclusive
+# - semester  : inclusive
+# - year      : inclusive
+#
+# APP_OBSERVATORY_PUBLISHED_UNTIL
+

--- a/api/src/pdc/services/observatory/ObservatoryServiceProvider.ts
+++ b/api/src/pdc/services/observatory/ObservatoryServiceProvider.ts
@@ -14,6 +14,7 @@ import { KeyfiguresAction } from "./actions/keyfigures/KeyfiguresAction.ts";
 import { LocationAction } from "./actions/location/LocationAction.ts";
 import { BestTerritoriesAction } from "./actions/occupation/BestTerritoriesAction.ts";
 import { EvolOccupationAction } from "./actions/occupation/EvolOccupationAction.ts";
+import { LastRecordAction } from "./actions/LastRecordAction.ts";
 import { OccupationAction } from "./actions/occupation/OccupationAction.ts";
 import { DistributionRepositoryProvider } from "./providers/DistributionRepositoryProvider.ts";
 import { FluxRepositoryProvider } from "./providers/FluxRepositoryProvider.ts";
@@ -22,6 +23,7 @@ import { IncentiveRepositoryProvider } from "./providers/IncentiveRepositoryProv
 import { InfraRepositoryProvider } from "./providers/InfraRepositoryProvider.ts";
 import { KeyfiguresRepositoryProvider } from "./providers/KeyfiguresRepositoryProvider.ts";
 import { LocationRepositoryProvider } from "./providers/LocationRepositoryProvider.ts";
+import { LastRecordRepositoryProvider } from "./providers/LastRecordRepositoryProvider.ts";
 import { OccupationRepositoryProvider } from "./providers/OccupationRepositoryProvider.ts";
 
 @serviceProvider({
@@ -35,6 +37,7 @@ import { OccupationRepositoryProvider } from "./providers/OccupationRepositoryPr
     OccupationRepositoryProvider,
     IncentiveRepositoryProvider,
     IncentiveCampaignsRepositoryProvider,
+    LastRecordRepositoryProvider,
   ],
   handlers: [
     AiresCovoiturageAction,
@@ -50,6 +53,7 @@ import { OccupationRepositoryProvider } from "./providers/OccupationRepositoryPr
     KeyfiguresAction,
     OccupationAction,
     CampaignsAction,
+    LastRecordAction,
   ],
   middlewares: [...defaultMiddlewareBindings, [
     "validate",

--- a/api/src/pdc/services/observatory/actions/LastRecordAction.ts
+++ b/api/src/pdc/services/observatory/actions/LastRecordAction.ts
@@ -24,7 +24,7 @@ export class LastRecordAction extends AbstractAction {
     super();
   }
 
-  public async handle(params: LastRecord): Promise<ResultInterface> {
+  public override async handle(params: LastRecord): Promise<ResultInterface> {
     const cutoff = config.observatory.publishedUntil;
     let maxYear: number | undefined;
     let maxMonth: number | undefined;

--- a/api/src/pdc/services/observatory/actions/LastRecordAction.ts
+++ b/api/src/pdc/services/observatory/actions/LastRecordAction.ts
@@ -1,0 +1,45 @@
+import { handler } from "@/ilos/common/index.ts";
+import { Action as AbstractAction } from "@/ilos/core/index.ts";
+import { config } from "../config/index.ts";
+import { LastRecord } from "../dto/LastRecord.ts";
+import { LastRecordRepositoryInterfaceResolver } from "../interfaces/LastRecordRepositoryProviderInterface.ts";
+
+export type ResultInterface = { year: number; month: number } | null;
+
+@handler({
+  service: "observatory",
+  method: "getLastRecord",
+  middlewares: [[
+    "validate",
+    LastRecord,
+  ]],
+  apiRoute: {
+    path: "/observatory/last-record",
+    method: "GET",
+    public: true,
+  },
+})
+export class LastRecordAction extends AbstractAction {
+  constructor(private repository: LastRecordRepositoryInterfaceResolver) {
+    super();
+  }
+
+  public async handle(params: LastRecord): Promise<ResultInterface> {
+    const cutoff = config.observatory.publishedUntil;
+    let maxYear: number | undefined;
+    let maxMonth: number | undefined;
+
+    if (cutoff) {
+      const parts = cutoff.split("-").map(Number);
+      if (parts.length >= 2 && !parts.some(isNaN)) {
+        // Cutoff is exclusive: 2026-03-01 means last valid month is Feb 2026
+        const d = new Date(parts[0], parts[1] - 1, parts[2] || 1);
+        d.setMonth(d.getMonth() - 1);
+        maxYear = d.getFullYear();
+        maxMonth = d.getMonth() + 1;
+      }
+    }
+
+    return this.repository.getLastRecord(params, maxYear, maxMonth);
+  }
+}

--- a/api/src/pdc/services/observatory/actions/distribution/JourneysByDistancesAction.ts
+++ b/api/src/pdc/services/observatory/actions/distribution/JourneysByDistancesAction.ts
@@ -4,6 +4,7 @@ import { Infer } from "@/lib/superstruct/index.ts";
 import { Direction } from "@/pdc/providers/superstruct/shared/index.ts";
 import { JourneysByDistances } from "@/pdc/services/observatory/dto/distribution/JourneysByDistances.ts";
 import { DistributionRepositoryInterfaceResolver } from "@/pdc/services/observatory/interfaces/DistributionRepositoryProviderInterface.ts";
+import { isPublished } from "../../helpers/publishedDate.ts";
 export type ResultInterface = {
   code: string;
   libelle: string;
@@ -33,6 +34,7 @@ export class JourneysByDistancesAction extends AbstractAction {
   }
 
   public async handle(params: JourneysByDistances): Promise<ResultInterface> {
+    if (!isPublished(params)) return [];
     return this.repository.getJourneysByDistances(params);
   }
 }

--- a/api/src/pdc/services/observatory/actions/distribution/JourneysByHoursAction.ts
+++ b/api/src/pdc/services/observatory/actions/distribution/JourneysByHoursAction.ts
@@ -4,6 +4,7 @@ import { Infer } from "@/lib/superstruct/index.ts";
 import { Direction } from "@/pdc/providers/superstruct/shared/index.ts";
 import { JourneysByHours } from "@/pdc/services/observatory/dto/distribution/JourneysByHours.ts";
 import { DistributionRepositoryInterfaceResolver } from "../../interfaces/DistributionRepositoryProviderInterface.ts";
+import { isPublished } from "../../helpers/publishedDate.ts";
 export type ResultInterface = {
   code: string;
   libelle: string;
@@ -35,6 +36,7 @@ export class JourneysByHoursAction extends AbstractAction {
   }
 
   public async handle(params: JourneysByHours): Promise<ResultInterface> {
+    if (!isPublished(params)) return [];
     return this.repository.getJourneysByHours(params);
   }
 }

--- a/api/src/pdc/services/observatory/actions/flux/BestFluxAction.ts
+++ b/api/src/pdc/services/observatory/actions/flux/BestFluxAction.ts
@@ -2,6 +2,7 @@ import { handler } from "@/ilos/common/index.ts";
 import { Action as AbstractAction } from "@/ilos/core/index.ts";
 import { BestFlux } from "@/pdc/services/observatory/dto/flux/BestFlux.ts";
 import { FluxRepositoryInterfaceResolver } from "@/pdc/services/observatory/interfaces/FluxRepositoryProviderInterface.ts";
+import { isPublished } from "../../helpers/publishedDate.ts";
 export type ResultInterface = {
   territory_1: BestFlux["code"];
   l_territory_1: string;
@@ -29,6 +30,7 @@ export class BestFluxAction extends AbstractAction {
   }
 
   public async handle(params: BestFlux): Promise<ResultInterface> {
+    if (!isPublished(params)) return [];
     return this.repository.getBestFlux(params);
   }
 }

--- a/api/src/pdc/services/observatory/actions/flux/EvolFluxAction.ts
+++ b/api/src/pdc/services/observatory/actions/flux/EvolFluxAction.ts
@@ -2,6 +2,7 @@ import { handler } from "@/ilos/common/index.ts";
 import { Action as AbstractAction } from "@/ilos/core/index.ts";
 import { EvolFlux } from "@/pdc/services/observatory/dto/flux/EvolFlux.ts";
 import { FluxRepositoryInterfaceResolver } from "@/pdc/services/observatory/interfaces/FluxRepositoryProviderInterface.ts";
+import { isPublished } from "../../helpers/publishedDate.ts";
 export type ResultInterface = {
   territory: EvolFlux["code"];
   l_territory: string;
@@ -31,6 +32,7 @@ export class EvolFluxAction extends AbstractAction {
   }
 
   public async handle(params: EvolFlux): Promise<ResultInterface> {
+    if (!isPublished(params)) return [];
     return this.repository.getEvolFlux(params);
   }
 }

--- a/api/src/pdc/services/observatory/actions/flux/FluxAction.ts
+++ b/api/src/pdc/services/observatory/actions/flux/FluxAction.ts
@@ -2,6 +2,7 @@ import { handler } from "@/ilos/common/index.ts";
 import { Action as AbstractAction } from "@/ilos/core/index.ts";
 import { Flux } from "@/pdc/services/observatory/dto/flux/Flux.ts";
 import { FluxRepositoryInterfaceResolver } from "../../interfaces/FluxRepositoryProviderInterface.ts";
+import { isPublished } from "../../helpers/publishedDate.ts";
 export type ResultInterface = {
   ter_1: Flux["code"];
   lng_1: number;
@@ -33,6 +34,7 @@ export class FluxAction extends AbstractAction {
   }
 
   public async handle(params: Flux): Promise<ResultInterface> {
+    if (!isPublished(params)) return [];
     return this.repository.getFlux(params);
   }
 }

--- a/api/src/pdc/services/observatory/actions/incentive/IncentiveAction.ts
+++ b/api/src/pdc/services/observatory/actions/incentive/IncentiveAction.ts
@@ -4,6 +4,7 @@ import { Infer } from "@/lib/superstruct/index.ts";
 import { Direction } from "@/pdc/providers/superstruct/shared/index.ts";
 import { Incentive } from "@/pdc/services/observatory/dto/Incentive.ts";
 import { IncentiveRepositoryInterfaceResolver } from "../../interfaces/IncentiveRepositoryProviderInterface.ts";
+import { isPublished } from "../../helpers/publishedDate.ts";
 
 export type ResultInterface = {
   code: Incentive["code"];
@@ -33,6 +34,7 @@ export class IncentiveAction extends AbstractAction {
   }
 
   public async handle(params: Incentive): Promise<ResultInterface> {
+    if (!isPublished(params)) return [];
     return this.repository.getIncentive(params);
   }
 }

--- a/api/src/pdc/services/observatory/actions/keyfigures/KeyfiguresAction.ts
+++ b/api/src/pdc/services/observatory/actions/keyfigures/KeyfiguresAction.ts
@@ -4,6 +4,7 @@ import { Infer } from "@/lib/superstruct/index.ts";
 import { Direction } from "@/pdc/providers/superstruct/shared/index.ts";
 import { KeyFigures } from "@/pdc/services/observatory/dto/KeyFigures.ts";
 import { KeyfiguresRepositoryInterfaceResolver } from "../../interfaces/KeyfiguresRepositoryProviderInterface.ts";
+import { isPublished } from "../../helpers/publishedDate.ts";
 export type ResultInterface = {
   territory: KeyFigures["code"];
   l_territory: string;
@@ -38,6 +39,7 @@ export class KeyfiguresAction extends AbstractAction {
   }
 
   public async handle(params: KeyFigures): Promise<ResultInterface> {
+    if (!isPublished(params)) return [];
     return this.repository.getKeyfigures(params);
   }
 }

--- a/api/src/pdc/services/observatory/actions/location/LocationAction.ts
+++ b/api/src/pdc/services/observatory/actions/location/LocationAction.ts
@@ -2,6 +2,7 @@ import { handler } from "@/ilos/common/index.ts";
 import { Action as AbstractAction } from "@/ilos/core/index.ts";
 import { Location } from "@/pdc/services/observatory/dto/Location.ts";
 import { LocationRepositoryInterfaceResolver } from "../../interfaces/LocationRepositoryProviderInterface.ts";
+import { isPublished } from "../../helpers/publishedDate.ts";
 export type ResultInterface = {
   hex: string;
   count: number;
@@ -26,6 +27,7 @@ export class LocationAction extends AbstractAction {
   }
 
   public async handle(params: Location): Promise<ResultInterface> {
+    if (!isPublished(params)) return [];
     return this.repository.getLocation(params);
   }
 }

--- a/api/src/pdc/services/observatory/actions/occupation/BestTerritoriesAction.ts
+++ b/api/src/pdc/services/observatory/actions/occupation/BestTerritoriesAction.ts
@@ -2,6 +2,7 @@ import { handler } from "@/ilos/common/index.ts";
 import { Action as AbstractAction } from "@/ilos/core/index.ts";
 import { BestTerritories } from "@/pdc/services/observatory/dto/occupation/BestTerritories.ts";
 import { OccupationRepositoryInterfaceResolver } from "@/pdc/services/observatory/interfaces/OccupationRepositoryProviderInterface.ts";
+import { isPublished } from "../../helpers/publishedDate.ts";
 export type ResultInterface = {
   territory: BestTerritories["code"];
   l_territory: string;
@@ -27,6 +28,7 @@ export class BestTerritoriesAction extends AbstractAction {
   }
 
   public async handle(params: BestTerritories): Promise<ResultInterface> {
+    if (!isPublished(params)) return [];
     return this.repository.getBestTerritories(params);
   }
 }

--- a/api/src/pdc/services/observatory/actions/occupation/EvolOccupationAction.ts
+++ b/api/src/pdc/services/observatory/actions/occupation/EvolOccupationAction.ts
@@ -2,6 +2,7 @@ import { handler } from "@/ilos/common/index.ts";
 import { Action as AbstractAction } from "@/ilos/core/index.ts";
 import { EvolOccupation } from "@/pdc/services/observatory/dto/occupation/EvolOccupation.ts";
 import { OccupationRepositoryInterfaceResolver } from "@/pdc/services/observatory/interfaces/OccupationRepositoryProviderInterface.ts";
+import { isPublished } from "../../helpers/publishedDate.ts";
 export type ResultInterface = {
   territory: EvolOccupation["code"];
   l_territory: string;
@@ -30,6 +31,7 @@ export class EvolOccupationAction extends AbstractAction {
   }
 
   public async handle(params: EvolOccupation): Promise<ResultInterface> {
+    if (!isPublished(params)) return [];
     return this.repository.getEvolOccupation(params);
   }
 }

--- a/api/src/pdc/services/observatory/actions/occupation/OccupationAction.ts
+++ b/api/src/pdc/services/observatory/actions/occupation/OccupationAction.ts
@@ -2,6 +2,7 @@ import { handler } from "@/ilos/common/index.ts";
 import { Action as AbstractAction } from "@/ilos/core/index.ts";
 import { Occupation } from "@/pdc/services/observatory/dto/occupation/Occupation.ts";
 import { OccupationRepositoryInterfaceResolver } from "@/pdc/services/observatory/interfaces/OccupationRepositoryProviderInterface.ts";
+import { isPublished } from "../../helpers/publishedDate.ts";
 import type { Feature } from "dep:turf-helpers";
 export type ResultInterface = {
   territory: Occupation["code"];
@@ -31,6 +32,7 @@ export class OccupationAction extends AbstractAction {
   }
 
   public async handle(params: Occupation): Promise<ResultInterface> {
+    if (!isPublished(params)) return [];
     return this.repository.getOccupation(params);
   }
 }

--- a/api/src/pdc/services/observatory/config/index.ts
+++ b/api/src/pdc/services/observatory/config/index.ts
@@ -1,0 +1,9 @@
+import { env } from "@/lib/env/index.ts";
+
+export const config = {
+  observatory: {
+    get publishedUntil() {
+      return env("APP_OBSERVATORY_PUBLISHED_UNTIL");
+    },
+  },
+};

--- a/api/src/pdc/services/observatory/dto/LastRecord.ts
+++ b/api/src/pdc/services/observatory/dto/LastRecord.ts
@@ -1,0 +1,12 @@
+import { Infer, object } from "@/lib/superstruct/index.ts";
+import {
+  TerritoryCode,
+  TerritoryType,
+} from "@/pdc/providers/superstruct/shared/index.ts";
+
+export const LastRecord = object({
+  type: TerritoryType,
+  code: TerritoryCode,
+});
+
+export type LastRecord = Infer<typeof LastRecord>;

--- a/api/src/pdc/services/observatory/helpers/publishedDate.ts
+++ b/api/src/pdc/services/observatory/helpers/publishedDate.ts
@@ -8,30 +8,34 @@ type PeriodParams = {
 };
 
 /**
- * Compute the exclusive upper bound date for a requested period.
- * E.g. month=2 (Feb) -> March 1st; year=2026 -> Jan 1st 2027.
+ * Compute the first day of a requested period.
+ * E.g. month=2 -> Feb 1st; trimester=1 -> Jan 1st; year=2026 -> Jan 1st.
  */
-export function getPeriodEnd(params: PeriodParams): Date {
+export function getPeriodStart(params: PeriodParams): Date {
   if (params.month !== undefined) {
-    // month is 1-based in params, 0-based in Date() => params.month maps to next month
-    return new Date(params.year, params.month, 1);
+    return new Date(params.year, params.month - 1, 1);
   }
   if (params.trimester !== undefined) {
-    return new Date(params.year, params.trimester * 3, 1);
+    return new Date(params.year, (params.trimester - 1) * 3, 1);
   }
   if (params.semester !== undefined) {
-    return new Date(params.year, params.semester * 6, 1);
+    return new Date(params.year, (params.semester - 1) * 6, 1);
   }
-  return new Date(params.year + 1, 0, 1);
+  return new Date(params.year, 0, 1);
 }
 
 /**
  * Check if a requested period is published based on
  * APP_OBSERVATORY_PUBLISHED_UNTIL (exclusive upper bound).
  *
+ * Uses rolling logic: a period is visible if its start date
+ * is strictly before the cutoff. This means partial trimesters,
+ * semesters, and years are shown as long as they contain data
+ * before the cutoff.
+ *
  * Returns true (published) when:
  * - config value is unset (backwards compatible, no gate)
- * - the period end date is <= the cutoff date
+ * - the period start date is strictly before the cutoff date
  *
  * NOTE: This assumes no response caching on observatory routes.
  * If route caching is added, cutoff changes require cache invalidation.
@@ -40,9 +44,12 @@ export function isPublished(params: PeriodParams): boolean {
   const cutoff = config.observatory.publishedUntil;
   if (!cutoff) return true;
 
-  const cutoffDate = new Date(cutoff);
-  if (isNaN(cutoffDate.getTime())) return false;
+  // Parse YYYY-MM-DD as local time to match getPeriodStart (also local time).
+  // new Date("2026-03-01") would create UTC midnight, causing timezone mismatches.
+  const parts = cutoff.split("-").map(Number);
+  if (parts.length !== 3 || parts.some(isNaN)) return false;
+  const cutoffDate = new Date(parts[0], parts[1] - 1, parts[2]);
 
-  const periodEnd = getPeriodEnd(params);
-  return periodEnd <= cutoffDate;
+  const periodStart = getPeriodStart(params);
+  return periodStart < cutoffDate;
 }

--- a/api/src/pdc/services/observatory/helpers/publishedDate.ts
+++ b/api/src/pdc/services/observatory/helpers/publishedDate.ts
@@ -1,0 +1,48 @@
+import { config } from "../config/index.ts";
+
+type PeriodParams = {
+  year: number;
+  month?: number;
+  trimester?: number;
+  semester?: number;
+};
+
+/**
+ * Compute the exclusive upper bound date for a requested period.
+ * E.g. month=2 (Feb) -> March 1st; year=2026 -> Jan 1st 2027.
+ */
+export function getPeriodEnd(params: PeriodParams): Date {
+  if (params.month !== undefined) {
+    // month is 1-based in params, 0-based in Date() => params.month maps to next month
+    return new Date(params.year, params.month, 1);
+  }
+  if (params.trimester !== undefined) {
+    return new Date(params.year, params.trimester * 3, 1);
+  }
+  if (params.semester !== undefined) {
+    return new Date(params.year, params.semester * 6, 1);
+  }
+  return new Date(params.year + 1, 0, 1);
+}
+
+/**
+ * Check if a requested period is published based on
+ * APP_OBSERVATORY_PUBLISHED_UNTIL (exclusive upper bound).
+ *
+ * Returns true (published) when:
+ * - config value is unset (backwards compatible, no gate)
+ * - the period end date is <= the cutoff date
+ *
+ * NOTE: This assumes no response caching on observatory routes.
+ * If route caching is added, cutoff changes require cache invalidation.
+ */
+export function isPublished(params: PeriodParams): boolean {
+  const cutoff = config.observatory.publishedUntil;
+  if (!cutoff) return true;
+
+  const cutoffDate = new Date(cutoff);
+  if (isNaN(cutoffDate.getTime())) return false;
+
+  const periodEnd = getPeriodEnd(params);
+  return periodEnd <= cutoffDate;
+}

--- a/api/src/pdc/services/observatory/helpers/publishedDate.unit.spec.ts
+++ b/api/src/pdc/services/observatory/helpers/publishedDate.unit.spec.ts
@@ -1,40 +1,48 @@
 import { assertEquals } from "dep:assert";
 import { afterEach, describe, it } from "dep:testing-bdd";
-import { getPeriodEnd, isPublished } from "./publishedDate.ts";
+import { getPeriodStart, isPublished } from "./publishedDate.ts";
 
-describe("getPeriodEnd", () => {
-  it("month: returns first day of next month", () => {
-    assertEquals(getPeriodEnd({ year: 2026, month: 2 }), new Date(2026, 2, 1));
+describe("getPeriodStart", () => {
+  it("month=2: returns Feb 1st", () => {
+    assertEquals(getPeriodStart({ year: 2026, month: 2 }), new Date(2026, 1, 1));
   });
 
-  it("month=12: rolls over to next year", () => {
-    assertEquals(getPeriodEnd({ year: 2026, month: 12 }), new Date(2027, 0, 1));
+  it("month=1: returns Jan 1st", () => {
+    assertEquals(getPeriodStart({ year: 2026, month: 1 }), new Date(2026, 0, 1));
   });
 
-  it("trimester=1: Q1 ends at April", () => {
-    assertEquals(getPeriodEnd({ year: 2026, trimester: 1 }), new Date(2026, 3, 1));
+  it("month=12: returns Dec 1st", () => {
+    assertEquals(getPeriodStart({ year: 2026, month: 12 }), new Date(2026, 11, 1));
   });
 
-  it("trimester=4: Q4 rolls to next year", () => {
-    assertEquals(getPeriodEnd({ year: 2026, trimester: 4 }), new Date(2027, 0, 1));
+  it("trimester=1: returns Jan 1st", () => {
+    assertEquals(getPeriodStart({ year: 2026, trimester: 1 }), new Date(2026, 0, 1));
   });
 
-  it("semester=1: H1 ends at July", () => {
-    assertEquals(getPeriodEnd({ year: 2026, semester: 1 }), new Date(2026, 6, 1));
+  it("trimester=2: returns Apr 1st", () => {
+    assertEquals(getPeriodStart({ year: 2026, trimester: 2 }), new Date(2026, 3, 1));
   });
 
-  it("semester=2: H2 rolls to next year", () => {
-    assertEquals(getPeriodEnd({ year: 2026, semester: 2 }), new Date(2027, 0, 1));
+  it("trimester=4: returns Oct 1st", () => {
+    assertEquals(getPeriodStart({ year: 2026, trimester: 4 }), new Date(2026, 9, 1));
   });
 
-  it("year only: returns Jan 1 of next year", () => {
-    assertEquals(getPeriodEnd({ year: 2026 }), new Date(2027, 0, 1));
+  it("semester=1: returns Jan 1st", () => {
+    assertEquals(getPeriodStart({ year: 2026, semester: 1 }), new Date(2026, 0, 1));
+  });
+
+  it("semester=2: returns Jul 1st", () => {
+    assertEquals(getPeriodStart({ year: 2026, semester: 2 }), new Date(2026, 6, 1));
+  });
+
+  it("year only: returns Jan 1st", () => {
+    assertEquals(getPeriodStart({ year: 2026 }), new Date(2026, 0, 1));
   });
 
   it("month takes priority over trimester", () => {
     assertEquals(
-      getPeriodEnd({ year: 2026, month: 3, trimester: 1 }),
-      new Date(2026, 3, 1),
+      getPeriodStart({ year: 2026, month: 3, trimester: 1 }),
+      new Date(2026, 2, 1),
     );
   });
 });
@@ -49,42 +57,63 @@ describe("isPublished", () => {
     assertEquals(isPublished({ year: 2099, month: 12 }), true);
   });
 
-  it("returns true when period is before cutoff", () => {
+  it("returns true when month starts before cutoff", () => {
     Deno.env.set("APP_OBSERVATORY_PUBLISHED_UNTIL", "2026-03-01");
     assertEquals(isPublished({ year: 2026, month: 2 }), true);
   });
 
-  it("returns false when period equals cutoff", () => {
+  it("returns false when month starts at cutoff (exclusive)", () => {
     Deno.env.set("APP_OBSERVATORY_PUBLISHED_UNTIL", "2026-03-01");
     assertEquals(isPublished({ year: 2026, month: 3 }), false);
   });
 
-  it("returns false when period is after cutoff", () => {
+  it("returns false when month starts after cutoff", () => {
     Deno.env.set("APP_OBSERVATORY_PUBLISHED_UNTIL", "2026-03-01");
     assertEquals(isPublished({ year: 2026, month: 6 }), false);
   });
 
-  it("works with trimester", () => {
-    Deno.env.set("APP_OBSERVATORY_PUBLISHED_UNTIL", "2026-04-01");
+  // Rolling: trimester is included if it starts before cutoff
+  it("trimester: Q1 included with cutoff 2026-03-01 (rolling)", () => {
+    Deno.env.set("APP_OBSERVATORY_PUBLISHED_UNTIL", "2026-03-01");
     assertEquals(isPublished({ year: 2026, trimester: 1 }), true);
+  });
+
+  it("trimester: Q2 excluded with cutoff 2026-03-01", () => {
+    Deno.env.set("APP_OBSERVATORY_PUBLISHED_UNTIL", "2026-03-01");
     assertEquals(isPublished({ year: 2026, trimester: 2 }), false);
   });
 
-  it("works with semester", () => {
-    Deno.env.set("APP_OBSERVATORY_PUBLISHED_UNTIL", "2026-07-01");
+  // Rolling: semester is included if it starts before cutoff
+  it("semester: H1 included with cutoff 2026-03-01 (rolling)", () => {
+    Deno.env.set("APP_OBSERVATORY_PUBLISHED_UNTIL", "2026-03-01");
     assertEquals(isPublished({ year: 2026, semester: 1 }), true);
+  });
+
+  it("semester: H2 excluded with cutoff 2026-03-01", () => {
+    Deno.env.set("APP_OBSERVATORY_PUBLISHED_UNTIL", "2026-03-01");
     assertEquals(isPublished({ year: 2026, semester: 2 }), false);
   });
 
-  it("works with year only", () => {
-    Deno.env.set("APP_OBSERVATORY_PUBLISHED_UNTIL", "2027-01-01");
+  // Rolling: year is included if it starts before cutoff
+  it("year: 2026 included with cutoff 2026-03-01 (rolling)", () => {
+    Deno.env.set("APP_OBSERVATORY_PUBLISHED_UNTIL", "2026-03-01");
     assertEquals(isPublished({ year: 2026 }), true);
+  });
+
+  it("year: 2027 excluded with cutoff 2026-03-01", () => {
+    Deno.env.set("APP_OBSERVATORY_PUBLISHED_UNTIL", "2026-03-01");
     assertEquals(isPublished({ year: 2027 }), false);
   });
 
-  it("boundary: cutoff exactly at period end is published", () => {
-    Deno.env.set("APP_OBSERVATORY_PUBLISHED_UNTIL", "2026-04-01");
-    assertEquals(isPublished({ year: 2026, trimester: 1 }), true);
+  // Boundary: cutoff at Jan 1 means nothing in that year is visible
+  it("boundary: cutoff 2026-01-01, month=1 excluded (starts at cutoff)", () => {
+    Deno.env.set("APP_OBSERVATORY_PUBLISHED_UNTIL", "2026-01-01");
+    assertEquals(isPublished({ year: 2026, month: 1 }), false);
+  });
+
+  it("boundary: cutoff 2026-01-01, year=2025 included", () => {
+    Deno.env.set("APP_OBSERVATORY_PUBLISHED_UNTIL", "2026-01-01");
+    assertEquals(isPublished({ year: 2025 }), true);
   });
 
   it("rejects invalid date format gracefully", () => {

--- a/api/src/pdc/services/observatory/helpers/publishedDate.unit.spec.ts
+++ b/api/src/pdc/services/observatory/helpers/publishedDate.unit.spec.ts
@@ -1,0 +1,94 @@
+import { assertEquals } from "dep:assert";
+import { afterEach, describe, it } from "dep:testing-bdd";
+import { getPeriodEnd, isPublished } from "./publishedDate.ts";
+
+describe("getPeriodEnd", () => {
+  it("month: returns first day of next month", () => {
+    assertEquals(getPeriodEnd({ year: 2026, month: 2 }), new Date(2026, 2, 1));
+  });
+
+  it("month=12: rolls over to next year", () => {
+    assertEquals(getPeriodEnd({ year: 2026, month: 12 }), new Date(2027, 0, 1));
+  });
+
+  it("trimester=1: Q1 ends at April", () => {
+    assertEquals(getPeriodEnd({ year: 2026, trimester: 1 }), new Date(2026, 3, 1));
+  });
+
+  it("trimester=4: Q4 rolls to next year", () => {
+    assertEquals(getPeriodEnd({ year: 2026, trimester: 4 }), new Date(2027, 0, 1));
+  });
+
+  it("semester=1: H1 ends at July", () => {
+    assertEquals(getPeriodEnd({ year: 2026, semester: 1 }), new Date(2026, 6, 1));
+  });
+
+  it("semester=2: H2 rolls to next year", () => {
+    assertEquals(getPeriodEnd({ year: 2026, semester: 2 }), new Date(2027, 0, 1));
+  });
+
+  it("year only: returns Jan 1 of next year", () => {
+    assertEquals(getPeriodEnd({ year: 2026 }), new Date(2027, 0, 1));
+  });
+
+  it("month takes priority over trimester", () => {
+    assertEquals(
+      getPeriodEnd({ year: 2026, month: 3, trimester: 1 }),
+      new Date(2026, 3, 1),
+    );
+  });
+});
+
+describe("isPublished", () => {
+  afterEach(() => {
+    Deno.env.delete("APP_OBSERVATORY_PUBLISHED_UNTIL");
+  });
+
+  it("returns true when env var is unset", () => {
+    Deno.env.delete("APP_OBSERVATORY_PUBLISHED_UNTIL");
+    assertEquals(isPublished({ year: 2099, month: 12 }), true);
+  });
+
+  it("returns true when period is before cutoff", () => {
+    Deno.env.set("APP_OBSERVATORY_PUBLISHED_UNTIL", "2026-03-01");
+    assertEquals(isPublished({ year: 2026, month: 2 }), true);
+  });
+
+  it("returns false when period equals cutoff", () => {
+    Deno.env.set("APP_OBSERVATORY_PUBLISHED_UNTIL", "2026-03-01");
+    assertEquals(isPublished({ year: 2026, month: 3 }), false);
+  });
+
+  it("returns false when period is after cutoff", () => {
+    Deno.env.set("APP_OBSERVATORY_PUBLISHED_UNTIL", "2026-03-01");
+    assertEquals(isPublished({ year: 2026, month: 6 }), false);
+  });
+
+  it("works with trimester", () => {
+    Deno.env.set("APP_OBSERVATORY_PUBLISHED_UNTIL", "2026-04-01");
+    assertEquals(isPublished({ year: 2026, trimester: 1 }), true);
+    assertEquals(isPublished({ year: 2026, trimester: 2 }), false);
+  });
+
+  it("works with semester", () => {
+    Deno.env.set("APP_OBSERVATORY_PUBLISHED_UNTIL", "2026-07-01");
+    assertEquals(isPublished({ year: 2026, semester: 1 }), true);
+    assertEquals(isPublished({ year: 2026, semester: 2 }), false);
+  });
+
+  it("works with year only", () => {
+    Deno.env.set("APP_OBSERVATORY_PUBLISHED_UNTIL", "2027-01-01");
+    assertEquals(isPublished({ year: 2026 }), true);
+    assertEquals(isPublished({ year: 2027 }), false);
+  });
+
+  it("boundary: cutoff exactly at period end is published", () => {
+    Deno.env.set("APP_OBSERVATORY_PUBLISHED_UNTIL", "2026-04-01");
+    assertEquals(isPublished({ year: 2026, trimester: 1 }), true);
+  });
+
+  it("rejects invalid date format gracefully", () => {
+    Deno.env.set("APP_OBSERVATORY_PUBLISHED_UNTIL", "not-a-date");
+    assertEquals(isPublished({ year: 2026, month: 1 }), false);
+  });
+});

--- a/api/src/pdc/services/observatory/interfaces/LastRecordRepositoryProviderInterface.ts
+++ b/api/src/pdc/services/observatory/interfaces/LastRecordRepositoryProviderInterface.ts
@@ -1,0 +1,24 @@
+import type {
+  ResultInterface as LastRecordResultInterface,
+} from "@/pdc/services/observatory/actions/LastRecordAction.ts";
+import type { LastRecord as LastRecordParamsInterface } from "@/pdc/services/observatory/dto/LastRecord.ts";
+
+export type { LastRecordParamsInterface, LastRecordResultInterface };
+
+export interface LastRecordRepositoryInterface {
+  getLastRecord(
+    params: LastRecordParamsInterface,
+    maxYear?: number,
+    maxMonth?: number,
+  ): Promise<LastRecordResultInterface>;
+}
+
+export abstract class LastRecordRepositoryInterfaceResolver implements LastRecordRepositoryInterface {
+  async getLastRecord(
+    params: LastRecordParamsInterface,
+    maxYear?: number,
+    maxMonth?: number,
+  ): Promise<LastRecordResultInterface> {
+    throw new Error();
+  }
+}

--- a/api/src/pdc/services/observatory/providers/LastRecordRepositoryProvider.ts
+++ b/api/src/pdc/services/observatory/providers/LastRecordRepositoryProvider.ts
@@ -1,0 +1,49 @@
+import { provider } from "@/ilos/common/index.ts";
+import { LegacyPostgresConnection } from "@/ilos/connection-postgres/index.ts";
+import sql, { join } from "@/lib/pg/sql.ts";
+import { checkTerritoryParam } from "@/pdc/services/observatory/helpers/checkParams.ts";
+import {
+  LastRecordParamsInterface,
+  LastRecordRepositoryInterface,
+  LastRecordRepositoryInterfaceResolver,
+  LastRecordResultInterface,
+} from "@/pdc/services/observatory/interfaces/LastRecordRepositoryProviderInterface.ts";
+
+@provider({
+  identifier: LastRecordRepositoryInterfaceResolver,
+})
+export class LastRecordRepositoryProvider implements LastRecordRepositoryInterface {
+  constructor(private pg: LegacyPostgresConnection) {}
+
+  async getLastRecord(
+    params: LastRecordParamsInterface,
+    maxYear?: number,
+    maxMonth?: number,
+  ): Promise<LastRecordResultInterface> {
+    const typeParam = checkTerritoryParam(params.type);
+    const filters = [
+      sql`type = ${typeParam}`,
+      sql`(territory_1 = ${params.code} OR territory_2 = ${params.code})`,
+      sql`direction = 'both'`,
+    ];
+
+    if (maxYear !== undefined && maxMonth !== undefined) {
+      filters.push(
+        sql`(year * 100 + month) <= ${maxYear * 100 + maxMonth}`,
+      );
+    }
+
+    const query = sql`
+      SELECT year, month
+      FROM observatoire_stats.flux_by_month
+      WHERE ${join(filters, " AND ")}
+      ORDER BY year DESC, month DESC
+      LIMIT 1
+    `;
+
+    const response = await this.pg.getClient().query(query);
+    return response.rows.length > 0
+      ? { year: response.rows[0].year, month: response.rows[0].month }
+      : null;
+  }
+}

--- a/api/src/pdc/services/observatory/providers/LastRecordRepositoryProvider.ts
+++ b/api/src/pdc/services/observatory/providers/LastRecordRepositoryProvider.ts
@@ -24,7 +24,6 @@ export class LastRecordRepositoryProvider implements LastRecordRepositoryInterfa
     const filters = [
       sql`type = ${typeParam}`,
       sql`(territory_1 = ${params.code} OR territory_2 = ${params.code})`,
-      sql`direction = 'both'`,
     ];
 
     if (maxYear !== undefined && maxMonth !== undefined) {

--- a/app-observatory/src/app/observatoire/territoire/Dashboard.tsx
+++ b/app-observatory/src/app/observatoire/territoire/Dashboard.tsx
@@ -8,9 +8,10 @@ import SelectSemester from '@/components/observatoire/SelectSemester';
 import SelectTerritory from '@/components/observatoire/SelectTerritory';
 import SelectTrimester from '@/components/observatoire/SelectTrimester';
 import SelectYear from '@/components/observatoire/SelectYear';
+import { Config } from '@/config';
 import { useDashboardContext } from '@/context/DashboardProvider';
-import { GetPeriod } from '@/helpers/dashboard';
 import { graphList, mapList } from '@/helpers/lists';
+import { useApi } from '@/hooks/useApi';
 import { PerimeterType } from '@/interfaces/observatoire/Perimeter';
 import { fr } from '@codegouvfr/react-dsfr';
 import CircularProgress from '@mui/material/CircularProgress';
@@ -33,7 +34,9 @@ import BestTerritoriesTable from './tables/BestTerritoriesTable';
 export default function Dashboard() {
   const searchParams = useSearchParams();
   const {dashboard} =useDashboardContext();
-  const period = GetPeriod();
+  const apiUrl = Config.get<string>('next.public_api_url', '');
+  const lastRecordUrl = `${apiUrl}/last-record?type=${dashboard.params.type}&code=${dashboard.params.code}`;
+  const { data: lastRecord } = useApi<{ year: number; month: number }>(lastRecordUrl);
   const observeLabel = dashboard.params.map == 1 ? 'Flux entre:' : 'Territoires observés';
   useEffect(() => {
     const params = {
@@ -72,9 +75,11 @@ export default function Dashboard() {
       : (
         <>
           <SectionTitle
-            title={`${dashboard.params.name} du ${new Date(period.start_date).toLocaleDateString()} au ${new Date(
-              period.end_date,
-            ).toLocaleDateString()}`}
+            title={`${dashboard.params.name} - Donn\u00e9es jusqu'\u00e0 ${
+              lastRecord
+                ? new Date(lastRecord.year, lastRecord.month - 1, 1).toLocaleDateString('fr-FR', { month: 'long', year: 'numeric' })
+                : '...'
+            }`}
           />
           <KeyFigures />
           <div className={fr.cx('fr-grid-row', 'fr-grid-row--gutters')}>

--- a/app-observatory/src/hooks/useApi.ts
+++ b/app-observatory/src/hooks/useApi.ts
@@ -7,14 +7,26 @@ export const useApi = <T>(input: RequestInfo | URL, init?: RequestInit) => {
     const fetchData = async () => {
       setError(null);
       setLoading(true);
-      const response = await fetch(input, init);
-      const res = await response.json();
-      if (response.ok) {
-        setData(res);
-        setLoading(false);
-      } else {
-        setError(res);
+      try {
+        const response = await fetch(input, init);
+        if (response.ok) {
+          const res = await response.json();
+          setData(res);
+        } else {
+          const text = await response.text();
+          let errorMessage: any;
+          try {
+            errorMessage = JSON.parse(text);
+          } catch {
+            errorMessage = text;
+          }
+          setError(errorMessage);
+          setData(undefined);
+        }
+      } catch (e: any) {
+        setError(e.message ?? "Network error");
         setData(undefined);
+      } finally {
         setLoading(false);
       }
     };

--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -93,6 +93,9 @@ services:
       APP_ROUTECACHE_GZIP_ENABLED: ${APP_ROUTECACHE_GZIP_ENABLED:-true}
       APP_ROUTECACHE_AUTHTOKEN: ${APP_ROUTECACHE_AUTHTOKEN:-}
 
+      # Observatory publication gate (exclusive upper bound, YYYY-MM-DD)
+      APP_OBSERVATORY_PUBLISHED_UNTIL: ${APP_OBSERVATORY_PUBLISHED_UNTIL:-}
+
       # Object storage (S3)
       AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID:-minioadmin}
       AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY:-minioadmin}


### PR DESCRIPTION
## Contexte

Les données de l'observatoire sont publiées automatiquement dès qu'elles
arrivent dans les tables `observatoire_stats`. Il n'existe aucun mécanisme
de validation avant mise à disposition publique.

## Modifications

### 1. Porte de publication (cutoff)

Ajout d'une **date de coupure** côté API via la variable d'environnement
`APP_OBSERVATORY_PUBLISHED_UNTIL` (borne supérieure exclusive, format `YYYY-MM-DD`).

Les 11 endpoints à données périodiques vérifient cette date avant d'interroger
la base. Si la période demandée dépasse la coupure, l'endpoint renvoie un
tableau vide.

**Logique glissante (rolling) :** une période est visible si son début est
strictement antérieur à la coupure. Avec `APP_OBSERVATORY_PUBLISHED_UNTIL=2026-03-01` :
- mois : février inclus, mars exclu (mois complets)
- trimestre : T1 (jan-mar) inclus car il démarre avant la coupure
- semestre : S1 (jan-jun) inclus
- année : 2026 inclus

Si la variable n'est pas définie, toutes les données restent accessibles
(rétrocompatible).

### 2. Dernier enregistrement disponible

Nouvel endpoint `GET /observatory/last-record` qui retourne le `max(year, month)`
depuis `flux_by_month`, plafonné par la coupure de publication. Permet au
frontend d'afficher la dernière période réellement disponible.

### 3. Affichage frontend

Le titre de section dans `app-observatory` affiche désormais
"Données jusqu'à {mois année}" (ex. "février 2026") au lieu de dates
théoriques calculées côté client.

### Endpoints concernés par la porte (11/13)

keyfigures, flux, best-flux, evol-flux, occupation, best-territories,
evol-occupation, journeys-by-hours, journeys-by-distances, location, incentive

**Non concernés :** `aires-covoiturage` (données statiques), `campaigns`
(cycle de vie propre).

### Fichiers

**API -- nouveaux :**
- `observatory/config/index.ts` -- lecture de la variable d'environnement
- `observatory/helpers/publishedDate.ts` -- logique de coupure (rolling)
- `observatory/helpers/publishedDate.unit.spec.ts` -- 23 tests unitaires
- `observatory/dto/LastRecord.ts` -- schéma de validation
- `observatory/interfaces/LastRecordRepositoryProviderInterface.ts`
- `observatory/providers/LastRecordRepositoryProvider.ts` -- requête SQL
- `observatory/actions/LastRecordAction.ts` -- endpoint last-record

**API -- modifiés :**
- 11 actions (ajout du guard `isPublished`)
- `ObservatoryServiceProvider.ts` (enregistrement du nouvel endpoint)
- `docker-compose.base.yml` (déclaration de la variable)

**Frontend -- modifié :**
- `app-observatory/.../Dashboard.tsx` (appel last-record + affichage)

## Phase suivante

Remplacement de la variable d'environnement par une table `common.settings`
avec interface d'administration dans app-partners pour un contrôle à chaud
sans redémarrage.

## Test plan

- [ ] Vérifier que les 23 tests unitaires passent (`deno test -A src/pdc/services/observatory/helpers/publishedDate.unit.spec.ts`)
- [ ] Définir `APP_OBSERVATORY_PUBLISHED_UNTIL=2025-01-01` et appeler un endpoint pour 2025+ : réponse `[]`
- [ ] Vérifier le rolling : avec cutoff `2026-03-01`, `trimester=1` retourne des données
- [ ] Appeler `/observatory/last-record?type=country&code=XXXXX` : retourne `{ year, month }` plafonné par le cutoff
- [ ] Supprimer la variable : les données redeviennent accessibles
- [ ] Vérifier qu'`aires-covoiturage` et `campaigns` ne sont pas affectés
- [ ] Frontend : le titre de section affiche la dernière période disponible
