### PR TITLE
refactor(api): migrate apdf service to DenoPostgresConnection

### DIFF
--- a/api/src/ilos/connection-postgres/DenoPostgresConnection.ts
+++ b/api/src/ilos/connection-postgres/DenoPostgresConnection.ts
@@ -5,6 +5,11 @@ import { logger } from "../../lib/logger/index.ts";
 import sql, { Sql } from "../../lib/pg/sql.ts";
 import { ConnectionInterface, DestroyHookInterface, InitHookInterface } from "../common/index.ts";
 
+export type Cursor<TResult> = {
+  read: (rowCount?: number) => AsyncGenerator<TResult[]>;
+  [Symbol.asyncDispose]: () => Promise<void>;
+};
+
 export class DenoPostgresConnection
   implements ConnectionInterface<Pool>, InitHookInterface, DestroyHookInterface, AsyncDisposable {
   #id = DenoPostgresConnection.id("pool");
@@ -229,10 +234,7 @@ export class DenoPostgresConnection
     return this.#wrap<TResult>(sql, "object", false);
   }
 
-  async cursor<TResult>(sql: Sql): Promise<{
-    read: (rowCount?: number) => AsyncGenerator<TResult[]>;
-    [Symbol.asyncDispose]: () => Promise<void>;
-  }> {
+  async cursor<TResult>(sql: Sql): Promise<Cursor<TResult>> {
     // keep client alive for the lifetime of the cursor object
     let disposed = false;
     const client = await this.#pool!.connect();

--- a/api/src/ilos/connection-postgres/index.ts
+++ b/api/src/ilos/connection-postgres/index.ts
@@ -1,3 +1,3 @@
 export type { PoolClient } from "dep:pg";
-export { DenoPostgresConnection } from "./DenoPostgresConnection.ts";
+export { type Cursor, DenoPostgresConnection } from "./DenoPostgresConnection.ts";
 export { LegacyPostgresConnection } from "./LegacyPostgresConnection.ts";

--- a/api/src/pdc/services/apdf/interfaces/APDFRepositoryProviderInterface.ts
+++ b/api/src/pdc/services/apdf/interfaces/APDFRepositoryProviderInterface.ts
@@ -1,4 +1,4 @@
-import { NativeCursor } from "@/ilos/connection-postgres/LegacyPostgresConnection.ts";
+import { Cursor } from "@/ilos/connection-postgres/index.ts";
 import { UnboundedSlices } from "../../policy/contracts/common/interfaces/Slices.ts";
 import { PolicyStatsInterface } from "../contracts/interfaces/PolicySliceStatInterface.ts";
 import { APDFTripInterface } from "./APDFTripInterface.ts";
@@ -27,7 +27,7 @@ export interface DataRepositoryInterface {
   ): Promise<PolicyStatsInterface>;
   getPolicyCursor(
     params: CampaignSearchParamsInterface,
-  ): Promise<NativeCursor<APDFTripInterface>>;
+  ): Promise<Cursor<APDFTripInterface>>;
 }
 
 export abstract class DataRepositoryProviderInterfaceResolver implements DataRepositoryInterface {
@@ -48,7 +48,7 @@ export abstract class DataRepositoryProviderInterfaceResolver implements DataRep
 
   public async getPolicyCursor(
     params: CampaignSearchParamsInterface,
-  ): Promise<NativeCursor<APDFTripInterface>> {
+  ): Promise<Cursor<APDFTripInterface>> {
     throw new Error("Not implemented");
   }
 }

