### PR TITLE
Campagne Grand Châtellerault 2026 - fix de l'exclusion de Grand Poitiers

### DIFF
--- a/api/src/pdc/services/policy/engine/policies/20260101_GrandChatellerault.ts
+++ b/api/src/pdc/services/policy/engine/policies/20260101_GrandChatellerault.ts
@@ -106,9 +106,7 @@ export const GrandChatellerault2026: PolicyHandlerStaticInterface = class extend
       "200069854", // CU du Grand Poitiers (200069854)
     ];
 
-    if (
-      startsAt(ctx, { aom: aomToExclude }) || endsAt(ctx, { aom: aomToExclude })
-    ) {
+    if (startsAt(ctx, { aom: aomToExclude })) {
       throw new NotEligibleTargetException();
     }
   }

--- a/api/src/pdc/services/policy/engine/policies/20260101_GrandChatellerault.unit.spec.ts
+++ b/api/src/pdc/services/policy/engine/policies/20260101_GrandChatellerault.unit.spec.ts
@@ -87,20 +87,20 @@ describe("Grand Châtellerault 2026 - Exclusions", () => {
       ],
     }, { incentive: [0] }));
 
-  it("OD in excluded AOM (Grand Poitiers)", async () =>
+  it("Origine from excluded AOM (Grand Poitiers)", async () =>
     await process({
       policy: { handler: Handler.id },
       carpool: [
         {
-          start: { ...defaultPosition, aom: "200069854" },
-          end: { ...defaultPosition, aom: "247200132" },
+          start: { ...defaultPosition, aom: "200069854" }, // start is excluded
+          end: { ...defaultPosition },
         },
         {
-          start: { ...defaultPosition, aom: "200071678" },
-          end: { ...defaultPosition, aom: "200069854" },
+          start: { ...defaultPosition },
+          end: { ...defaultPosition, aom: "200069854" }, // end is fine
         },
       ],
-    }, { incentive: [0, 0] }));
+    }, { incentive: [0, 150] }));
 });
 
 describe("Grand Châtellerault 2026 - Incentives", () => {


### PR DESCRIPTION
Exclusion des origines uniquement sur les AOM exclues et non origine ou destination sur la campagne Grand Châtellerault 2026.
Concerne uniquement Grand Poitiers pour le moment.
