### PR TITLE
fix(obs): backend observatory - last-record et publication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ dbt/edr_target
 .claude/settings.local.json
 .claude/settings.json
 .claude/worktrees
+.claude/superpowers
 .mcp.json
 .worktrees
 

--- a/api/.env.example
+++ b/api/.env.example
@@ -158,3 +158,16 @@ DEX_GRPC_PORT=
 BREVO_API_KEY=your-brevo-api-key                                                                                                                                                     
 BREVO_WELCOME_TEMPLATE_ID=123  
 BREVO_API_URL=https://api.brevo.com/v3/smtp/email
+
+##
+# Observatory Service
+#
+# Cutoff date for observatory endpoint data. (format: YYYY-MM-DD)
+# Default: null (displays all data)
+# - month     : exclusive (current month is hidden)
+# - trimester : inclusive
+# - semester  : inclusive
+# - year      : inclusive
+#
+# APP_OBSERVATORY_PUBLISHED_UNTIL
+

--- a/api/src/pdc/services/observatory/ObservatoryServiceProvider.ts
+++ b/api/src/pdc/services/observatory/ObservatoryServiceProvider.ts
@@ -14,6 +14,7 @@ import { KeyfiguresAction } from "./actions/keyfigures/KeyfiguresAction.ts";
 import { LocationAction } from "./actions/location/LocationAction.ts";
 import { BestTerritoriesAction } from "./actions/occupation/BestTerritoriesAction.ts";
 import { EvolOccupationAction } from "./actions/occupation/EvolOccupationAction.ts";
+import { LastRecordAction } from "./actions/LastRecordAction.ts";
 import { OccupationAction } from "./actions/occupation/OccupationAction.ts";
 import { DistributionRepositoryProvider } from "./providers/DistributionRepositoryProvider.ts";
 import { FluxRepositoryProvider } from "./providers/FluxRepositoryProvider.ts";
@@ -22,6 +23,7 @@ import { IncentiveRepositoryProvider } from "./providers/IncentiveRepositoryProv
 import { InfraRepositoryProvider } from "./providers/InfraRepositoryProvider.ts";
 import { KeyfiguresRepositoryProvider } from "./providers/KeyfiguresRepositoryProvider.ts";
 import { LocationRepositoryProvider } from "./providers/LocationRepositoryProvider.ts";
