### PR TITLE
fix(app-partners): keep graph header visible on empty/error responses (#3176)

### DIFF
--- a/app-partners/src/app/activite/campagnes/details/graphs/JourneysGraph.tsx
+++ b/app-partners/src/app/activite/campagnes/details/graphs/JourneysGraph.tsx
@@ -69,7 +69,21 @@ export default function JourneysGraph(props: { title: string; campaignId: number
   }
 
   if (!data || data.length === 0) {
-    return null;
+    return (
+      <div className={fr.cx("fr-my-4w")}>
+        {header}
+        <Alert
+          severity="info"
+          title="Aucune donnée disponible"
+          description={
+            period === "day"
+              ? "Aucun trajet enregistré sur les jours récents pour cette campagne."
+              : "Aucun trajet enregistré sur les derniers mois pour cette campagne."
+          }
+          small
+        />
+      </div>
+    );
   }
   const name = ["Trajets avec Origine OU destination sur le territoire", "Trajets incités et validés par le RPC"];
   const colors = ["#6a6af4", "#000091"];

--- a/app-partners/src/app/activite/campagnes/details/graphs/OperatorsGraph.tsx
+++ b/app-partners/src/app/activite/campagnes/details/graphs/OperatorsGraph.tsx
@@ -70,7 +70,21 @@ export default function OperatorsGraph(props: { title: string; campaignId: numbe
   }
 
   if (!data || data.length === 0) {
-    return <></>;
+    return (
+      <div className={fr.cx("fr-my-4w")}>
+        {header}
+        <Alert
+          severity="info"
+          title="Aucune donnée disponible"
+          description={
+            period === "day"
+              ? "Aucun trajet enregistré sur les jours récents pour cette campagne."
+              : "Aucun trajet enregistré sur les derniers mois pour cette campagne."
+          }
+          small
+        />
+      </div>
+    );
   }
   const name = [...new Set(data?.map((d) => d.operator_name))] as string[];
   const colors = [

--- a/app-partners/src/app/page.tsx
+++ b/app-partners/src/app/page.tsx
@@ -22,7 +22,7 @@ export default function Home() {
         className={fr.cx("fr-grid-row", "fr-grid-row--gutters", "fr-grid-row--center", "fr-grid-row--middle")}
       >
         <div className={fr.cx("fr-col-12", "fr-col-sm-6")} style={{ wordBreak: "break-word", minWidth: 0 }}>
-          <PageTitle title={`Bievenue sur l'espace partenaire de covoiturage.beta.gouv.fr`} />
+          <PageTitle title={`Bienvenue sur l'espace partenaire de covoiturage.beta.gouv.fr`} />
         </div>
         <div className={fr.cx("fr-col-12", "fr-col-sm-6", "fr-hidden", "fr-unhidden-sm")}>
           <Image

--- a/app-partners/src/hooks/useApi.ts
+++ b/app-partners/src/hooks/useApi.ts
@@ -25,16 +25,31 @@ export const useApi = <T>(
       setError(null);
       setLoading(true);
       const response = await fetch(url, { ...init, credentials: "include" });
-      const res = (await response.json()) as ApiResponse<T>;
+      const text = await response.text();
+      let res: ApiResponse<T> | null = null;
+      if (text.length > 0) {
+        try {
+          res = JSON.parse(text) as ApiResponse<T>;
+        } catch {
+          if (!response.ok) {
+            throw new Error(
+              response.statusText || `Erreur ${response.status}`,
+            );
+          }
+          res = null;
+        }
+      }
       if (!response.ok) {
         throw new Error(
-          (res as ErrorResponse).message ?? "Une erreur est survenue",
+          (res as ErrorResponse | null)?.message ??
+            response.statusText ??
+            "Une erreur est survenue",
         );
       }
 
       if (
         paginate &&
-        ((res as PaginateAPIResponse<T>).meta?.totalPages ?? 0) > 1
+        ((res as PaginateAPIResponse<T> | null)?.meta?.totalPages ?? 0) > 1
       ) {
         const paginateResponse = res as PaginateAPIResponse<T>;
 
@@ -43,7 +58,7 @@ export const useApi = <T>(
           data: paginateResponse.data,
         } as T);
       } else {
-        setData(res as T);
+        setData((res ?? undefined) as T | undefined);
       }
     } catch (e) {
       setError(e as Error);


### PR DESCRIPTION
## Summary

Re-opens #3176. The BigInt fix in v3.92.1 stopped the 500 on `/dashboard/operators/day`, but the graph still disappears whenever the server returns an empty payload because the React components hide the entire callout (incl. the Evolution mensuelle / journalière toggle) the moment `data` is empty. Once a user clicks "Evolution journalière" with no data, the toggle vanishes and they cannot return to the monthly view without reloading.

- `OperatorsGraph.tsx` / `JourneysGraph.tsx`: empty/`null` data now renders the header (period toggle) + a DSFR info Alert ("Aucune donnée disponible"), so the user can still switch periods.
- `useApi.ts`: reads the body as text first, parses only when non-empty. Empty body / 204 / non-JSON success responses no longer crash the JSON parser; non-OK responses surface `statusText` or `Erreur <status>` instead of a cryptic SyntaxError.

Also picks up a small typo fix in `app/page.tsx` made in the same branch.

## Test plan

- [ ] Open a campaign with no journeys, switch to "Evolution journalière" -- header + toggle stay visible, info Alert shown
- [ ] Switch back to "Evolution mensuelle" without reloading -- still works
- [ ] Same on JourneysGraph (Trajets par opérateurs)
- [ ] Verify on IDFM campaign (id=459) which originally exhibited both graphs disappearing
- [ ] Trigger a 500 from the API (e.g. revert BigInt fix locally) -- error Alert shown with readable message, not `Unexpected end of JSON input`

Closes #3176

🤖 Generated with [Claude Code](https://claude.com/claude-code)