### PR TITLE
fix(sqlmesh): périmètres 2025 -- repli sur 2024 quand le code AOM CEREMA est absent

### DIFF
--- a/sqlmesh/models/2_trusted_zone/geo/perimeters.sql
+++ b/sqlmesh/models/2_trusted_zone/geo/perimeters.sql
@@ -34,16 +34,16 @@ WITH old_perimeters AS (
   LEFT JOIN raw_zone.old_perimeters_centroid c ON a.year = c.year AND a.arr = c.arr
 ),
 new_com AS (
-  SELECT 
+  SELECT
     2025 AS year,
-    a.com AS arr, 
-    a.l_com AS l_arr, 
-    a.com, 
+    a.com AS arr,
+    a.l_com AS l_arr,
+    a.com,
     a.l_com,
     a.epci,
     b.l_epci,
-    e.aom,
-    e.l_aom,
+    COALESCE(e.aom,   prev.aom)   AS aom,
+    COALESCE(e.l_aom, prev.l_aom) AS l_aom,
     a.dep,
     c.l_dep,
     a.reg,
@@ -60,8 +60,9 @@ new_com AS (
   LEFT JOIN raw_zone.ign_aecarto_dep_2025 c ON a.dep = c.dep
   LEFT JOIN raw_zone.ign_aecarto_reg_2025 d ON a.reg = d.reg
   LEFT JOIN raw_zone.cerema_aom_2025 e ON a.com = e.com
+  LEFT JOIN raw_zone.old_perimeters_simple prev ON a.com = prev.arr AND prev.year = 2024
   LEFT JOIN raw_zone.ign_ae_com_2025 f ON a.com = f.com
-  LEFT JOIN raw_zone.ign_aecentroid_com_2025 g ON a.com = g.com 
+  LEFT JOIN raw_zone.ign_aecentroid_com_2025 g ON a.com = g.com
 ),
 new_arr AS (
   SELECT 


### PR DESCRIPTION
## Problème

Le modèle `trusted_zone.perimeters` construit les données 2025 à partir des sources IGN et CEREMA. La jointure CEREMA est une `LEFT JOIN` sur le code commune :

```sql
LEFT JOIN raw_zone.cerema_aom_2025 e ON a.com = e.com
```

Lorsqu'une commune n'est pas couverte par le fichier CEREMA 2025, les champs `aom` et `l_aom` sont `NULL` dans `trusted_zone.perimeters` pour l'année 2025. Tous les modèles consommant ces périmètres pour filtrer ou agréger par AOM en sont affectés.

## Correctif

Ajout d'une jointure de repli sur `raw_zone.old_perimeters_simple` (données 2024) dans le CTE `new_com`, avec `COALESCE` :

```sql
COALESCE(e.aom,   prev.aom)   AS aom,
COALESCE(e.l_aom, prev.l_aom) AS l_aom,
...
LEFT JOIN raw_zone.old_perimeters_simple prev
  ON a.com = prev.arr AND prev.year = 2024
```

Si CEREMA 2025 fournit le code AOM, il est utilisé en priorité. Sinon, la valeur de l'année 2024 est héritée.

## Impact

Après merge, `sqlmesh plan` + `sqlmesh run` sur `trusted_zone.perimeters` puis `refined_zone.export_carpool_list` restoreront des codes AOM complets pour 2025.

## Ordre de merge recommandé

Ce PR corrige la cause racine. Le PR #3190 (`fix/export-aom-filter`) corrige le symptôme au niveau de la vue -- les deux sont indépendants, mais ce PR rend l'autre défensif plutôt que nécessaire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)