### PR TITLE
fix(docker): bind postgres on all interfaces and allow docker bridge

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -4,8 +4,15 @@ services:
       - 5432:5432
     environment:
       PGDATA: '/var/lib/postgresql/data/pgdata'
+    command:
+      - postgres
+      - -c
+      - listen_addresses=*
+      - -c
+      - hba_file=/etc/postgresql/pg_hba.conf
     volumes:
       - ./db/postgres:/var/lib/postgresql/data/pgdata
+      - ./docker/postgres/pg_hba.conf:/etc/postgresql/pg_hba.conf:ro
     shm_size: 8g
 
   redis:

--- a/docker/postgres/pg_hba.conf
+++ b/docker/postgres/pg_hba.conf
@@ -1,0 +1,10 @@
+# Local dev pg_hba.conf - mounted into the postgres container.
+# Trust posture matches the default container config; only used locally.
+local   all             all                                     trust
+host    all             all             127.0.0.1/32            trust
+host    all             all             ::1/128                 trust
+# Docker bridge networks (host -> container via docker-proxy enters from the bridge gateway)
+host    all             all             samenet                 trust
+local   replication     all                                     trust
+host    replication     all             127.0.0.1/32            trust
+host    replication     all             ::1/128                 trust


### PR DESCRIPTION
## Contexte

Depuis #3171, plus aucune connexion à postgres depuis l'hôte
(`server closed the connection unexpectedly`).

## Cause

L'image `postgis:17-alpine` initialise un répertoire avec
`listen_addresses=localhost` et un `pg_hba.conf` limité à la loopback.
docker-proxy ne peut donc pas relayer le trafic vers le conteneur.

## Correction

- Lancement de postgres avec `-c listen_addresses=*` et
  `-c hba_file=/etc/postgresql/pg_hba.conf`.
- `pg_hba.conf` monté autorisant le réseau bridge Docker.

## Vérification

- `psql -h 127.0.0.1 -U postgres -d <db>` → OK
- MCP `postgres` (dbhub) : `Reconnected to postgres.`