+import { LastRecordRepositoryProvider } from "./providers/LastRecordRepositoryProvider.ts";
 import { OccupationRepositoryProvider } from "./providers/OccupationRepositoryProvider.ts";
 
 @serviceProvider({
@@ -35,6 +37,7 @@ import { OccupationRepositoryProvider } from "./providers/OccupationRepositoryPr
     OccupationRepositoryProvider,
     IncentiveRepositoryProvider,
     IncentiveCampaignsRepositoryProvider,
+    LastRecordRepositoryProvider,
   ],
   handlers: [
     AiresCovoiturageAction,
@@ -50,6 +53,7 @@ import { OccupationRepositoryProvider } from "./providers/OccupationRepositoryPr
     KeyfiguresAction,
     OccupationAction,
     CampaignsAction,
+    LastRecordAction,
   ],
   middlewares: [...defaultMiddlewareBindings, [
     "validate",

--- a/api/src/pdc/services/observatory/actions/LastRecordAction.ts
+++ b/api/src/pdc/services/observatory/actions/LastRecordAction.ts
@@ -1,0 +1,45 @@
+import { handler } from "@/ilos/common/index.ts";
+import { Action as AbstractAction } from "@/ilos/core/index.ts";
+import { config } from "../config/index.ts";
+import { LastRecord } from "../dto/LastRecord.ts";
+import { LastRecordRepositoryInterfaceResolver } from "../interfaces/LastRecordRepositoryProviderInterface.ts";
+
+export type ResultInterface = { year: number; month: number } | null;
+
+@handler({
+  service: "observatory",
+  method: "getLastRecord",
+  middlewares: [[
+    "validate",
+    LastRecord,
+  ]],
+  apiRoute: {
+    path: "/observatory/last-record",
+    method: "GET",
+    public: true,
+  },
+})
+export class LastRecordAction extends AbstractAction {
+  constructor(private repository: LastRecordRepositoryInterfaceResolver) {
+    super();
+  }
+
+  public override async handle(params: LastRecord): Promise<ResultInterface> {
+    const cutoff = config.observatory.publishedUntil;
+    let maxYear: number | undefined;
+    let maxMonth: number | undefined;
+
+    if (cutoff) {
+      const parts = cutoff.split("-").map(Number);
+      if (parts.length >= 2 && !parts.some(isNaN)) {
+        // Cutoff is exclusive: 2026-03-01 means last valid month is Feb 2026
+        const d = new Date(parts[0], parts[1] - 1, parts[2] || 1);
+        d.setMonth(d.getMonth() - 1);
+        maxYear = d.getFullYear();
+        maxMonth = d.getMonth() + 1;
+      }
+    }
+
+    return this.repository.getLastRecord(params, maxYear, maxMonth);
+  }
+}

--- a/api/src/pdc/services/observatory/actions/distribution/JourneysByDistancesAction.ts
+++ b/api/src/pdc/services/observatory/actions/distribution/JourneysByDistancesAction.ts
@@ -4,6 +4,7 @@ import { Infer } from "@/lib/superstruct/index.ts";
 import { Direction } from "@/pdc/providers/superstruct/shared/index.ts";
 import { JourneysByDistances } from "@/pdc/services/observatory/dto/distribution/JourneysByDistances.ts";
 import { DistributionRepositoryInterfaceResolver } from "@/pdc/services/observatory/interfaces/DistributionRepositoryProviderInterface.ts";
+import { isPublished } from "../../helpers/publishedDate.ts";
 export type ResultInterface = {
   code: string;
   libelle: string;
@@ -33,6 +34,7 @@ export class JourneysByDistancesAction extends AbstractAction {
   }
 
   public async handle(params: JourneysByDistances): Promise<ResultInterface> {
+    if (!isPublished(params)) return [];
     return this.repository.getJourneysByDistances(params);
   }
 }

--- a/api/src/pdc/services/observatory/actions/distribution/JourneysByHoursAction.ts
+++ b/api/src/pdc/services/observatory/actions/distribution/JourneysByHoursAction.ts
@@ -4,6 +4,7 @@ import { Infer } from "@/lib/superstruct/index.ts";
 import { Direction } from "@/pdc/providers/superstruct/shared/index.ts";
 import { JourneysByHours } from "@/pdc/services/observatory/dto/distribution/JourneysByHours.ts";
 import { DistributionRepositoryInterfaceResolver } from "../../interfaces/DistributionRepositoryProviderInterface.ts";
+import { isPublished } from "../../helpers/publishedDate.ts";
 export type ResultInterface = {
   code: string;
   libelle: string;
@@ -35,6 +36,7 @@ export class JourneysByHoursAction extends AbstractAction {
   }
 
   public async handle(params: JourneysByHours): Promise<ResultInterface> {
+    if (!isPublished(params)) return [];
     return this.repository.getJourneysByHours(params);
   }
 }

--- a/api/src/pdc/services/observatory/actions/flux/BestFluxAction.ts
+++ b/api/src/pdc/services/observatory/actions/flux/BestFluxAction.ts
@@ -2,6 +2,7 @@ import { handler } from "@/ilos/common/index.ts";
 import { Action as AbstractAction } from "@/ilos/core/index.ts";
 import { BestFlux } from "@/pdc/services/observatory/dto/flux/BestFlux.ts";
 import { FluxRepositoryInterfaceResolver } from "@/pdc/services/observatory/interfaces/FluxRepositoryProviderInterface.ts";
+import { isPublished } from "../../helpers/publishedDate.ts";
 export type ResultInterface = {
   territory_1: BestFlux["code"];
   l_territory_1: string;
@@ -29,6 +30,7 @@ export class BestFluxAction extends AbstractAction {
   }
 
   public async handle(params: BestFlux): Promise<ResultInterface> {
+    if (!isPublished(params)) return [];
     return this.repository.getBestFlux(params);
   }
 }

--- a/api/src/pdc/services/observatory/actions/flux/EvolFluxAction.ts
+++ b/api/src/pdc/services/observatory/actions/flux/EvolFluxAction.ts
@@ -2,6 +2,7 @@ import { handler } from "@/ilos/common/index.ts";
 import { Action as AbstractAction } from "@/ilos/core/index.ts";
 import { EvolFlux } from "@/pdc/services/observatory/dto/flux/EvolFlux.ts";
 import { FluxRepositoryInterfaceResolver } from "@/pdc/services/observatory/interfaces/FluxRepositoryProviderInterface.ts";
+import { isPublished } from "../../helpers/publishedDate.ts";
 export type ResultInterface = {
   territory: EvolFlux["code"];
   l_territory: string;
@@ -31,6 +32,7 @@ export class EvolFluxAction extends AbstractAction {
   }
 
   public async handle(params: EvolFlux): Promise<ResultInterface> {
+    if (!isPublished(params)) return [];
     return this.repository.getEvolFlux(params);
   }
 }

--- a/api/src/pdc/services/observatory/actions/flux/FluxAction.ts
+++ b/api/src/pdc/services/observatory/actions/flux/FluxAction.ts
@@ -2,6 +2,7 @@ import { handler } from "@/ilos/common/index.ts";
 import { Action as AbstractAction } from "@/ilos/core/index.ts";
 import { Flux } from "@/pdc/services/observatory/dto/flux/Flux.ts";
 import { FluxRepositoryInterfaceResolver } from "../../interfaces/FluxRepositoryProviderInterface.ts";
+import { isPublished } from "../../helpers/publishedDate.ts";
 export type ResultInterface = {
   ter_1: Flux["code"];
   lng_1: number;
@@ -33,6 +34,7 @@ export class FluxAction extends AbstractAction {
   }
 
   public async handle(params: Flux): Promise<ResultInterface> {
+    if (!isPublished(params)) return [];
     return this.repository.getFlux(params);
   }
 }

--- a/api/src/pdc/services/observatory/actions/incentive/IncentiveAction.ts
+++ b/api/src/pdc/services/observatory/actions/incentive/IncentiveAction.ts
@@ -4,6 +4,7 @@ import { Infer } from "@/lib/superstruct/index.ts";
 import { Direction } from "@/pdc/providers/superstruct/shared/index.ts";
 import { Incentive } from "@/pdc/services/observatory/dto/Incentive.ts";
 import { IncentiveRepositoryInterfaceResolver } from "../../interfaces/IncentiveRepositoryProviderInterface.ts";
+import { isPublished } from "../../helpers/publishedDate.ts";
 
 export type ResultInterface = {
   code: Incentive["code"];
@@ -33,6 +34,7 @@ export class IncentiveAction extends AbstractAction {
   }
 
   public async handle(params: Incentive): Promise<ResultInterface> {
+    if (!isPublished(params)) return [];
     return this.repository.getIncentive(params);
   }
 }

--- a/api/src/pdc/services/observatory/actions/keyfigures/KeyfiguresAction.ts
+++ b/api/src/pdc/services/observatory/actions/keyfigures/KeyfiguresAction.ts
@@ -4,6 +4,7 @@ import { Infer } from "@/lib/superstruct/index.ts";
 import { Direction } from "@/pdc/providers/superstruct/shared/index.ts";
 import { KeyFigures } from "@/pdc/services/observatory/dto/KeyFigures.ts";
 import { KeyfiguresRepositoryInterfaceResolver } from "../../interfaces/KeyfiguresRepositoryProviderInterface.ts";
+import { isPublished } from "../../helpers/publishedDate.ts";
 export type ResultInterface = {
   territory: KeyFigures["code"];
   l_territory: string;
@@ -38,6 +39,7 @@ export class KeyfiguresAction extends AbstractAction {
   }
 
   public async handle(params: KeyFigures): Promise<ResultInterface> {
+    if (!isPublished(params)) return [];
     return this.repository.getKeyfigures(params);
   }
 }

--- a/api/src/pdc/services/observatory/actions/location/LocationAction.ts
+++ b/api/src/pdc/services/observatory/actions/location/LocationAction.ts
@@ -2,6 +2,7 @@ import { handler } from "@/ilos/common/index.ts";
 import { Action as AbstractAction } from "@/ilos/core/index.ts";
 import { Location } from "@/pdc/services/observatory/dto/Location.ts";
 import { LocationRepositoryInterfaceResolver } from "../../interfaces/LocationRepositoryProviderInterface.ts";
+import { isPublished } from "../../helpers/publishedDate.ts";
 export type ResultInterface = {
   hex: string;
   count: number;
@@ -26,6 +27,7 @@ export class LocationAction extends AbstractAction {
   }
 
   public async handle(params: Location): Promise<ResultInterface> {
+    if (!isPublished(params)) return [];
     return this.repository.getLocation(params);
   }
 }

--- a/api/src/pdc/services/observatory/actions/occupation/BestTerritoriesAction.ts
+++ b/api/src/pdc/services/observatory/actions/occupation/BestTerritoriesAction.ts
@@ -2,6 +2,7 @@ import { handler } from "@/ilos/common/index.ts";
 import { Action as AbstractAction } from "@/ilos/core/index.ts";
 import { BestTerritories } from "@/pdc/services/observatory/dto/occupation/BestTerritories.ts";
 import { OccupationRepositoryInterfaceResolver } from "@/pdc/services/observatory/interfaces/OccupationRepositoryProviderInterface.ts";
+import { isPublished } from "../../helpers/publishedDate.ts";
 export type ResultInterface = {
   territory: BestTerritories["code"];
   l_territory: string;
@@ -27,6 +28,7 @@ export class BestTerritoriesAction extends AbstractAction {
   }
 
   public async handle(params: BestTerritories): Promise<ResultInterface> {
+    if (!isPublished(params)) return [];
     return this.repository.getBestTerritories(params);
   }
 }

--- a/api/src/pdc/services/observatory/actions/occupation/EvolOccupationAction.ts
+++ b/api/src/pdc/services/observatory/actions/occupation/EvolOccupationAction.ts
@@ -2,6 +2,7 @@ import { handler } from "@/ilos/common/index.ts";
 import { Action as AbstractAction } from "@/ilos/core/index.ts";
 import { EvolOccupation } from "@/pdc/services/observatory/dto/occupation/EvolOccupation.ts";
 import { OccupationRepositoryInterfaceResolver } from "@/pdc/services/observatory/interfaces/OccupationRepositoryProviderInterface.ts";
+import { isPublished } from "../../helpers/publishedDate.ts";
 export type ResultInterface = {
   territory: EvolOccupation["code"];
   l_territory: string;
@@ -30,6 +31,7 @@ export class EvolOccupationAction extends AbstractAction {
   }
 
   public async handle(params: EvolOccupation): Promise<ResultInterface> {
+    if (!isPublished(params)) return [];
     return this.repository.getEvolOccupation(params);
   }
 }

--- a/api/src/pdc/services/observatory/actions/occupation/OccupationAction.ts
+++ b/api/src/pdc/services/observatory/actions/occupation/OccupationAction.ts
@@ -2,6 +2,7 @@ import { handler } from "@/ilos/common/index.ts";
 import { Action as AbstractAction } from "@/ilos/core/index.ts";
 import { Occupation } from "@/pdc/services/observatory/dto/occupation/Occupation.ts";
 import { OccupationRepositoryInterfaceResolver } from "@/pdc/services/observatory/interfaces/OccupationRepositoryProviderInterface.ts";
+import { isPublished } from "../../helpers/publishedDate.ts";
 import type { Feature } from "dep:turf-helpers";
 export type ResultInterface = {
   territory: Occupation["code"];
@@ -31,6 +32,7 @@ export class OccupationAction extends AbstractAction {
   }
 
   public async handle(params: Occupation): Promise<ResultInterface> {
+    if (!isPublished(params)) return [];
     return this.repository.getOccupation(params);
   }
 }

--- a/api/src/pdc/services/observatory/config/index.ts
+++ b/api/src/pdc/services/observatory/config/index.ts
@@ -1,0 +1,9 @@
+import { env } from "@/lib/env/index.ts";
+
+export const config = {
+  observatory: {
+    get publishedUntil() {
+      return env("APP_OBSERVATORY_PUBLISHED_UNTIL");
+    },
+  },
+};

--- a/api/src/pdc/services/observatory/dto/LastRecord.ts
+++ b/api/src/pdc/services/observatory/dto/LastRecord.ts
@@ -1,0 +1,12 @@
+import { Infer, object } from "@/lib/superstruct/index.ts";
+import {
+  TerritoryCode,
+  TerritoryType,
+} from "@/pdc/providers/superstruct/shared/index.ts";
+
+export const LastRecord = object({
+  type: TerritoryType,
+  code: TerritoryCode,
+});
+
+export type LastRecord = Infer<typeof LastRecord>;

--- a/api/src/pdc/services/observatory/helpers/publishedDate.ts
+++ b/api/src/pdc/services/observatory/helpers/publishedDate.ts
@@ -1,0 +1,55 @@
+import { config } from "../config/index.ts";
+
+type PeriodParams = {
+  year: number;
+  month?: number;
+  trimester?: number;
+  semester?: number;
+};
+
+/**
+ * Compute the first day of a requested period.
+ * E.g. month=2 -> Feb 1st; trimester=1 -> Jan 1st; year=2026 -> Jan 1st.
+ */
+export function getPeriodStart(params: PeriodParams): Date {
+  if (params.month !== undefined) {
+    return new Date(params.year, params.month - 1, 1);
+  }
+  if (params.trimester !== undefined) {
+    return new Date(params.year, (params.trimester - 1) * 3, 1);
+  }
+  if (params.semester !== undefined) {
+    return new Date(params.year, (params.semester - 1) * 6, 1);
+  }
+  return new Date(params.year, 0, 1);
+}
+
+/**
+ * Check if a requested period is published based on
+ * APP_OBSERVATORY_PUBLISHED_UNTIL (exclusive upper bound).
+ *
+ * Uses rolling logic: a period is visible if its start date
+ * is strictly before the cutoff. This means partial trimesters,
+ * semesters, and years are shown as long as they contain data
+ * before the cutoff.
+ *
+ * Returns true (published) when:
+ * - config value is unset (backwards compatible, no gate)
+ * - the period start date is strictly before the cutoff date
+ *
+ * NOTE: This assumes no response caching on observatory routes.
+ * If route caching is added, cutoff changes require cache invalidation.
+ */
+export function isPublished(params: PeriodParams): boolean {
+  const cutoff = config.observatory.publishedUntil;
+  if (!cutoff) return true;
+
+  // Parse YYYY-MM-DD as local time to match getPeriodStart (also local time).
+  // new Date("2026-03-01") would create UTC midnight, causing timezone mismatches.
+  const parts = cutoff.split("-").map(Number);
+  if (parts.length !== 3 || parts.some(isNaN)) return false;
+  const cutoffDate = new Date(parts[0], parts[1] - 1, parts[2]);
+
+  const periodStart = getPeriodStart(params);
+  return periodStart < cutoffDate;
+}

--- a/api/src/pdc/services/observatory/helpers/publishedDate.unit.spec.ts
+++ b/api/src/pdc/services/observatory/helpers/publishedDate.unit.spec.ts
@@ -1,0 +1,123 @@
+import { assertEquals } from "dep:assert";
+import { afterEach, describe, it } from "dep:testing-bdd";
+import { getPeriodStart, isPublished } from "./publishedDate.ts";
+
+describe("getPeriodStart", () => {
+  it("month=2: returns Feb 1st", () => {
+    assertEquals(getPeriodStart({ year: 2026, month: 2 }), new Date(2026, 1, 1));
+  });
+
+  it("month=1: returns Jan 1st", () => {
+    assertEquals(getPeriodStart({ year: 2026, month: 1 }), new Date(2026, 0, 1));
+  });
+
+  it("month=12: returns Dec 1st", () => {
+    assertEquals(getPeriodStart({ year: 2026, month: 12 }), new Date(2026, 11, 1));
+  });
+
+  it("trimester=1: returns Jan 1st", () => {
+    assertEquals(getPeriodStart({ year: 2026, trimester: 1 }), new Date(2026, 0, 1));
+  });
+
+  it("trimester=2: returns Apr 1st", () => {
+    assertEquals(getPeriodStart({ year: 2026, trimester: 2 }), new Date(2026, 3, 1));
+  });
+
+  it("trimester=4: returns Oct 1st", () => {
+    assertEquals(getPeriodStart({ year: 2026, trimester: 4 }), new Date(2026, 9, 1));
+  });
+
+  it("semester=1: returns Jan 1st", () => {
+    assertEquals(getPeriodStart({ year: 2026, semester: 1 }), new Date(2026, 0, 1));
+  });
+
+  it("semester=2: returns Jul 1st", () => {
+    assertEquals(getPeriodStart({ year: 2026, semester: 2 }), new Date(2026, 6, 1));
+  });
+
+  it("year only: returns Jan 1st", () => {
+    assertEquals(getPeriodStart({ year: 2026 }), new Date(2026, 0, 1));
+  });
+
+  it("month takes priority over trimester", () => {
+    assertEquals(
+      getPeriodStart({ year: 2026, month: 3, trimester: 1 }),
+      new Date(2026, 2, 1),
+    );
+  });
+});
+
+describe("isPublished", () => {
+  afterEach(() => {
+    Deno.env.delete("APP_OBSERVATORY_PUBLISHED_UNTIL");
+  });
+
+  it("returns true when env var is unset", () => {
+    Deno.env.delete("APP_OBSERVATORY_PUBLISHED_UNTIL");
+    assertEquals(isPublished({ year: 2099, month: 12 }), true);
+  });
+
+  it("returns true when month starts before cutoff", () => {
+    Deno.env.set("APP_OBSERVATORY_PUBLISHED_UNTIL", "2026-03-01");
+    assertEquals(isPublished({ year: 2026, month: 2 }), true);
+  });
+
+  it("returns false when month starts at cutoff (exclusive)", () => {
+    Deno.env.set("APP_OBSERVATORY_PUBLISHED_UNTIL", "2026-03-01");
+    assertEquals(isPublished({ year: 2026, month: 3 }), false);
+  });
+
+  it("returns false when month starts after cutoff", () => {
+    Deno.env.set("APP_OBSERVATORY_PUBLISHED_UNTIL", "2026-03-01");
+    assertEquals(isPublished({ year: 2026, month: 6 }), false);
+  });
+
+  // Rolling: trimester is included if it starts before cutoff
+  it("trimester: Q1 included with cutoff 2026-03-01 (rolling)", () => {
+    Deno.env.set("APP_OBSERVATORY_PUBLISHED_UNTIL", "2026-03-01");
+    assertEquals(isPublished({ year: 2026, trimester: 1 }), true);
+  });
+
+  it("trimester: Q2 excluded with cutoff 2026-03-01", () => {
+    Deno.env.set("APP_OBSERVATORY_PUBLISHED_UNTIL", "2026-03-01");
+    assertEquals(isPublished({ year: 2026, trimester: 2 }), false);
+  });
+
+  // Rolling: semester is included if it starts before cutoff
+  it("semester: H1 included with cutoff 2026-03-01 (rolling)", () => {
+    Deno.env.set("APP_OBSERVATORY_PUBLISHED_UNTIL", "2026-03-01");
+    assertEquals(isPublished({ year: 2026, semester: 1 }), true);
+  });
+
+  it("semester: H2 excluded with cutoff 2026-03-01", () => {
+    Deno.env.set("APP_OBSERVATORY_PUBLISHED_UNTIL", "2026-03-01");
+    assertEquals(isPublished({ year: 2026, semester: 2 }), false);
+  });
+
+  // Rolling: year is included if it starts before cutoff
+  it("year: 2026 included with cutoff 2026-03-01 (rolling)", () => {
+    Deno.env.set("APP_OBSERVATORY_PUBLISHED_UNTIL", "2026-03-01");
+    assertEquals(isPublished({ year: 2026 }), true);
+  });
+
+  it("year: 2027 excluded with cutoff 2026-03-01", () => {
+    Deno.env.set("APP_OBSERVATORY_PUBLISHED_UNTIL", "2026-03-01");
+    assertEquals(isPublished({ year: 2027 }), false);
+  });
+
+  // Boundary: cutoff at Jan 1 means nothing in that year is visible
+  it("boundary: cutoff 2026-01-01, month=1 excluded (starts at cutoff)", () => {
+    Deno.env.set("APP_OBSERVATORY_PUBLISHED_UNTIL", "2026-01-01");
+    assertEquals(isPublished({ year: 2026, month: 1 }), false);
+  });
+
+  it("boundary: cutoff 2026-01-01, year=2025 included", () => {
+    Deno.env.set("APP_OBSERVATORY_PUBLISHED_UNTIL", "2026-01-01");
+    assertEquals(isPublished({ year: 2025 }), true);
+  });
+
+  it("rejects invalid date format gracefully", () => {
+    Deno.env.set("APP_OBSERVATORY_PUBLISHED_UNTIL", "not-a-date");
+    assertEquals(isPublished({ year: 2026, month: 1 }), false);
+  });
+});

--- a/api/src/pdc/services/observatory/interfaces/LastRecordRepositoryProviderInterface.ts
+++ b/api/src/pdc/services/observatory/interfaces/LastRecordRepositoryProviderInterface.ts
@@ -1,0 +1,24 @@
+import type {
+  ResultInterface as LastRecordResultInterface,
+} from "@/pdc/services/observatory/actions/LastRecordAction.ts";
+import type { LastRecord as LastRecordParamsInterface } from "@/pdc/services/observatory/dto/LastRecord.ts";
+
+export type { LastRecordParamsInterface, LastRecordResultInterface };
+
+export interface LastRecordRepositoryInterface {
+  getLastRecord(
+    params: LastRecordParamsInterface,
+    maxYear?: number,
+    maxMonth?: number,
+  ): Promise<LastRecordResultInterface>;
+}
+
+export abstract class LastRecordRepositoryInterfaceResolver implements LastRecordRepositoryInterface {
+  async getLastRecord(
+    params: LastRecordParamsInterface,
+    maxYear?: number,
+    maxMonth?: number,
+  ): Promise<LastRecordResultInterface> {
+    throw new Error();
+  }
+}

--- a/api/src/pdc/services/observatory/providers/LastRecordRepositoryProvider.ts
+++ b/api/src/pdc/services/observatory/providers/LastRecordRepositoryProvider.ts
@@ -1,0 +1,48 @@
+import { provider } from "@/ilos/common/index.ts";
+import { LegacyPostgresConnection } from "@/ilos/connection-postgres/index.ts";
+import sql, { join } from "@/lib/pg/sql.ts";
+import { checkTerritoryParam } from "@/pdc/services/observatory/helpers/checkParams.ts";
+import {
+  LastRecordParamsInterface,
+  LastRecordRepositoryInterface,
+  LastRecordRepositoryInterfaceResolver,
+  LastRecordResultInterface,
+} from "@/pdc/services/observatory/interfaces/LastRecordRepositoryProviderInterface.ts";
+
+@provider({
+  identifier: LastRecordRepositoryInterfaceResolver,
+})
+export class LastRecordRepositoryProvider implements LastRecordRepositoryInterface {
+  constructor(private pg: LegacyPostgresConnection) {}
+
+  async getLastRecord(
+    params: LastRecordParamsInterface,
+    maxYear?: number,
+    maxMonth?: number,
+  ): Promise<LastRecordResultInterface> {
+    const typeParam = checkTerritoryParam(params.type);
+    const filters = [
+      sql`type = ${typeParam}`,
+      sql`(territory_1 = ${params.code} OR territory_2 = ${params.code})`,
+    ];
+
+    if (maxYear !== undefined && maxMonth !== undefined) {
+      filters.push(
+        sql`(year * 100 + month) <= ${maxYear * 100 + maxMonth}`,
+      );
+    }
+
+    const query = sql`
+      SELECT year, month
+      FROM observatoire_stats.flux_by_month
+      WHERE ${join(filters, " AND ")}
+      ORDER BY year DESC, month DESC
+      LIMIT 1
+    `;
+
+    const response = await this.pg.getClient().query(query);
+    return response.rows.length > 0
+      ? { year: response.rows[0].year, month: response.rows[0].month }
+      : null;
+  }
+}

--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -93,6 +93,9 @@ services:
       APP_ROUTECACHE_GZIP_ENABLED: ${APP_ROUTECACHE_GZIP_ENABLED:-true}
       APP_ROUTECACHE_AUTHTOKEN: ${APP_ROUTECACHE_AUTHTOKEN:-}
 
+      # Observatory publication gate (exclusive upper bound, YYYY-MM-DD)
+      APP_OBSERVATORY_PUBLISHED_UNTIL: ${APP_OBSERVATORY_PUBLISHED_UNTIL:-}
+
       # Object storage (S3)
       AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID:-minioadmin}
       AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY:-minioadmin}


### PR DESCRIPTION
## Contexte

Le déploiement précédent (v3.90.0) incluait des changements frontend et backend couplés, ce qui a causé un crash de l'observatoire. Ce PR découple le backend pour permettre un déploiement en deux étapes :

1. Déployer le backend (ce PR) pour exposer les nouveaux endpoints
2. Corriger et déployer le frontend séparément après validation

## Changements

- Ajout du endpoint `/observatory/last-record` pour récupérer la dernière période disponible dans les données flux
- Correction du filtre `direction = 'both'` qui n'existe pas dans `flux_by_month`
- Ajout du contrôle de publication (`APP_OBSERVATORY_PUBLISHED_UNTIL`) sur tous les endpoints de l'observatoire
- Tests unitaires pour `publishedDate` helper
