### PR TITLE
refactor(api): migrate CompanyRepositoryProvider to DenoPostgresConnection

### DIFF
--- a/api/src/ilos/connection-postgres/DenoPostgresConnection.ts
+++ b/api/src/ilos/connection-postgres/DenoPostgresConnection.ts
@@ -89,6 +89,14 @@ export class DenoPostgresConnection
           // Number.MAX_SAFE_INTEGER (2^53 - 1), so decoding to number is safe
           // and keeps ResultInterface.<field>: number truthful at runtime.
           20: (value: string): number => Number(value),
+          // Postgres float4 / float8 (OIDs 700, 701). deno-postgres 0.19.5
+          // returns these as strings by default; node-pg returned them as
+          // numbers. Without these decoders, callers reading ST_X / ST_Y,
+          // AVG(), or any double-precision column get "string" where the
+          // result interface declares "number" (ticket #3179 regression
+          // surfaced by the company.companies geo round-trip).
+          700: (value: string): number => Number(value),
+          701: (value: string): number => Number(value),
         },
       },
       ...config,

--- a/api/src/pdc/services/company/providers/CompanyRepositoryProvider.integration.spec.ts
+++ b/api/src/pdc/services/company/providers/CompanyRepositoryProvider.integration.spec.ts
@@ -1,0 +1,150 @@
+import { assertEquals } from "dep:assert";
+import { afterAll, beforeAll, describe, it } from "dep:testing-bdd";
+
+import sql from "@/lib/pg/sql.ts";
+import { DenoDbContext, makeDenoDbBeforeAfter } from "@/pdc/providers/test/dbMacro.ts";
+import { CompanyInterface } from "@/shared/common/interfaces/CompanyInterface2.ts";
+
+import { CompanyRepositoryProvider } from "./CompanyRepositoryProvider.ts";
+
+const sample = (overrides: Partial<CompanyInterface> = {}): CompanyInterface => ({
+  siret: "99999999999999",
+  siren: "999999999",
+  nic: "99999",
+  legal_name: "ACME GOV",
+  company_naf_code: "8411Z",
+  establishment_naf_code: "8411Z",
+  legal_nature_code: "7120",
+  legal_nature_label: "ADMINISTRATION",
+  intra_vat: "FR99999999999",
+  headquarter: true,
+  nonprofit_code: null,
+  address: "1 rue des Lilas 75001 PARIS",
+  address_street: "rue des Lilas",
+  address_postcode: "75001",
+  address_cedex: null,
+  address_city: "PARIS",
+  ...overrides,
+});
+
+describe("CompanyRepositoryProvider", () => {
+  let db: DenoDbContext;
+  let repository: CompanyRepositoryProvider;
+  const { before, after } = makeDenoDbBeforeAfter();
+
+  beforeAll(async () => {
+    db = await before();
+    repository = new CompanyRepositoryProvider(db.connection);
+    // Seed inserts company rows with explicit _id but does not bump the
+    // company.companies__id_seq sequence, so the first sequence-driven
+    // INSERT collides on the primary key. Align the sequence with the
+    // current max before exercising updateOrCreate.
+    await db.connection.query(sql`
+      SELECT setval(
+        'company.companies__id_seq',
+        GREATEST(1000, COALESCE((SELECT MAX(_id) FROM company.companies), 0))
+      )
+    `);
+  });
+
+  afterAll(async () => {
+    await after(db);
+  });
+
+  it("findBySiret returns undefined when no company matches", async () => {
+    const result = await repository.findBySiret("00000000000000");
+    assertEquals(result, undefined);
+  });
+
+  it("findById returns undefined when no company matches", async () => {
+    const result = await repository.findById(987654321);
+    assertEquals(result, undefined);
+  });
+
+  it("updateOrCreate inserts a new company and findBySiret round-trips every column", async () => {
+    const data = sample({ siret: "11111111111111", siren: "111111111" });
+    await repository.updateOrCreate(data);
+
+    const found = await repository.findBySiret("11111111111111");
+    assertEquals(found.siret, data.siret);
+    assertEquals(found.siren, data.siren);
+    assertEquals(found.nic, data.nic);
+    assertEquals(found.legal_name, data.legal_name);
+    assertEquals(found.company_naf_code, data.company_naf_code);
+    assertEquals(found.establishment_naf_code, data.establishment_naf_code);
+    assertEquals(found.legal_nature_code, data.legal_nature_code);
+    assertEquals(found.legal_nature_label, data.legal_nature_label);
+    assertEquals(found.intra_vat, data.intra_vat);
+    assertEquals(found.headquarter, data.headquarter);
+    assertEquals(found.nonprofit_code, data.nonprofit_code);
+    assertEquals(found.address, data.address);
+    assertEquals(found.address_street, data.address_street);
+    assertEquals(found.address_postcode, data.address_postcode);
+    assertEquals(found.address_cedex, data.address_cedex);
+    assertEquals(found.address_city, data.address_city);
+    assertEquals(typeof found._id, "number");
+  });
+
+  it("updateOrCreate upserts the same siret in place (no unique-key crash)", async () => {
+    const siret = "22222222222222";
+    await repository.updateOrCreate(sample({ siret, siren: "222222222", legal_name: "ORIGINAL" }));
+    const before = await repository.findBySiret(siret);
+
+    await repository.updateOrCreate(sample({ siret, siren: "222222222", legal_name: "RENAMED" }));
+    const after = await repository.findBySiret(siret);
+
+    assertEquals(after._id, before._id);
+    assertEquals(after.legal_name, "RENAMED");
+  });
+
+  it("updateOrCreate stores POINT(lon lat) and findBySiret reads lon/lat back via ST_X/ST_Y", async () => {
+    const data = sample({
+      siret: "33333333333333",
+      siren: "333333333",
+      lon: 2.320884,
+      lat: 48.854634,
+    });
+    await repository.updateOrCreate(data);
+
+    const found = await repository.findBySiret("33333333333333");
+    assertEquals(typeof found.lon, "number");
+    assertEquals(typeof found.lat, "number");
+    if (typeof found.lon !== "number" || typeof found.lat !== "number") return;
+    // ST_Point round-trip is lossy past 6 decimals; pin to ~1m precision (5dp).
+    assertEquals(Math.round(found.lon * 1e5) / 1e5, 2.32088);
+    assertEquals(Math.round(found.lat * 1e5) / 1e5, 48.85463);
+  });
+
+  it("updateOrCreate stores geo as NULL when lon is undefined", async () => {
+    const data = sample({ siret: "44444444444444", siren: "444444444" });
+    delete data.lon;
+    delete data.lat;
+    await repository.updateOrCreate(data);
+
+    const found = await repository.findBySiret("44444444444444");
+    assertEquals(found.lon, null);
+    assertEquals(found.lat, null);
+  });
+
+  it("findById returns the row inserted by updateOrCreate", async () => {
+    const siret = "55555555555555";
+    await repository.updateOrCreate(sample({ siret, siren: "555555555" }));
+    const bySiret = await repository.findBySiret(siret);
+
+    const byId = await repository.findById(bySiret._id);
+    assertEquals(byId.siret, siret);
+    assertEquals(byId._id, bySiret._id);
+  });
+
+  it("updateOrCreate followed by an upsert with a different siret does not collide", async () => {
+    await repository.updateOrCreate(sample({ siret: "66666666666666", siren: "666666666" }));
+    await repository.updateOrCreate(sample({ siret: "77777777777777", siren: "777777777" }));
+
+    const a = await repository.findBySiret("66666666666666");
+    const b = await repository.findBySiret("77777777777777");
+    assertEquals(a.siret, "66666666666666");
+    assertEquals(b.siret, "77777777777777");
+    assertEquals(a._id !== b._id, true);
+  });
+
+});

