### PR TITLE
chore: bump local to postgresql 17

### DIFF
--- a/docker/postgres/Dockerfile
+++ b/docker/postgres/Dockerfile
@@ -1,10 +1,10 @@
-FROM postgis/postgis:16-3.5-alpine
+FROM postgis/postgis:17-3.5-alpine
 # Dépendances de build
 RUN apk add --no-cache \
     git \
     build-base \
     cmake \
-    postgresql16-dev \
+    postgresql17-dev \
     llvm21-dev \
     clang21
 
@@ -23,6 +23,6 @@ RUN apk del \
     git \
     build-base \
     cmake \
-    postgresql16-dev \
+    postgresql17-dev \
     llvm21-dev \
     clang21

--- a/flake.nix
+++ b/flake.nix
@@ -48,7 +48,7 @@
       {
         devShells.default = pkgs.mkShell {
           # expose pg_config for building psycopg2
-          nativeBuildInputs = [ pkgs.postgresql_16.pg_config ];
+          nativeBuildInputs = [ pkgs.postgresql_17.pg_config ];
 
           buildInputs = with pkgs; [
             # system packages
@@ -61,7 +61,7 @@
 
             # rpc infra
             nodejs_24
-            postgresql_16
+            postgresql_17
             deno
 
             # data stack
@@ -87,7 +87,7 @@
             export DENO_DIR="$PWD/api/.cache"
             export SEVEN_ZIP_BIN_PATH=$(which 7z)
             export LESS="-SRXF"
-            if [ -L /run/current-system ]; then export LD_LIBRARY_PATH="${pkgs.lib.getLib pkgs.postgresql_16}/lib:${pkgs.stdenv.cc.cc.lib.outPath}/lib:${pkgs.pythonManylinuxPackages.manylinux2014Package}/lib:$LD_LIBRARY_PATH"; fi;
+            if [ -L /run/current-system ]; then export LD_LIBRARY_PATH="${pkgs.lib.getLib pkgs.postgresql_17}/lib:${pkgs.stdenv.cc.cc.lib.outPath}/lib:${pkgs.pythonManylinuxPackages.manylinux2014Package}/lib:$LD_LIBRARY_PATH"; fi;
             test -d .nix-venv || uv venv .nix-venv --no-project --no-managed-python --no-python-downloads
             source .nix-venv/bin/activate
             $(cd sqlmesh && UV_PROJECT_ENVIRONMENT=../.nix-venv uv sync)


### PR DESCRIPTION
## Résumé

Passage de l'environnement local de PostgreSQL 16 à PostgreSQL 17. PostGIS reste en 3.5 (pas de bump majeur côté extension).

- `docker/postgres/Dockerfile` : image de base `postgis/postgis:17-3.5-alpine`, paquet de build `postgresql17-dev`
- `flake.nix` : `postgresql_17` dans `nativeBuildInputs`, `buildInputs` et le `LD_LIBRARY_PATH` du `shellHook`

L'extension `h3-pg` v4.2.3 (commit `a26630b`) est inchangée et se recompile correctement contre PG17.

## Migration de la donnée locale (`db/postgres`)

Le cluster local créé par la précédente image PG16 n'est **pas lisible** par PG17 (incompatibilité majeure). Deux options selon le contexte.

### Option A : repartir à zéro (recommandé si la donnée locale est jetable)

```sh
docker compose down
sudo rm -rf db/postgres
docker compose up -d postgres
```

L'image se rebuilde, le cluster s'initialise vide en PG17 + PostGIS 3.5.

### Option B : `pg_upgrade --link` (si la donnée locale doit être conservée)

`pg_upgrade --link` migre le cluster en place via des hardlinks (rapide, peu d'espace disque additionnel). Le défi : PostgreSQL n'autorise l'opération que si **toutes les extensions** chargées par l'ancien cluster sont disponibles dans le nouveau, à des chemins compatibles. Sur ce projet, cela veut dire fournir dans une seule image Docker :

- PG 16 (binaire d'origine, celui qui a créé le cluster)
- PG 17 (binaire cible)
- PostGIS 3.5 compilé pour **les deux** versions de PG
- `h3-pg` v4.2.3 compilé pour **les deux** versions de PG

#### 1. Arrêter proprement l'ancien cluster

`pg_upgrade` exige un cluster en état `shut down` (et non `in production`). Si le dernier `docker compose down` a coupé brutalement le conteneur, relancer l'image PG16 d'origine, laisser la *crash recovery* se faire, puis stopper proprement :

```sh
docker run -d --name pg16-shutdown --rm \
  -v $PWD/db/postgres:/var/lib/postgresql/data/pgdata \
  -e PGDATA=/var/lib/postgresql/data/pgdata \
  -e POSTGRES_PASSWORD=postgres \
  postgis/postgis:16-3.5-alpine
sleep 8
docker exec pg16-shutdown su postgres -c \
  "pg_ctl -D /var/lib/postgresql/data/pgdata stop -m fast -w"
```

Vérifier que `pg_controldata` rapporte `Database cluster state: shut down`.

#### 2. Construire l'image d'upgrade

Créer un `Dockerfile` temporaire (ex. `/tmp/pg-upgrade/Dockerfile`) :

```dockerfile
FROM postgis/postgis:16-3.5-alpine

# Cette image apporte : PG 16.14 (upstream) dans /usr/local + PostGIS 3.5 + utilisateur postgres
# On ajoute  : PG 17.10 (apk) dans /usr/libexec/postgresql17 + PostGIS 3.5 pour PG17 + h3-pg pour les deux

USER root

RUN apk add --no-cache \
      postgresql17 postgresql17-dev postgresql17-contrib \
      build-base cmake git curl \
      geos geos-dev proj proj-dev gdal gdal-dev \
      libxml2 libxml2-dev json-c json-c-dev sqlite sqlite-dev \
      protobuf-c protobuf-c-dev \
      autoconf automake libtool perl-dev \
      llvm21-dev clang21

# PostGIS 3.5.3 pour PG17 (PG16 l'a deja dans l'image de base)
RUN curl -fsSL https://download.osgeo.org/postgis/source/postgis-3.5.3.tar.gz | tar xz -C /tmp \
 && cd /tmp/postgis-3.5.3 \
 && ./configure --with-pgconfig=/usr/libexec/postgresql17/pg_config \
 && make -j$(nproc) \
 && make install \
 && rm -rf /tmp/postgis-3.5.3

# h3-pg pour PG16 (defaut /usr/local)
RUN git clone https://github.com/zachasme/h3-pg.git /tmp/h3-pg16 \
 && cd /tmp/h3-pg16 && git checkout a26630b8353d441e6bc8065c0a8dcaa3d89ef87b \
 && cmake -B build -DCMAKE_BUILD_TYPE=Release \
      -DPostgreSQL_INCLUDE_DIR=/usr/local/include/postgresql/server \
      -DPostgreSQL_LIBRARY=/usr/local/lib \
 && cmake --build build -j$(nproc) \
 && cmake --install build --component h3-pg \
 && rm -rf /tmp/h3-pg16

# h3-pg pour PG17 (chemins apk explicites)
RUN git clone https://github.com/zachasme/h3-pg.git /tmp/h3-pg17 \
 && cd /tmp/h3-pg17 && git checkout a26630b8353d441e6bc8065c0a8dcaa3d89ef87b \
 && PATH=/usr/libexec/postgresql17:$PATH cmake -B build -DCMAKE_BUILD_TYPE=Release \
      -DPostgreSQL_ADDITIONAL_VERSIONS=17 \
      -DPostgreSQL_INCLUDE_DIR=/usr/include/postgresql/17/server \
      -DPostgreSQL_LIBRARY_DIR=/usr/lib/postgresql17 \
 && cmake --build build -j$(nproc) \
 && cmake --install build --component h3-pg \
 && rm -rf /tmp/h3-pg17

# Les binaires PG17 (apk) cherchent libpq.so.5 dans /usr/local/lib en premier,
# ou se trouve celle de PG16 (qui ne contient pas les symboles PG17).
# On force la libpq PG17 pour les deux.
RUN ln -sf /usr/lib/libpq.so.5.18 /usr/local/lib/libpq.so.5 \
 && ln -sf /usr/lib/libpq.so.5.18 /usr/local/lib/libpq.so.5.18

USER postgres
WORKDIR /var/lib/postgresql
```

```sh
docker build -t pg16-to-17-upgrader /tmp/pg-upgrade
```

#### 3. Préparer le nouveau cluster et exécuter `pg_upgrade`

Les deux `datadir` doivent être sur le **même système de fichiers** pour que les hardlinks fonctionnent (donc deux sous-dossiers du même `db/`).

```sh
chmod 777 db
docker run --rm \
  -v $PWD/db:/data \
  pg16-to-17-upgrader \
  sh -c '
    set -e
    mkdir -p /data/postgres-new && chmod 700 /data/postgres-new
    /usr/libexec/postgresql17/initdb -D /data/postgres-new \
      --encoding=UTF8 --locale=en_US.utf8 -U postgres
    /usr/libexec/postgresql17/pg_upgrade \
      --old-bindir=/usr/local/bin \
      --new-bindir=/usr/libexec/postgresql17 \
      --old-datadir=/data/postgres \
      --new-datadir=/data/postgres-new \
      --check
  '
```

Si la sortie se termine par `*Clusters are compatible*`, lancer l'upgrade pour de vrai :

```sh
docker run --rm \
  -v $PWD/db:/data \
  pg16-to-17-upgrader \
  /usr/libexec/postgresql17/pg_upgrade \
    --old-bindir=/usr/local/bin \
    --new-bindir=/usr/libexec/postgresql17 \
    --old-datadir=/data/postgres \
    --new-datadir=/data/postgres-new \
    --link --jobs=4
```

#### 4. Basculer les dossiers et démarrer PG17

```sh
docker run --rm -v $PWD/db:/data pg16-to-17-upgrader \
  sh -c 'mv /data/postgres /data/postgres.pg16.bak && mv /data/postgres-new /data/postgres'
docker compose up -d postgres
```

#### 5. Finitions PostGIS et statistiques

`pg_upgrade` n'embarque pas les statistiques de l'optimiseur, et PostGIS recommande de réaligner les fonctions catalogue sur le binaire installé :

```sh
for db in avril25 local test template_postgis; do
  docker compose exec -T postgres psql -U postgres -d "$db" \
    -c "SELECT postgis_extensions_upgrade();"
done

docker compose exec -T postgres \
  vacuumdb -U postgres --all --analyze-in-stages --jobs=4
```

#### 6. Nettoyage (une fois sûr·e)

`pg_upgrade --link` partage les fichiers de données via des hardlinks : `db/postgres.pg16.bak` ne consomme que quelques Go (le catalogue dupliqué, le WAL renommé). Supprimer une fois la migration validée :

```sh
docker run --rm -v $PWD/db:/data pg16-to-17-upgrader rm -rf /data/postgres.pg16.bak
docker image rm pg16-to-17-upgrader
```

## Test plan

- [ ] `docker compose build postgres` réussit
- [ ] `nix develop` charge bien `postgresql_17`
- [ ] `docker compose up -d postgres` démarre proprement
- [ ] `psql -c "SELECT version()"` renvoie `PostgreSQL 17.10`
- [ ] `SELECT postgis_full_version()` ne mentionne pas `procs need upgrade`
- [ ] Pour Option B : `\dx` dans chaque base liste `h3`, `postgis` et leurs dépendances habituelles

🤖 Generated with [Claude Code](https://claude.com/claude-code)
