### PR TITLE
refactor(api): migrate honor service to DenoPostgresConnection

### DIFF
--- a/api/src/pdc/services/honor/actions/SaveAction.ts
+++ b/api/src/pdc/services/honor/actions/SaveAction.ts
@@ -18,7 +18,7 @@ export class SaveAction extends AbstractAction {
     super();
   }
 
-  public async handle(params: ParamsInterface): Promise<ResultInterface> {
-    await this.pg.save(params.type, params.employer);
+  public override async handle(params: ParamsInterface): Promise<ResultInterface> {
+    await this.pg.save(params.type, params.employer ?? "");
   }
 }

--- a/api/src/pdc/services/honor/actions/StatsAction.ts
+++ b/api/src/pdc/services/honor/actions/StatsAction.ts
@@ -18,7 +18,7 @@ export class StatsAction extends AbstractAction {
     super();
   }
 
-  public async handle(params: ParamsInterface): Promise<ResultInterface> {
+  public override async handle(params: ParamsInterface): Promise<ResultInterface> {
     return this.pg.stats(params);
   }
 }

--- a/api/src/pdc/services/honor/contracts/save.contract.ts
+++ b/api/src/pdc/services/honor/contracts/save.contract.ts
@@ -2,7 +2,7 @@ export type ResultInterface = void;
 
 export interface ParamsInterface {
   type: string;
-  employer: string | null;
+  employer?: string;
 }
 
 export const handlerConfig = {

--- a/api/src/pdc/services/honor/providers/HonorRepositoryProvider.integration.spec.ts
+++ b/api/src/pdc/services/honor/providers/HonorRepositoryProvider.integration.spec.ts
@@ -1,0 +1,72 @@
+import { assertEquals } from "dep:assert";
+import { afterAll, beforeAll, describe, it } from "dep:testing-bdd";
+
+import sql from "@/lib/pg/sql.ts";
+import { DenoDbContext, makeDenoDbBeforeAfter } from "@/pdc/providers/test/dbMacro.ts";
+
+import { HonorRepositoryProvider } from "./HonorRepositoryProvider.ts";
+
+type Row = { _id: number; type: string; employer: string };
+
+describe("HonorRepositoryProvider", () => {
+  let db: DenoDbContext;
+  let repository: HonorRepositoryProvider;
+  const { before, after } = makeDenoDbBeforeAfter();
+
+  beforeAll(async () => {
+    db = await before();
+    repository = new HonorRepositoryProvider(db.connection);
+  });
+
+  afterAll(async () => {
+    await after(db);
+  });
+
+  it("save inserts a row that round-trips type and employer", async () => {
+    await repository.save("public", "ACME");
+
+    const rows = await db.connection.query<Row>(sql`
+      SELECT _id, type, employer
+      FROM honor.tracking
+      WHERE employer = 'ACME'
+      ORDER BY _id DESC
+      LIMIT 1
+    `);
+
+    assertEquals(rows.length, 1);
+    assertEquals(rows[0].type, "public");
+    assertEquals(rows[0].employer, "ACME");
+    assertEquals(typeof rows[0]._id, "number");
+  });
+
+  it("save accepts the limited type and an empty employer", async () => {
+    await repository.save("limited", "");
+
+    const rows = await db.connection.query<Row>(sql`
+      SELECT _id, type, employer
+      FROM honor.tracking
+      WHERE type = 'limited' AND employer = ''
+      ORDER BY _id DESC
+      LIMIT 1
+    `);
+
+    assertEquals(rows.length, 1);
+    assertEquals(rows[0].type, "limited");
+    assertEquals(rows[0].employer, "");
+  });
+
+  it("save allocates distinct _ids for repeated inserts", async () => {
+    await repository.save("public", "ID-A");
+    await repository.save("public", "ID-B");
+
+    const rows = await db.connection.query<Row>(sql`
+      SELECT _id, employer
+      FROM honor.tracking
+      WHERE employer IN ('ID-A', 'ID-B')
+      ORDER BY _id
+    `);
+
+    assertEquals(rows.length, 2);
+    assertEquals(rows[0]._id !== rows[1]._id, true);
+  });
+});

--- a/api/src/pdc/services/honor/providers/HonorRepositoryProvider.integration.spec.ts
+++ b/api/src/pdc/services/honor/providers/HonorRepositoryProvider.integration.spec.ts
@@ -69,4 +69,36 @@ describe("HonorRepositoryProvider", () => {
     assertEquals(rows.length, 2);
     assertEquals(rows[0]._id !== rows[1]._id, true);
   });
+
+  it("stats returns empty datasets when no rows match", async () => {
+    await db.connection.query(sql`TRUNCATE honor.tracking RESTART IDENTITY`);
+
+    const result = await repository.stats({});
+
+    assertEquals(result.labels, []);
+    assertEquals(result.count, { total: 0, public: 0, limited: 0 });
+    assertEquals(result.datasets.length, 2);
+    assertEquals(result.datasets[0].label, "Public");
+    assertEquals(result.datasets[0].data, []);
+    assertEquals(result.datasets[1].label, "Limited");
+    assertEquals(result.datasets[1].data, []);
+  });
+
+  it("stats buckets rows per created_at day and per type", async () => {
+    await db.connection.query(sql`TRUNCATE honor.tracking RESTART IDENTITY`);
+    await db.connection.query(sql`
+      INSERT INTO honor.tracking (created_at, type, employer) VALUES
+        ('2024-01-01T08:00:00Z', 'public',  'A'),
+        ('2024-01-01T09:00:00Z', 'public',  'B'),
+        ('2024-01-01T10:00:00Z', 'limited', 'C'),
+        ('2024-01-02T08:00:00Z', 'limited', 'D')
+    `);
+
+    const result = await repository.stats({});
+
+    assertEquals(result.labels, ["2024-01-01", "2024-01-02"]);
+    assertEquals(result.datasets[0].data, [2, 0]);
+    assertEquals(result.datasets[1].data, [1, 1]);
+    assertEquals(result.count, { total: 4, public: 2, limited: 2 });
+  });
 });

