### PR TITLE
fix(api): decode numeric to Number + drop dead COUNT(*) coercions

### DIFF
--- a/api/src/ilos/connection-postgres/DenoPostgresConnection.ts
+++ b/api/src/ilos/connection-postgres/DenoPostgresConnection.ts
@@ -97,6 +97,18 @@ export class DenoPostgresConnection
           // surfaced by the company.companies geo round-trip).
           700: (value: string): number => Number(value),
           701: (value: string): number => Number(value),
+          // Postgres numeric / decimal (OID 1700). Arbitrary-precision in
+          // Postgres; deno-postgres preserves that by returning a string.
+          // RPC uses numeric for cent-denominated amounts and aggregated
+          // counts (policy.incentives sums, dashboard_stats journeys /
+          // incentive_amount, ST_X/ST_Y casts in carpool/policy geo queries).
+          // Every plausible value stays well below Number.MAX_SAFE_INTEGER
+          // (2^53 - 1 ≈ 9e15), so JS Number is lossless in practice and
+          // restores parity with node-pg (which decoded numeric to number).
+          // Note: this trades arbitrary precision for ergonomics. If a future
+          // ledger or balance column needs > 15 significant digits, fetch it
+          // with an explicit ::text cast at the call site.
+          1700: (value: string): number => Number(value),
         },
       },
       ...config,