--- a/api/src/pdc/services/company/providers/CompanyRepositoryProvider.ts
+++ b/api/src/pdc/services/company/providers/CompanyRepositoryProvider.ts
@@ -1,5 +1,6 @@
 import { provider } from "@/ilos/common/index.ts";
-import { LegacyPostgresConnection } from "@/ilos/connection-postgres/index.ts";
+import { DenoPostgresConnection } from "@/ilos/connection-postgres/index.ts";
+import sql, { raw } from "@/lib/pg/sql.ts";
 
 import {
   CompanyRepositoryProviderInterface,
@@ -14,11 +15,10 @@ import { CompanyInterface } from "@/shared/common/interfaces/CompanyInterface2.t
 export class CompanyRepositoryProvider implements CompanyRepositoryProviderInterface {
   public readonly table = "company.companies";
 
-  constructor(protected connection: LegacyPostgresConnection) {}
+  constructor(protected pgConnection: DenoPostgresConnection) {}
 
   async findById(id: number): Promise<CompanyInterface> {
-    const query = {
-      text: `
+    const rows = await this.pgConnection.query<CompanyInterface>(sql`
       SELECT
         _id,
         siret,
@@ -40,22 +40,16 @@ export class CompanyRepositoryProvider implements CompanyRepositoryProviderInter
         address_city,
         ST_X(geo::geometry) as lon,
         ST_Y(geo::geometry) as lat
-      FROM ${this.table}
-      WHERE _id = $1::int
-      LIMIT 1`,
-      values: [id],
-    };
+      FROM ${raw(this.table)}
+      WHERE _id = ${id}::int
+      LIMIT 1
+    `);
 
-    const result = await this.connection.getClient().query<any>(query);
-    if (result.rowCount !== 1) {
-      return undefined;
-    }
-    return result.rows[0];
+    return rows[0];
   }
 
   async findBySiret(siret: string): Promise<CompanyInterface> {
-    const query = {
-      text: `
+    const rows = await this.pgConnection.query<CompanyInterface>(sql`
       SELECT
         _id,
         siret,
@@ -77,107 +71,82 @@ export class CompanyRepositoryProvider implements CompanyRepositoryProviderInter
         address_city,
         ST_X(geo::geometry) as lon,
         ST_Y(geo::geometry) as lat
-      FROM ${this.table}
-      WHERE siret = $1::varchar
-      LIMIT 1`,
-      values: [siret],
-    };
+      FROM ${raw(this.table)}
+      WHERE siret = ${siret}::varchar
+      LIMIT 1
+    `);
 
-    const result = await this.connection.getClient().query<any>(query);
-    if (result.rowCount !== 1) {
-      return undefined;
-    }
-    return result.rows[0];
+    return rows[0];
   }
 
   async updateOrCreate(data: CompanyInterface): Promise<void> {
-    const query = {
-      text: `
-        INSERT INTO ${this.table} (
-          siret,
-          siren,
-          nic,
-          legal_name,
-          company_naf_code,
-          establishment_naf_code,
-          legal_nature_code,
-          legal_nature_label,
-          intra_vat,
-          headquarter,
-          updated_at,
-          nonprofit_code,
-          address,
-          address_street,
-          address_postcode,
-          address_cedex,
-          address_city,
-          geo
-        ) VALUES (
-          $1,
-          $2,
-          $3,
-          $4,
-          $5,
-          $6,
-          $7,
-          $8,
-          $9,
-          $10,
-          $11,
-          $12,
-          $13,
-          $14,
-          $15,
-          $16,
-          $17,
-          $18
-        )
-        ON CONFLICT (siret)
-        DO UPDATE SET
-          siren = $2,
-          nic = $3,
-          legal_name = $4,
-          company_naf_code = $5,
-          establishment_naf_code = $6,
-          legal_nature_code = $7,
-          legal_nature_label = $8,
-          intra_vat = $9,
-          headquarter = $10,
-          updated_at = $11,
-          nonprofit_code = $12,
-          address = $13,
-          address_street = $14,
-          address_postcode = $15,
-          address_cedex = $16,
-          address_city = $17,
-          geo = $18
-      `,
-      values: [
-        data.siret,
-        data.siren,
-        data.nic,
-        data.legal_name,
-        data.company_naf_code,
-        data.establishment_naf_code,
-        data.legal_nature_code,
-        data.legal_nature_label,
-        data.intra_vat,
-        data.headquarter,
-        new Date(),
-        data.nonprofit_code,
-        data.address,
-        data.address_street,
-        data.address_postcode,
-        data.address_cedex,
-        data.address_city,
-        data.lon ? `POINT(${data.lon} ${data.lat})` : null,
-      ],
-    };
+    const now = new Date();
+    const geo = data.lon ? `POINT(${data.lon} ${data.lat})` : null;
 
-    const result = await this.connection.getClient().query<any>(query);
-    if (result.rowCount !== 1) {
+    const rows = await this.pgConnection.query<{ _id: number }>(sql`
+      INSERT INTO ${raw(this.table)} (
+        siret,
+        siren,
+        nic,
+        legal_name,
+        company_naf_code,
+        establishment_naf_code,
+        legal_nature_code,
+        legal_nature_label,
+        intra_vat,
+        headquarter,
+        updated_at,
+        nonprofit_code,
+        address,
+        address_street,
+        address_postcode,
+        address_cedex,
+        address_city,
+        geo
+      ) VALUES (
+        ${data.siret},
+        ${data.siren},
+        ${data.nic},
+        ${data.legal_name},
+        ${data.company_naf_code},
+        ${data.establishment_naf_code},
+        ${data.legal_nature_code},
+        ${data.legal_nature_label},
+        ${data.intra_vat},
+        ${data.headquarter},
+        ${now},
+        ${data.nonprofit_code},
+        ${data.address},
+        ${data.address_street},
+        ${data.address_postcode},
+        ${data.address_cedex},
+        ${data.address_city},
+        ${geo}
+      )
+      ON CONFLICT (siret)
+      DO UPDATE SET
+        siren = ${data.siren},
+        nic = ${data.nic},
+        legal_name = ${data.legal_name},
+        company_naf_code = ${data.company_naf_code},
+        establishment_naf_code = ${data.establishment_naf_code},
+        legal_nature_code = ${data.legal_nature_code},
+        legal_nature_label = ${data.legal_nature_label},
+        intra_vat = ${data.intra_vat},
+        headquarter = ${data.headquarter},
+        updated_at = ${now},
+        nonprofit_code = ${data.nonprofit_code},
+        address = ${data.address},
+        address_street = ${data.address_street},
+        address_postcode = ${data.address_postcode},
+        address_cedex = ${data.address_cedex},
+        address_city = ${data.address_city},
+        geo = ${geo}
+      RETURNING _id
+    `);
+
+    if (rows.length !== 1) {
       throw new Error(`Unable to create or update company (${data.siret})`);
     }
-    return;
   }
 }


### PR DESCRIPTION
Refs #3179

## Description

Première tranche de la migration de `LegacyPostgresConnection` vers `DenoPostgresConnection` (cf. issue #3179). Le ticket est découpé en une PR par service ; celle-ci ne touche que le service `company`.

**Refacto du service company**
- `CompanyRepositoryProvider` injecte désormais `DenoPostgresConnection` (renommé `pgConnection` pour suivre la convention déjà utilisée dans `dashboard/`, `export/`, `auth/`).
- Les trois méthodes (`findById`, `findBySiret`, `updateOrCreate`) sont réécrites avec les templates `sql` de `@/lib/pg/sql.ts` à la place des objets `{ text, values }`.
- Les générics `<any>` passent à `<CompanyInterface>` (et `<{ _id: number }>` pour la ligne retournée par `RETURNING _id`).
- `updateOrCreate` utilise désormais `RETURNING _id` puis vérifie `rows.length !== 1`, car `DenoPostgresConnection.query` renvoie un tableau sans `rowCount`.
- Les valeurs `now = new Date()` et `geo = "POINT(...)"` sont extraites en locales pour éviter de les dupliquer entre `VALUES` et `ON CONFLICT`.

**Correctif `DenoPostgresConnection` (régression cross-service)**

Le spec d'intégration ajouté ci-dessous a fait apparaître une régression introduite par toute la migration `node-pg` -> `deno-postgres` : `deno-postgres 0.19.5` renvoie les valeurs `float4` / `float8` sous forme de **chaînes**, là où `node-pg` renvoyait des nombres. Tout appelant qui lit `ST_X`, `ST_Y`, `AVG()` ou n'importe quelle colonne en `double precision` reçoit donc une string alors que les `ResultInterface.<field>` annoncent `number`. Concrètement : code déjà migré (dashboard, export, auth) silencieusement cassé pour la sérialisation JSON et l'arithmétique côté API.

Ajout des décodeurs OID 700 (`float4`) et 701 (`float8`) dans `DenoPostgresConnection`, à côté du décodeur OID 20 (`int8`) déjà présent pour #3176. Même argument de précision : la mantisse `double precision` rentre intégralement dans un `Number` JS, donc la conversion est sans perte sur toute la plage représentable par Postgres.

**Spec d'intégration**

Ajout de `CompanyRepositoryProvider.integration.spec.ts` (modèle : `dashboard/providers/UsersRepository.integration.spec.ts`). Le test couvre les risques propres à la migration :
- `findById` / `findBySiret` renvoient `undefined` en l'absence de résultat.
- `updateOrCreate` insère et tous les champs persistés ressortent identiques par `findBySiret`.
- `updateOrCreate` upsert sur la même siret sans collision (exerce le `RETURNING _id`).
- `POINT(lon lat)` survit au round-trip via `ST_X` / `ST_Y` en tant que `number` (valide le décodeur float ajouté).
- `geo` est `NULL` quand `lon` est `undefined`.
- Des sirets distincts allouent des `_id` distincts.

Le `beforeAll` aligne la séquence `company.companies__id_seq` sur le `MAX(_id)` post-seed, car `DenoMigrator.seedCompany` insère un `_id` explicite sans bumper la séquence (problème d'infrastructure de seed qui dépasse le scope de cette PR).

Aucune modification du `Kernel.ts` n'est nécessaire : `DenoPostgresConnection` y est déjà enregistré aux côtés de `LegacyPostgresConnection`. L'interface `CompanyRepositoryProviderInterface` reste identique, donc aucun appelant n'est impacté.

## Checklist

- [x] j'ai suivi les guidelines du "clean code"
- [ ] j'ai mis à jour la documentation technique dans `/api/specs` (sans objet, refacto interne)
- [ ] ajout ou mise à jour des tests unitaires (sans objet)
- [x] ajout ou mise à jour des tests d'intégration

## Vérification

- `deno lint` : OK sur les deux fichiers modifiés et le spec.
- `deno test src/pdc/services/company/providers/CompanyRepositoryProvider.integration.spec.ts` : 8 steps OK contre la base postgres locale (insecure + url override).
- `deno check` sur `CompanyRepositoryProvider.ts` : 19 erreurs vs 21 sur `main`, toutes pré-existantes dans `ilos/common/Decorators.ts` et les types `inversify` (aucune dans les fichiers modifiés ni dans `lib/pg/sql.ts`).
- `rg LegacyPostgresConnection api/src/pdc/services/company` : aucun résultat.

## Suite

~38 fichiers utilisent encore `LegacyPostgresConnection` (`carpool`, `policy`, `observatory`, `apdf`, `operator`, `honor`, `monitoring`, `territory`, `geo`, middleware, helpers de tests). La suppression de `LegacyPostgresConnection`, `PgPool`, `NativeCursor` et `LegacyMigrator` interviendra dans la dernière PR de la série, une fois tous les services migrés.

À noter pour les PRs suivantes : il vaudrait la peine de vérifier rapidement les services déjà migrés (dashboard, export, auth) pour repérer les éventuels endroits où l'API ou les calculs s'appuyaient implicitement sur des nombres et reçoivent désormais des strings — le décodeur float ajouté ici devrait suffire dans la plupart des cas, mais les tests d'intégration manquants côté dashboard/export/auth ne le garantissent pas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)