### PR TITLE
fix: correct EPCI code for CCSPSL 2026 policy

### DIFF
--- a/api/src/pdc/services/policy/engine/policies/20260301_CCSPSL_2026.ts
+++ b/api/src/pdc/services/policy/engine/policies/20260301_CCSPSL_2026.ts
@@ -24,7 +24,7 @@ import { AbstractPolicyHandler } from "./AbstractPolicyHandler.ts";
 // INSERT INTO policy.policies ( territory_id, start_date, end_date, name, unit, status, handler, max_amount )
 // VALUES ( ???, '2026-03-01T00:00:00+0100', '2027-01-01T00:00:00+0100', 'CC Saint-Pourcain Sioule Limagne 2026', 'euro', 'draft', 'ccspsl_2026', 213500 );
 
-// Campagne CC Saint-Pourcain Sioule Limagne 2026 - epci:200049646
+// Campagne CC Saint-Pourcain Sioule Limagne 2026 - epci:200071389
 export const CCSPSL2026: PolicyHandlerStaticInterface = class extends AbstractPolicyHandler
   implements PolicyHandlerInterface {
   static readonly id = "ccspsl_2026";
@@ -98,7 +98,7 @@ export const CCSPSL2026: PolicyHandlerStaticInterface = class extends AbstractPo
 
     onDistanceRangeOrThrow(ctx, { min: 2_000, max: 80_001 });
 
-    if (!startsAt(ctx, { epci: ["200049646"] }) && !endsAt(ctx, { epci: ["200049646"] })) {
+    if (!startsAt(ctx, { epci: ["200071389"] }) && !endsAt(ctx, { epci: ["200071389"] })) {
       throw new NotEligibleTargetException();
     }
 

--- a/api/src/pdc/services/policy/engine/policies/20260301_CCSPSL_2026.unit.spec.ts
+++ b/api/src/pdc/services/policy/engine/policies/20260301_CCSPSL_2026.unit.spec.ts
@@ -4,12 +4,12 @@ import { OperatorsEnum } from "../../interfaces/index.ts";
 import { makeProcessHelper } from "../tests/macro.ts";
 import { CCSPSL2026 as Handler } from "./20260301_CCSPSL_2026.ts";
 
-// Saint-Pourcain-sur-Sioule (03254), EPCI 200049646
+// Saint-Pourcain-sur-Sioule (03254), EPCI 200071389
 const defaultPosition = {
   arr: "03254",
   com: "03254",
-  aom: "200049646",
-  epci: "200049646",
+  aom: "200071389",
+  epci: "200071389",
   dep: "03",
   reg: "84",
   country: "XXXXX",


### PR DESCRIPTION
## Summary
- Correct EPCI code from `200049646` to `200071389` (CC Saint-Pourcain Sioule Limagne) in the CCSPSL 2026 policy handler (line 27 comment, line 101 eligibility check).
- Align unit test fixture EPCI/AOM with the corrected value so the suite still passes.

## Follow-up (ops)
- Replay campaign processing job for policy id `1151` over `2026-03-01` -> now to recompute existing validated `amount=0` rows.

## Test plan
- [x] `deno test --no-check src/pdc/services/policy/engine/policies/20260301_CCSPSL_2026.unit.spec.ts` -> 5 passed (17 steps), 0 failed.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