--- a/api/src/pdc/services/honor/providers/HonorRepositoryProvider.ts
+++ b/api/src/pdc/services/honor/providers/HonorRepositoryProvider.ts
@@ -1,5 +1,6 @@
 import { provider } from "@/ilos/common/index.ts";
-import { LegacyPostgresConnection } from "@/ilos/connection-postgres/index.ts";
+import { DenoPostgresConnection } from "@/ilos/connection-postgres/index.ts";
+import sql, { raw } from "@/lib/pg/sql.ts";
 
 import {
   DataSetInterface,
@@ -34,34 +35,29 @@ export abstract class HonorRepositoryInterfaceResolver implements HonorRepositor
 export class HonorRepositoryProvider implements HonorRepositoryInterface {
   private readonly table = "honor.tracking";
 
-  constructor(private pg: LegacyPostgresConnection) {}
+  constructor(protected pgConnection: DenoPostgresConnection) {}
 
-  async stats(params: StatsParamsInterface): Promise<StatsResultInterface> {
+  async stats(_params: StatsParamsInterface): Promise<StatsResultInterface> {
     // substring from 11 for days
     // substring from 8 for months
     // TODO switch from days to months when we have enough data (starts 10/2020)
-    const response: { rowCount: number; rows: StatsResponseRow[] } = await this
-      .pg.getClient().query({
-        text: `
-        SELECT
-          to_char(journey_start_datetime::date, 'yyyy-mm-dd') as day,
-          type,
-          SUM(1)::int as total
-        FROM ${this.table}
-        GROUP BY day, type
-        ORDER BY day, type
-      `,
-        values: [params.tz || "Europe/Paris"],
-      });
+    const rows = await this.pgConnection.query<StatsResponseRow>(sql`
+      SELECT
+        to_char(journey_start_datetime::date, 'yyyy-mm-dd') as day,
+        type,
+        SUM(1)::int as total
+      FROM ${raw(this.table)}
+      GROUP BY day, type
+      ORDER BY day, type
+    `);
 
-    return this.statsConvert(response.rowCount ? response.rows : []);
+    return this.statsConvert(rows);
   }
 
   async save(type: string, employer: string): Promise<void> {
-    await this.pg.getClient().query({
-      text: "INSERT INTO honor.tracking (type, employer) VALUES ($1, $2);",
-      values: [type, employer],
-    });
+    await this.pgConnection.query(sql`
+      INSERT INTO ${raw(this.table)} (type, employer) VALUES (${type}, ${employer})
+    `);
   }
 
   /**

--- a/api/src/pdc/services/honor/providers/HonorRepositoryProvider.ts
+++ b/api/src/pdc/services/honor/providers/HonorRepositoryProvider.ts
@@ -9,8 +9,8 @@ import {
 } from "../contracts/stats.contract.ts";
 
 type StatsResponseRow = {
-  day: string | null;
-  type: "public" | "limited" | null;
+  day: string;
+  type: "public" | "limited";
   total: number;
 };
 
@@ -38,12 +38,10 @@ export class HonorRepositoryProvider implements HonorRepositoryInterface {
   constructor(protected pgConnection: DenoPostgresConnection) {}
 
   async stats(_params: StatsParamsInterface): Promise<StatsResultInterface> {
-    // substring from 11 for days
-    // substring from 8 for months
     // TODO switch from days to months when we have enough data (starts 10/2020)
     const rows = await this.pgConnection.query<StatsResponseRow>(sql`
       SELECT
-        to_char(journey_start_datetime::date, 'yyyy-mm-dd') as day,
+        to_char(created_at::date, 'yyyy-mm-dd') as day,
         type,
         SUM(1)::int as total
       FROM ${raw(this.table)}


### PR DESCRIPTION
Refs #3179

## Description

Next slice of the LegacyPostgresConnection migration: swap `HonorRepositoryProvider` over to `DenoPostgresConnection`, plus a follow-up commit that repairs a long-standing bug in `honor.stats` and tightens the surrounding TS types so the honor service is now type-clean.

### `refactor(api): migrate HonorRepositoryProvider to DenoPostgresConnection`

- Replace `{ text, values }` query objects with `sql` tagged templates and `raw(this.table)`.
- Drop the dead `values: [params.tz]` argument from `stats()` — the SQL text never referenced `$1`.
- Rename the constructor field from `pg` to `pgConnection` for consistency with previously migrated repositories.
- Add `HonorRepositoryProvider.integration.spec.ts` covering `save()` round-trip, the `limited` type with an empty employer string, and distinct sequence-driven `_id`s on repeated inserts.

### `fix(api): repair honor.stats query and tighten honor TS types`

- `stats()` referenced `honor.tracking.journey_start_datetime`, a column that has never existed on the table (schema: `_id, created_at, type, employer`). The endpoint would have thrown at runtime against the migrated connection. Bucket by `created_at::date` instead — the only timestamp the table records.
- `StatsResponseRow` declared `day` and `type` as nullable, but both columns are `NOT NULL` in the schema, so `statsConvert` was tripping TS2345 / TS2538 on every iteration. Drop the `| null` arms.
- `SaveAction` / `StatsAction` `handle` methods needed the `override` modifier (TS4114). `SaveAction`'s `employer` was `string | null` in the contract but `string` in the schema (optional, not nullable) and `string` in `HonorRepositoryProvider.save()`; align the contract to `string?` and coalesce to `""` at the action boundary so we never `INSERT null` into the `NOT NULL DEFAULT ''` column.
- Add two `stats()` integration specs: empty-table baseline and multi-day / multi-type bucketing.

## Checklist

- [x] j'ai suivi les guidelines du "clean code"
- [ ] j'ai mis à jour la documentation technique dans `/api/specs` (n/a — internal repository wiring only)
- [x] ajout ou mise à jour des tests unitaires (n/a — integration tests added)
- [x] ajout ou mise à jour des tests d'intégration

## Test plan

- [x] `just dc` stack up
- [x] `APP_POSTGRES_URL=... APP_POSTGRES_INSECURE=true deno test -A --no-check --trace-leaks --unsafely-ignore-certificate-errors 'src/pdc/services/honor/**/*.integration.spec.ts'` → 5 / 5 pass
- [x] `deno check --allow-import src/pdc/services/honor` → 0 errors in honor source files (transitive deps unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)