--- a/api/src/pdc/services/apdf/providers/DataRepositoryProvider.integration.spec.ts
+++ b/api/src/pdc/services/apdf/providers/DataRepositoryProvider.integration.spec.ts
@@ -1,0 +1,67 @@
+import { assertEquals } from "dep:assert";
+import { afterAll, beforeAll, describe, it } from "dep:testing-bdd";
+
+import { DenoDbContext, makeDenoDbBeforeAfter } from "@/pdc/providers/test/dbMacro.ts";
+
+import { APDFTripInterface } from "../interfaces/APDFTripInterface.ts";
+import { DataRepositoryProvider } from "./DataRepositoryProvider.ts";
+
+describe("DataRepositoryProvider", () => {
+  let db: DenoDbContext;
+  let repository: DataRepositoryProvider;
+  const { before, after } = makeDenoDbBeforeAfter();
+
+  const params = {
+    campaign_id: 9_999,
+    operator_id: 9_999,
+    start_date: new Date("2099-01-01T00:00:00Z"),
+    end_date: new Date("2099-02-01T00:00:00Z"),
+  };
+
+  beforeAll(async () => {
+    db = await before();
+    repository = new DataRepositoryProvider(db.connection);
+  });
+
+  afterAll(async () => {
+    await after(db);
+  });
+
+  it("getPolicyActiveOperators returns an empty list when no carpools match the campaign window", async () => {
+    const result = await repository.getPolicyActiveOperators(
+      params.campaign_id,
+      params.start_date,
+      params.end_date,
+    );
+    assertEquals(result, []);
+  });
+
+  it("getPolicyStats returns a zero total_count when no carpools match", async () => {
+    const result = await repository.getPolicyStats(params, []);
+    // count(*) over empty returns 0; sum() over empty returns null
+    // (pre-existing behaviour preserved by the migration).
+    assertEquals(result.total_count, 0);
+    assertEquals(result.subsidized_count, 0);
+    assertEquals(result.slices, []);
+  });
+
+  it("getPolicyStats compiles the slice filter clauses without crashing", async () => {
+    const slices = [
+      { start: 0, end: 5_000 },
+      { start: 5_000, end: 15_000 },
+      { start: 15_000 },
+    ];
+    const result = await repository.getPolicyStats(params, slices);
+    assertEquals(result.total_count, 0);
+    assertEquals(result.subsidized_count, 0);
+  });
+
+  it("getPolicyCursor opens a cursor that yields no batches when no carpools match", async () => {
+    await using cursor = await repository.getPolicyCursor(params);
+    const batches: APDFTripInterface[][] = [];
+    for await (const rows of cursor.read(50)) {
+      batches.push(rows);
+    }
+    assertEquals(batches, []);
+  });
+});

--- a/api/src/pdc/services/apdf/providers/DataRepositoryProvider.ts
+++ b/api/src/pdc/services/apdf/providers/DataRepositoryProvider.ts
@@ -1,7 +1,5 @@
-/* eslint-disable max-len */
 import { provider } from "@/ilos/common/index.ts";
-import { LegacyPostgresConnection } from "@/ilos/connection-postgres/index.ts";
-import { NativeCursor } from "@/ilos/connection-postgres/LegacyPostgresConnection.ts";
+import { Cursor, DenoPostgresConnection } from "@/ilos/connection-postgres/index.ts";
 import { set } from "@/lib/object/index.ts";
 import sql, { raw } from "@/lib/pg/sql.ts";
 import { UnboundedSlices } from "../../policy/contracts/common/interfaces/Slices.ts";
@@ -13,6 +11,13 @@ import {
 } from "../interfaces/APDFRepositoryProviderInterface.ts";
 import { APDFTripInterface } from "../interfaces/APDFTripInterface.ts";
 