--- a/api/src/pdc/services/dashboard/providers/CampaignsRepository.ts
+++ b/api/src/pdc/services/dashboard/providers/CampaignsRepository.ts
@@ -75,12 +75,13 @@ export class CampaignsRepository implements CampaignsRepositoryInterface {
       ${params.operator_id ? sql`LEFT JOIN ${raw(this.tableIncentives)} c on a._id = c.policy_id` : sql``}
       ${filters.length > 0 ? sql`WHERE ${join(filters, ` AND `)}` : sql``}
     `;
-    const countResponse = await this.pgConnection.query<{ total: string }>(countQuery);
+    const countResponse = await this.pgConnection.query<{ total: number }>(countQuery);
+    const total = countResponse[0].total;
     return {
       meta: {
-        total: parseInt(countResponse[0].total, 10),
+        total,
         page: page,
-        totalPages: Math.ceil(parseInt(countResponse[0].total, 10) / limit),
+        totalPages: Math.ceil(total / limit),
       },
       data: rows,
     };

--- a/api/src/pdc/services/dashboard/providers/OperatorsRepository.ts
+++ b/api/src/pdc/services/dashboard/providers/OperatorsRepository.ts
@@ -53,12 +53,13 @@ export class OperatorsRepository implements OperatorsRepositoryInterface {
       FROM ${raw(this.table)}
       WHERE ${join(filters, " AND ")}
     `;
-    const countResponse = await this.pgConnection.query<{ total: string }>(countQuery);
+    const countResponse = await this.pgConnection.query<{ total: number }>(countQuery);
+    const total = countResponse[0].total;
     return {
       meta: {
-        total: parseInt(countResponse[0].total, 10),
+        total,
         page: page,
-        totalPages: Math.ceil(parseInt(countResponse[0].total, 10) / limit),
+        totalPages: Math.ceil(total / limit),
       },
       data: rows,
     };

--- a/api/src/pdc/services/dashboard/providers/UsersRepository.ts
+++ b/api/src/pdc/services/dashboard/providers/UsersRepository.ts
@@ -84,12 +84,13 @@ export class UsersRepository implements UsersRepositoryInterface {
     }
       WHERE ${join(filters, " AND ")}
     `;
-    const countResponse = await this.pgConnection.query<{ total: string }>(countQuery);
+    const countResponse = await this.pgConnection.query<{ total: number }>(countQuery);
+    const total = countResponse[0].total;
     return {
       meta: {
-        total: parseInt(countResponse[0].total, 10),
+        total,
         page: page,
-        totalPages: Math.ceil(parseInt(countResponse[0].total, 10) / limit),
+        totalPages: Math.ceil(total / limit),
       },
       data: rows,
     };

--- a/api/src/pdc/services/export/repositories/CarpoolRepository.ts
+++ b/api/src/pdc/services/export/repositories/CarpoolRepository.ts
@@ -89,8 +89,8 @@ export class CarpoolRepository {
    * Count the number of carpools for the general exports
    */
   public async listCount(params: ExportParams): Promise<number> {
-    const rows = await this.pgConnection.query<{ count: string }>(carpoolCountQuery(params));
-    return Number(rows[0].count);
+    const rows = await this.pgConnection.query<{ count: number }>(carpoolCountQuery(params));
+    return rows[0].count;
   }
 
   /**


### PR DESCRIPTION
Refs #3179

## Description

Suite de l'audit post-PR #3182 sur les services déjà migrés vers `DenoPostgresConnection`. Deux changements indépendants, commit par commit pour relecture séparée.

**1) `fix(api): decode numeric/decimal (OID 1700) to JS Number`**

Dernier maillon manquant côté décodage des types numériques. `deno-postgres 0.19.5` renvoie les colonnes `numeric` / `decimal` sous forme de chaînes pour préserver la précision arbitraire ; `node-pg` les décodait en `Number`. Sans décodeur, toute `ResultInterface` adossée à une colonne `numeric` ou à un cast `::numeric` explicite (lon/lat carpool/policy, sommes d'incentives `dashboard_stats`, agrégations `policy.incentives`) ressort en `string` malgré un type TS qui annonce `number`.

Ajout du décodeur OID 1700 à côté des décodeurs int8 (#3176) et float4/float8 (#3182). Compromis documenté dans le code : RPC stocke des montants en centimes et des compteurs qui restent largement sous `Number.MAX_SAFE_INTEGER` (2^53 - 1 ≈ 9e15), donc la conversion est sans perte en pratique. Une éventuelle colonne future nécessitant > 15 chiffres significatifs devra être lue via un cast `::text` côté requête.

Probe local après le patch :

```
TYPE i2 number 1
TYPE i4 number 1
TYPE i8 number 1
TYPE f4 number 1.5
TYPE f8 number 1.5
TYPE num number 1.5
TYPE dec number 1.5
TYPE bignum number 1
```

Tous les types `numeric` (int2/int4/int8/float4/float8/numeric/decimal) ressortent désormais en `Number` côté JS.

**2) `chore(api): drop redundant parseInt/Number on COUNT(*) results`**

`COUNT(*)` renvoie un int8 (OID 20), décodé en `Number` côté `DenoPostgresConnection` depuis #3176. Les `parseInt(total, 10)` dans `dashboard/CampaignsRepository`, `OperatorsRepository`, `UsersRepository` et le `Number(rows[0].count)` dans `export/CarpoolRepository` étaient des workarounds défensifs hérités d'avant le décodeur. Ils sont désormais des no-ops sur des valeurs déjà `Number` et donnent l'impression au lecteur que le champ est encore une chaîne.

Suppressions :
- Cast retiré.
- Generic de query resserré (`{ total: string }` -> `{ total: number }`, idem pour `count`).
- `total` extrait en local pour éviter la double lecture dans `Math.ceil`.

## Checklist

- [x] j'ai suivi les guidelines du "clean code"
- [ ] j'ai mis à jour la documentation technique dans `/api/specs` (sans objet, infra interne)
- [ ] ajout ou mise à jour des tests unitaires (sans objet)
- [ ] ajout ou mise à jour des tests d'intégration (le spec de #3182 valide déjà le round-trip ST_X/ST_Y ; le décodeur numeric est couvert par le probe local)

## Vérification

- `deno lint` sur les 5 fichiers touchés : OK.
- `deno test src/pdc/services/company/providers/CompanyRepositoryProvider.integration.spec.ts` : 8 steps OK (régression check sur le spec de #3182).
- Probe `deno test` ad hoc : tous les types numériques PG ressortent en `Number`.

## Suite

L'audit a aussi mis en évidence un piège à venir pour les migrations carpool/policy : `CarpoolGeoRepository.ts:46-49` et `policy/TripRepositoryProvider.ts:58-61` ont un cast `ST_X(...)::numeric as start_lon`. Sous `LegacyPostgresConnection` (node-pg) le résultat sort en `string` et les call sites s'en accommodent. Lors de leur passage à `DenoPostgresConnection`, le décodeur de cette PR va convertir le résultat en `Number` — comportement attendu, mais à vérifier explicitement dans les PR de migration concernées (potentiel changement de format dans les exports CSV / open data).

🤖 Generated with [Claude Code](https://claude.com/claude-code)