### PR TITLE
fix(sqlmesh): export AOM -- préférer l'année la plus récente avec un code AOM non nul

### DIFF
--- a/sqlmesh/models/3_refined_zone/export/export_carpool_list.sql
+++ b/sqlmesh/models/3_refined_zone/export/export_carpool_list.sql
@@ -24,7 +24,7 @@ WITH latest_perimeters AS (
       ELSE 2
     END AS precision
   FROM trusted_zone.perimeters
-  ORDER BY arr, year DESC
+  ORDER BY arr, (aom IS NULL) ASC, year DESC
 )
 
 SELECT


### PR DESCRIPTION
## Problème

Les exports filtrés par AOM (ex. `{"aom":["256900994"]}`) ne retournaient presque aucun trajet — 8 résultats au lieu de ~26 000 pour janvier 2026.

## Cause

Le CTE `latest_perimeters` dans `export_carpool_list.sql` utilise `ORDER BY arr, year DESC` pour récupérer les données les plus récentes par commune. Depuis l'ajout des données IGN/CEREMA 2025 dans `trusted_zone.perimeters`, la jointure CEREMA est partielle : les communes absentes du fichier `cerema_aom_2025` reçoivent `aom = NULL`. Comme 2025 est l'année la plus récente, ces lignes sont sélectionnées en priorité -- et le filtre `start_aom_code = '256900994'` échoue silencieusement (`NULL ≠ valeur`).

## Correctif

Une seule ligne modifiée dans le `ORDER BY` du CTE `latest_perimeters` :

```sql
-- avant
ORDER BY arr, year DESC

-- après
ORDER BY arr, (aom IS NULL) ASC, year DESC
```

`(aom IS NULL) ASC` place les lignes avec un code AOM renseigné avant celles avec `NULL`, pour la même commune. On choisit ainsi l'année la plus récente **avec un code AOM valide**, avec repli sur l'année la plus récente si aucune année n'a de code AOM.

## Validation

Requête de référence SYTRAL (via `geo.perimeters`, `year = 2024`) : ~26 000 trajets en janvier 2026. L'export doit retourner un résultat cohérent après ce correctif.

## Relation avec le PR connexe

Le PR `fix/perimeters-aom-2025` corrige la cause racine (données `NULL` dans `trusted_zone.perimeters`). Ce PR est un filet de sécurité défensif au niveau de la vue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)