+type PolicyStatsRow = {
+  total_count: number;
+  total_sum: number;
+  subsidized_count: number;
+  [slice_key: string]: number | string;
+};
+
 @provider({ identifier: DataRepositoryProviderInterfaceResolver })
 export class DataRepositoryProvider implements DataRepositoryInterface {
   protected readonly carpoolV2Table = "carpool_v2.carpools";
@@ -22,7 +27,7 @@ export class DataRepositoryProvider implements DataRepositoryInterface {
   protected readonly geoPerimetersTable = "geo.perimeters";
   protected readonly operatorsTable = "operator.operators";
 
-  constructor(public connection: LegacyPostgresConnection) {
+  constructor(public pgConnection: DenoPostgresConnection) {
   }
 
   /**
@@ -34,7 +39,7 @@ export class DataRepositoryProvider implements DataRepositoryInterface {
     start_date: Date,
     end_date: Date,
   ): Promise<number[]> {
-    const query = sql`
+    const rows = await this.pgConnection.query<{ operator_id: number }>(sql`
       SELECT cc.operator_id
       FROM ${raw(this.policyIncentivesTable)} pi
       JOIN ${raw(this.carpoolV2Table)} cc
@@ -51,11 +56,9 @@ export class DataRepositoryProvider implements DataRepositoryInterface {
         AND cs.anomaly_status = 'passed'
       GROUP BY cc.operator_id
       ORDER BY cc.operator_id
-    `;
+    `);
 
-    const result = await this.connection.getClient().query(query);
-
-    return result.rowCount ? result.rows.map((r) => r.operator_id) : [];
+    return rows.map((r) => r.operator_id);
   }
 
   /**
@@ -67,7 +70,9 @@ export class DataRepositoryProvider implements DataRepositoryInterface {
   ): Promise<PolicyStatsInterface> {
     const { start_date, end_date, operator_id, campaign_id } = params;
 
-    // prepare slice filters
+    // Build slice filter expressions. start/end come from the campaign
+    // configuration and are validated as numbers before reaching here, so
+    // inlining them is safe.
     const sliceFilters: string = slices
       .map(({ start, end }, i: number) => {
         const f = `filter (where distance >= ${start}${end ? ` and distance < ${end}` : ""})`;
@@ -83,42 +88,37 @@ export class DataRepositoryProvider implements DataRepositoryInterface {
 
     // select all trips with a positive incentive calculated by us for a given campaign
     // calculate a global count and incentive sum as well as details for each slice
-    const query = {
-      text: `
-        with trips as (
-          select
-              cc.uuid,
-              cc.distance,
-              coalesce(pi.amount, 0) as amount
-          from ${this.policyIncentivesTable} pi
-          join ${this.carpoolV2Table} cc
-            on  cc.operator_id = pi.operator_id
-            and cc.operator_journey_id = pi.operator_journey_id
-          join ${this.carpoolV2StatusTable} cs on cs.carpool_id = cc._id
-        where
-                cc.start_datetime >= $1
-            and cc.start_datetime  < $2
-            and cs.acquisition_status in ('processed', 'canceled', 'updated')
-            and cs.fraud_status       in ('passed', 'failed')
-            and cc.operator_id = $3
-            and pi.policy_id = $4
-            and pi.status = 'validated'
-            and pi.amount >= 0
-          )
+    const rows = await this.pgConnection.query<PolicyStatsRow>(sql`
+      with trips as (
         select
-          count(uuid)::int as total_count,
-          sum(amount)::int as total_sum,
-          (count(uuid) filter (where amount > 0))::int as subsidized_count
-          ${sliceFilters.length ? `, ${sliceFilters}` : ""}
-        from trips
-        `,
-      values: [start_date, end_date, operator_id, campaign_id],
-    };
-
-    const result = await this.connection.getClient().query(query);
+            cc.uuid,
+            cc.distance,
+            coalesce(pi.amount, 0) as amount
+        from ${raw(this.policyIncentivesTable)} pi
+        join ${raw(this.carpoolV2Table)} cc
+          on  cc.operator_id = pi.operator_id
+          and cc.operator_journey_id = pi.operator_journey_id
+        join ${raw(this.carpoolV2StatusTable)} cs on cs.carpool_id = cc._id
+      where
+              cc.start_datetime >= ${start_date}
+          and cc.start_datetime  < ${end_date}
+          and cs.acquisition_status in ('processed', 'canceled', 'updated')
+          and cs.fraud_status       in ('passed', 'failed')
+          and cc.operator_id = ${operator_id}
+          and pi.policy_id = ${campaign_id}
+          and pi.status = 'validated'
+          and pi.amount >= 0
+        )
+      select
+        count(uuid)::int as total_count,
+        sum(amount)::int as total_sum,
+        (count(uuid) filter (where amount > 0))::int as subsidized_count
+        ${raw(sliceFilters.length ? `, ${sliceFilters}` : "")}
+      from trips
+    `);
 
     // return null results on missing data
-    if (!result.rowCount) {
+    if (!rows.length) {
       return {
         total_count: 0,
         total_sum: 0,
@@ -128,7 +128,7 @@ export class DataRepositoryProvider implements DataRepositoryInterface {
     }
 
     // rearrange the return object
-    const row = result.rows[0];
+    const row = rows[0];
     return Object.keys(row).reduce(
       (p, k) => {
         if (!k.includes("slice_")) return p;
@@ -159,10 +159,10 @@ export class DataRepositoryProvider implements DataRepositoryInterface {
   /**
    * List all carpools for CSV APDF export using a cursor
    */
-  public async getPolicyCursor(params: CampaignSearchParamsInterface): Promise<NativeCursor<APDFTripInterface>> {
+  public async getPolicyCursor(params: CampaignSearchParamsInterface): Promise<Cursor<APDFTripInterface>> {
     const { start_date, end_date, operator_id, campaign_id } = params;
 
-    const queryText = `
+    return this.pgConnection.cursor<APDFTripInterface>(sql`
       -- list in api/services/trip/src/providers/excel/TripsWorksheetWriter.ts
       select
         cc.uuid as rpc_journey_id,
@@ -190,32 +190,25 @@ export class DataRepositoryProvider implements DataRepositoryInterface {
         oo.name as operator,
         cc.operator_class
 
-      from ${this.policyIncentivesTable} pi
-      join ${this.carpoolV2Table} cc on cc.operator_id = pi.operator_id and cc.operator_journey_id = pi.operator_journey_id
-      join ${this.carpoolV2StatusTable} cs on cc._id = cs.carpool_id
-      join ${this.carpoolV2GeoTable} cg on cc._id = cg.carpool_id
-      left join ${this.geoPerimetersTable} gps on cg.start_geo_code = gps.arr and gps.year = geo.get_latest_millesime_or(extract(year from cc.start_datetime)::smallint)
-      left join ${this.geoPerimetersTable} gpe on cg.end_geo_code = gpe.arr and gpe.year = geo.get_latest_millesime_or(extract(year from cc.end_datetime)::smallint)
-      left join ${this.operatorsTable} oo on oo._id = cc.operator_id
+      from ${raw(this.policyIncentivesTable)} pi
+      join ${raw(this.carpoolV2Table)} cc on cc.operator_id = pi.operator_id and cc.operator_journey_id = pi.operator_journey_id
+      join ${raw(this.carpoolV2StatusTable)} cs on cc._id = cs.carpool_id
+      join ${raw(this.carpoolV2GeoTable)} cg on cc._id = cg.carpool_id
+      left join ${raw(this.geoPerimetersTable)} gps on cg.start_geo_code = gps.arr and gps.year = geo.get_latest_millesime_or(extract(year from cc.start_datetime)::smallint)
+      left join ${raw(this.geoPerimetersTable)} gpe on cg.end_geo_code = gpe.arr and gpe.year = geo.get_latest_millesime_or(extract(year from cc.end_datetime)::smallint)
+      left join ${raw(this.operatorsTable)} oo on oo._id = cc.operator_id
 
       where
-            cc.start_datetime >= $1
-        and cc.start_datetime  < $2
+            cc.start_datetime >= ${start_date}
+        and cc.start_datetime  < ${end_date}
         and cs.acquisition_status in ('processed', 'canceled', 'updated')
         and cs.fraud_status in ('passed', 'failed')
-        and cc.operator_id = $3
-        and pi.policy_id = $4
+        and cc.operator_id = ${operator_id}
+        and pi.policy_id = ${campaign_id}
         and pi.status = 'validated'
         and pi.amount >= 0
 
       order by cc.start_datetime
-    `;
-
-    return this.connection.getNativeCursor(queryText, [
-      start_date,
-      end_date,
-      operator_id,
-      campaign_id,
-    ]);
+    `);
   }
 }

--- a/api/src/pdc/services/apdf/providers/excel/BuildExcel.ts
+++ b/api/src/pdc/services/apdf/providers/excel/BuildExcel.ts
@@ -1,6 +1,5 @@
 import { defaultTimezone } from "@/config/time.ts";
 import { KernelInterfaceResolver, provider } from "@/ilos/common/index.ts";
-import { NativeCursor } from "@/ilos/connection-postgres/LegacyPostgresConnection.ts";
 import { logger } from "@/lib/logger/index.ts";
 import { APDFNameProvider } from "@/pdc/providers/storage/index.ts";
 import { APDFTripInterface } from "@/pdc/services/apdf/interfaces/APDFTripInterface.ts";
@@ -80,10 +79,9 @@ export class BuildExcel {
     wkw: excel.stream.xlsx.WorkbookWriter,
     params: CampaignSearchParamsInterface,
   ): Promise<void> {
-    let cursor: NativeCursor<APDFTripInterface> | undefined = undefined;
     try {
       const config = await this.getConfig(params.campaign_id);
-      cursor = await this.apdfRepoProvider.getPolicyCursor(params);
+      await using cursor = await this.apdfRepoProvider.getPolicyCursor(params);
       await this.TripsWsWriter.call(cursor, config, wkw);
     } catch (e) {
       logger.error(`[apdf:buildExcel] Error while writing trips. Campaign: ${params.campaign_id}`);
@@ -91,8 +89,6 @@ export class BuildExcel {
         logger.error(e.message);
         logger.error(e.stack);
       }
-    } finally {
-      cursor && await cursor.release();
     }
   }
 

--- a/api/src/pdc/services/apdf/providers/excel/BuildExcel.unit.spec.ts
+++ b/api/src/pdc/services/apdf/providers/excel/BuildExcel.unit.spec.ts
@@ -1,7 +1,7 @@
 import { assertEquals } from "dep:assert";
 import { afterEach, beforeEach, describe, it } from "dep:testing-bdd";
 import { KernelInterfaceResolver } from "@/ilos/common/index.ts";
-import { NativeCursor } from "@/ilos/connection-postgres/LegacyPostgresConnection.ts";
+import { Cursor } from "@/ilos/connection-postgres/index.ts";
 import { APDFNameProvider } from "@/pdc/providers/storage/index.ts";
 import excel from "dep:excel";
 import sinon from "dep:sinon";
@@ -63,11 +63,11 @@ describe("BuildExcel", () => {
     createSlicesSheetToWorkbook,
     nameProvider,
   );
-  const cursorCallback: NativeCursor<unknown[]> = {
-    read: async (_rowCount?: number) => {
-      return [];
+  const cursorCallback: Cursor<unknown> = {
+    read: async function* (_rowCount?: number) {
+      // empty cursor — yields no batches
     },
-    release: async () => {},
+    [Symbol.asyncDispose]: async () => {},
   };
 
   beforeEach(() => {

--- a/api/src/pdc/services/apdf/providers/excel/TripsWorksheetWriter.ts
+++ b/api/src/pdc/services/apdf/providers/excel/TripsWorksheetWriter.ts
@@ -1,5 +1,5 @@
 import { provider } from "@/ilos/common/index.ts";
-import { NativeCursor } from "@/ilos/connection-postgres/LegacyPostgresConnection.ts";
+import { Cursor } from "@/ilos/connection-postgres/index.ts";
 import { logger } from "@/lib/logger/index.ts";
 import { ExcelCampaignConfig } from "@/pdc/services/apdf/interfaces/ExcelTypes.ts";
 import excel from "dep:excel";
@@ -35,7 +35,7 @@ export class TripsWorksheetWriter extends AbstractWorksheetWriter {
   ].map((header) => ({ header, key: header }));
 
   async call(
-    cursor: NativeCursor<APDFTripInterface>,
+    cursor: Cursor<APDFTripInterface>,
     config: ExcelCampaignConfig,
     workbookWriter: excel.stream.xlsx.WorkbookWriter,
   ): Promise<void> {
@@ -85,10 +85,8 @@ export class TripsWorksheetWriter extends AbstractWorksheetWriter {
 
     const b1 = new Date();
 
-    let rows: APDFTripInterface[] = await cursor.read(this.CURSOR_BATCH_SIZE);
-    while (rows.length > 0) {
+    for await (const rows of cursor.read(this.CURSOR_BATCH_SIZE)) {
       rows.forEach((t) => t && worksheet.addRow(normalize(t, config)).commit());
-      rows = await cursor.read(this.CURSOR_BATCH_SIZE);
     }
 
     const b2 = new Date();


### PR DESCRIPTION
Refs #3179

## Description

Next slice of the LegacyPostgresConnection migration: swap the apdf service over to DenoPostgresConnection, including the cursor path used by the Excel export.

### `refactor(api): migrate apdf service to DenoPostgresConnection`

- `DataRepositoryProvider`: constructor takes `DenoPostgresConnection`, rename the field to `pgConnection`. Both aggregate queries (`getPolicyActiveOperators`, `getPolicyStats`) move to `sql` tagged templates and `pgConnection.query`. The dynamic slice-filter expression built from validated numeric slice boundaries is inlined via `raw()`. `getPolicyCursor` moves from `connection.getNativeCursor(text, values)` to `pgConnection.cursor(sql`` `` `)`, which returns an `AsyncDisposable` cursor whose `read()` is an `AsyncGenerator` (matches the pattern already used by `export.CarpoolRepository`).
- Export a reusable `Cursor<T>` type alias from `connection-postgres` so callers can name the cursor return type without restating the shape.
- `TripsWorksheetWriter` consumes the new cursor with `for await (const rows of cursor.read(N))` instead of polling `cursor.read(N)` in a `while` loop.
- `BuildExcel.writeTrips` uses `await using cursor = ...` instead of a `try / finally` release pair, so disposal stays tied to scope.
- `BuildExcel.unit.spec` updates the cursor mock to an async generator `read` and a `[Symbol.asyncDispose]` (matching the new `Cursor<T>`).

Adds an integration spec for `DataRepositoryProvider` that exercises the three query paths against the seeded test database with a no-match campaign window: `getPolicyActiveOperators` returns `[]`, `getPolicyStats` returns `total_count = 0` and `subsidized_count = 0` (sum() over empty rows stays null, a pre-existing semantic preserved by the migration), `getPolicyStats` with three slices compiles without crashing, and `getPolicyCursor` opens a cursor whose async generator yields no batches.

## Checklist

- [x] j'ai suivi les guidelines du "clean code"
- [ ] j'ai mis à jour la documentation technique dans `/api/specs` (n/a - internal repository wiring only)
- [x] ajout ou mise à jour des tests unitaires (BuildExcel cursor mock)
- [x] ajout ou mise à jour des tests d'intégration

## Test plan

- [x] `just dc` stack up
- [x] `deno test ... 'src/pdc/services/apdf/**/*.unit.spec.ts'` -> 13 / 13 pass (BuildExcel + CheckCampaign + getCampaignOperators + wrapSlicesHelper)
- [x] `deno test ... 'src/pdc/services/apdf/**/*.integration.spec.ts'` -> 4 / 4 pass (DataRepositoryProvider)
- [x] `deno check --allow-import src/pdc/services/apdf` -> 0 new errors introduced by this PR (pre-existing errors in wrapSlicesHelper, TripsWorksheetWriter:74, createGetCampaignResult.helper unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)