### PR TITLE
refactor(api): migrate policy service to DenoPostgresConnection

### DIFF
--- a/api/src/pdc/services/policy/providers/IncentiveRepositoryProvider.integration.spec.ts
+++ b/api/src/pdc/services/policy/providers/IncentiveRepositoryProvider.integration.spec.ts
@@ -1,14 +1,15 @@
 import { assertEquals } from "dep:assert";
 import { afterAll, beforeAll, describe, it } from "dep:testing-bdd";
-import { LegacyDbContext, makeLegacyDbBeforeAfter } from "@/pdc/providers/test/index.ts";
+import sql, { raw } from "@/lib/pg/sql.ts";
+import { DenoDbContext, makeDenoDbBeforeAfter } from "@/pdc/providers/test/index.ts";
 
 import { IncentiveStateEnum, IncentiveStatusEnum } from "../interfaces/index.ts";
 import { IncentiveRepositoryProvider } from "./IncentiveRepositoryProvider.ts";
 
 describe("IncentiveRepositoryProvider", () => {
-  let db: LegacyDbContext;
+  let db: DenoDbContext;
   let repository: IncentiveRepositoryProvider | undefined;
-  const { before, after } = makeLegacyDbBeforeAfter();
+  const { before, after } = makeDenoDbBeforeAfter();
   beforeAll(async () => {
     db = await before();
     repository = new IncentiveRepositoryProvider(
@@ -70,17 +71,17 @@ describe("IncentiveRepositoryProvider", () => {
 
     await repository?.createOrUpdateMany(incentives);
 
-    const incentiveResults = await db.connection.getClient().query({
-      text: `SELECT * FROM ${repository?.incentivesTable} WHERE policy_id = $1`,
-      values: [0],
-    });
-    assertEquals(incentiveResults.rowCount, 2);
+    type IncentiveRow = { operator_journey_id: string; result: number; state: string };
+    const incentiveResults = await db.connection.query<IncentiveRow>(sql`
+      SELECT * FROM ${raw(repository!.incentivesTable)} WHERE policy_id = ${0}
+    `);
+    assertEquals(incentiveResults.length, 2);
     assertEquals(
-      incentiveResults.rows.find((i) => i.operator_journey_id === "operator_journey_id-1").result,
+      incentiveResults.find((i) => i.operator_journey_id === "operator_journey_id-1")?.result,
       100,
     );
     assertEquals(
-      incentiveResults.rows.find((i) => i.operator_journey_id === "operator_journey_id-2").result,
+      incentiveResults.find((i) => i.operator_journey_id === "operator_journey_id-2")?.result,
       200,
     );
   });
@@ -137,47 +138,46 @@ describe("IncentiveRepositoryProvider", () => {
 
     await repository?.createOrUpdateMany(incentives);
 
-    const incentiveResults = await db.connection.getClient().query({
-      text: `SELECT * FROM ${repository?.incentivesTable} WHERE policy_id = $1`,
-      values: [0],
-    });
+    type IncentiveRow = { operator_journey_id: string; result: number; state: string };
+    const incentiveResults = await db.connection.query<IncentiveRow>(sql`
+      SELECT * FROM ${raw(repository!.incentivesTable)} WHERE policy_id = ${0}
+    `);
 
-    assertEquals(incentiveResults.rowCount, 3);
+    assertEquals(incentiveResults.length, 3);
     assertEquals(
-      incentiveResults.rows.find((i) => i.operator_journey_id === "operator_journey_id-1").result,
+      incentiveResults.find((i) => i.operator_journey_id === "operator_journey_id-1")?.result,
       0,
     );
     assertEquals(
-      incentiveResults.rows.find((i) => i.operator_journey_id === "operator_journey_id-1").state,
+      incentiveResults.find((i) => i.operator_journey_id === "operator_journey_id-1")?.state,
       "null",
     );
     assertEquals(
-      incentiveResults.rows.find((i) => i.operator_journey_id === "operator_journey_id-2").result,
+      incentiveResults.find((i) => i.operator_journey_id === "operator_journey_id-2")?.result,
       500,
     );
     assertEquals(
-      incentiveResults.rows.find((i) => i.operator_journey_id === "operator_journey_id-3").result,
+      incentiveResults.find((i) => i.operator_journey_id === "operator_journey_id-3")?.result,
       100,
     );
   });
 
   it("Should update many incentives amount", async () => {
-    const incentives = await db.connection.getClient().query({
-      text: `SELECT * FROM ${repository?.incentivesTable} WHERE policy_id = $1`,
-      values: [0],
-    });
+    type IncentiveRow = { state: string };
+    const incentives = await db.connection.query<Record<string, unknown>>(sql`
+      SELECT * FROM ${raw(repository!.incentivesTable)} WHERE policy_id = ${0}
+    `);
 
-    const data = incentives.rows.map((i) => ({ ...i, statefulAmount: 0 }));
+    const data = incentives.map((i) => ({ ...i, statefulAmount: 0 }));
     await repository?.updateStatefulAmount(data as any);
 
-    const incentiveResults = await db.connection.getClient().query({
-      text: `SELECT * FROM ${repository?.incentivesTable} WHERE policy_id = $1`,
-      values: [0],
-    });
+    const incentiveResults = await db.connection.query<IncentiveRow>(sql`
+      SELECT * FROM ${raw(repository!.incentivesTable)} WHERE policy_id = ${0}
+    `);
 
-    assertEquals(incentiveResults.rowCount, 3);
+    assertEquals(incentiveResults.length, 3);
     assertEquals(
-      incentiveResults.rows.filter((i) => i.state === "null").length,
+      incentiveResults.filter((i) => i.state === "null").length,
       3,
     );
   });

--- a/api/src/pdc/services/policy/providers/IncentiveRepositoryProvider.ts
+++ b/api/src/pdc/services/policy/providers/IncentiveRepositoryProvider.ts
@@ -1,7 +1,7 @@
 import { provider } from "@/ilos/common/index.ts";
-import { LegacyPostgresConnection } from "@/ilos/connection-postgres/index.ts";
-
+import { DenoPostgresConnection } from "@/ilos/connection-postgres/index.ts";
 import { logger } from "@/lib/logger/index.ts";
+import sql, { empty, raw } from "@/lib/pg/sql.ts";
 import {
   IncentiveRepositoryProviderInterfaceResolver,
   IncentiveStateEnum,
@@ -18,55 +18,41 @@ export class IncentiveRepositoryProvider implements IncentiveRepositoryProviderI
   public readonly carpoolTable = "carpool_v2.carpools";
   public readonly carpoolStatusTable = "carpool_v2.status";
 
-  constructor(protected connection: LegacyPostgresConnection) {}
+  constructor(protected pgConnection: DenoPostgresConnection) {}
 
   async disableOnExcludedCarpool(from: Date, to: Date): Promise<void> {
-    const query = {
-      text: `
-        UPDATE ${this.incentivesTable} AS pi
-        SET
-          state = 'disabled'::policy.incentive_state_enum,
-          status = 'error'::policy.incentive_status_enum
-        FROM ${this.carpoolTable} AS cc
-        JOIN ${this.carpoolStatusTable} AS cs
-          ON cs.carpool_id = cc._id
-        WHERE cc.start_datetime >= $1::timestamp
-          AND cc.start_datetime <  $2::timestamp
-          AND cc.operator_id = pi.operator_id
-          AND cc.operator_journey_id = pi.operator_journey_id
-          AND (
-            cs.acquisition_status = 'canceled'
-            OR cs.anomaly_status = 'failed'
-            OR cs.fraud_status = 'failed'
-          )
-      `,
-      values: [from, to],
-    };
-
-    await this.connection.getClient().query<any>(query);
+    await this.pgConnection.query(sql`
+      UPDATE ${raw(this.incentivesTable)} AS pi
+      SET
+        state = 'disabled'::policy.incentive_state_enum,
+        status = 'error'::policy.incentive_status_enum
+      FROM ${raw(this.carpoolTable)} AS cc
+      JOIN ${raw(this.carpoolStatusTable)} AS cs
+        ON cs.carpool_id = cc._id
+      WHERE cc.start_datetime >= ${from}::timestamp
+        AND cc.start_datetime <  ${to}::timestamp
+        AND cc.operator_id = pi.operator_id
+        AND cc.operator_journey_id = pi.operator_journey_id
+        AND (
+          cs.acquisition_status = 'canceled'
+          OR cs.anomaly_status = 'failed'
+          OR cs.fraud_status = 'failed'
+        )
+    `);
   }
 
   /**
    * Set the status of pending incentives to either Draft or Validated
    */
   async setStatus(from: Date, to: Date, hasFailed = false): Promise<void> {
-    const query = {
-      text: `
-        UPDATE ${this.incentivesTable}
-          SET status = $1::policy.incentive_status_enum
-        WHERE datetime >= $2::timestamp
-          AND datetime <  $3::timestamp
-          AND status = $4::policy.incentive_status_enum
-      `,
-      values: [
-        hasFailed ? IncentiveStatusEnum.Draft : IncentiveStatusEnum.Validated,
-        from,
-        to,
-        IncentiveStatusEnum.Pending,
-      ],
-    };
-
-    await this.connection.getClient().query<any>(query);
+    const nextStatus = hasFailed ? IncentiveStatusEnum.Draft : IncentiveStatusEnum.Validated;
+    await this.pgConnection.query(sql`
+      UPDATE ${raw(this.incentivesTable)}
+        SET status = ${nextStatus}::policy.incentive_status_enum
+      WHERE datetime >= ${from}::timestamp
+        AND datetime <  ${to}::timestamp
+        AND status = ${IncentiveStatusEnum.Pending}::policy.incentive_status_enum
+    `);
   }
 
   async updateStatefulAmount(
@@ -74,7 +60,6 @@ export class IncentiveRepositoryProvider implements IncentiveRepositoryProviderI
     status?: IncentiveStatusEnum,
   ): Promise<void> {
     const idSet: Set<string> = new Set();
-    const ids: number[] = [];
 
     // get only last incentive for each carpool / policy
     const filteredData = data.reverse().filter((d) => {
@@ -87,30 +72,28 @@ export class IncentiveRepositoryProvider implements IncentiveRepositoryProviderI
     });
 
     // pick values for the given keys. Override status if defined
-    const values: [Array<number>, Array<number>, Array<IncentiveStatusEnum>] = filteredData.reduce(
-      ([ids, amounts, statuses]: [Array<number>, Array<number>, Array<IncentiveStatusEnum>], i) => {
-        ids.push(i._id);
-        amounts.push(i.statefulAmount);
-        statuses.push(status ?? i.status);
-        return [ids, amounts, statuses];
-      },
-      [[], [], []],
-    );
+    const ids: number[] = [];
+    const amounts: number[] = [];
+    const statuses: IncentiveStatusEnum[] = [];
+    for (const i of filteredData) {
+      ids.push(i._id);
+      amounts.push(i.statefulAmount);
+      statuses.push(status ?? i.status);
+    }
 
-    const query = {
-      text: `
+    await this.pgConnection.query(sql`
       WITH data AS (
         SELECT * FROM UNNEST (
-          $1::int[],
-          $2::int[],
-          $3::policy.incentive_status_enum[]
+          ${ids}::int[],
+          ${amounts}::int[],
+          ${statuses}::policy.incentive_status_enum[]
         ) as t(
           _id,
           amount,
           status
         )
       )
-      UPDATE ${this.incentivesTable} as pi
+      UPDATE ${raw(this.incentivesTable)} as pi
       SET (
         amount,
         state,
@@ -123,11 +106,7 @@ export class IncentiveRepositoryProvider implements IncentiveRepositoryProviderI
       FROM data
       WHERE
         data._id = pi._id
-      `,
-      values: [...values],
-    };
-
-    await this.connection.getClient().query(query);
+    `);
   }
 
   async *findDraftIncentive(
@@ -135,23 +114,20 @@ export class IncentiveRepositoryProvider implements IncentiveRepositoryProviderI
     batchSize = 100,
     from?: Date,
   ): AsyncGenerator<SerializedIncentiveInterface<number>[], void, void> {
-    const resCount = await this.connection.getClient().query({
-      text: `
-      SELECT
-        count(*)
-      FROM ${this.incentivesTable}
+    const fromFilter = from ? sql`AND datetime >= ${from}::timestamp` : empty;
+
+    const countRows = await this.pgConnection.query<{ count: number }>(sql`
+      SELECT count(*)::int as count
+      FROM ${raw(this.incentivesTable)}
       WHERE
-        status = $1::policy.incentive_status_enum
-        ${from ? "AND datetime >= $3::timestamp" : ""}
-        AND datetime < $2::timestamp
-      `,
-      values: [IncentiveStatusEnum.Draft, to, ...(from ? [from] : [])],
-    });
+        status = ${IncentiveStatusEnum.Draft}::policy.incentive_status_enum
+        ${fromFilter}
+        AND datetime < ${to}::timestamp
+    `);
 
-    logger.debug(`FOUND ${resCount.rows[0].count} incentives to process`);
+    logger.debug(`FOUND ${countRows[0].count} incentives to process`);
 
-    const query = {
-      text: `
+    const query = sql`
       SELECT
         _id,
         policy_id,
@@ -163,35 +139,40 @@ export class IncentiveRepositoryProvider implements IncentiveRepositoryProviderI
         operator_id,
         operator_journey_id,
         meta
-      FROM ${this.incentivesTable}
+      FROM ${raw(this.incentivesTable)}
       WHERE
-        status = $1::policy.incentive_status_enum
-        ${from ? "AND datetime >= $3::timestamp" : ""}
-        AND datetime <= $2::timestamp
-      ORDER BY datetime ASC;
-      `,
-      values: [IncentiveStatusEnum.Draft, to, ...(from ? [from] : [])],
+        status = ${IncentiveStatusEnum.Draft}::policy.incentive_status_enum
+        ${fromFilter}
+        AND datetime <= ${to}::timestamp
+      ORDER BY datetime ASC
+    `;
+
+    type DraftRow = {
+      _id: number;
+      policy_id: number;
+      datetime: Date;
+      stateless_amount: number;
+      stateful_amount: number;
+      status: IncentiveStatusEnum;
+      state: IncentiveStateEnum;
+      operator_id: number;
+      operator_journey_id: string;
+      meta: SerializedMetadataVariableDefinitionInterface[];
     };
 
-    const cursor = await this.connection.getNativeCursor<any>(query.text, query.values);
-    let count = 0;
-
     try {
-      do {
-        const rows = await cursor.read(batchSize);
-        count = rows.length;
-        if (count > 0) {
-          yield rows.map((r) => {
-            const { stateful_amount, stateless_amount, ...other } = r;
-            return {
-              ...other,
-              statefulAmount: r.stateful_amount,
-              statelessAmount: r.stateless_amount,
-            };
-          });
-        }
-        logger.log({ count });
-      } while (count > 0);
+      await using cursor = await this.pgConnection.cursor<DraftRow>(query);
+      for await (const rows of cursor.read(batchSize)) {
+        yield rows.map((r) => {
+          const { stateful_amount, stateless_amount, ...other } = r;
+          return {
+            ...other,
+            statefulAmount: stateful_amount,
+            statelessAmount: stateless_amount,
+          };
+        });
+        logger.log({ count: rows.length });
+      }
     } catch (e) {
       if (e instanceof Error) {
         logger.error(`[IncentiveRepositoryProvider] ${e.message}`, { from, to });
@@ -199,8 +180,6 @@ export class IncentiveRepositoryProvider implements IncentiveRepositoryProviderI
         logger.error(`[IncentiveRepositoryProvider] Unknown error`, { from, to });
       }
       throw e;
-    } finally {
-      await cursor.release();
     }
   }
 
@@ -225,130 +204,92 @@ export class IncentiveRepositoryProvider implements IncentiveRepositoryProviderI
         meta: i.meta || {},
       }));
 
-    const values: [
-      Array<number>,
-      Array<Date>,
-      Array<number>,
-      Array<number>,
-      Array<IncentiveStatusEnum>,
-      Array<IncentiveStateEnum>,
-      Array<number>,
-      Array<number>,
-      Array<SerializedMetadataVariableDefinitionInterface>,
-    ] = filteredData.reduce(
-      (
-        [
-          policyIds,
-          datetimes,
-          statelessAmounts,
-          statefulAmounts,
-          statuses,
-          states,
-          operatorIds,
-          operatorJourneyIds,
-          metas,
-        ],
-        i,
-      ) => {
-        policyIds.push(i.policy_id);
-        datetimes.push(i.datetime);
-        statelessAmounts.push(i.statelessAmount);
-        statefulAmounts.push(i.statefulAmount);
-        statuses.push(i.status);
-        states.push(i.state);
-        operatorIds.push(i.operator_id);
-        operatorJourneyIds.push(i.operator_journey_id);
-        metas.push(JSON.stringify(i.meta));
-        return [
-          policyIds,
-          datetimes,
-          statelessAmounts,
-          statefulAmounts,
-          statuses,
-          states,
-          operatorIds,
-          operatorJourneyIds,
-          metas,
-        ];
-      },
-      [[], [], [], [], [], [], [], [], []],
-    );
+    const policyIds: number[] = [];
+    const datetimes: Date[] = [];
+    const statelessAmounts: number[] = [];
+    const statefulAmounts: number[] = [];
+    const statuses: IncentiveStatusEnum[] = [];
+    const states: IncentiveStateEnum[] = [];
+    const operatorIds: number[] = [];
+    const operatorJourneyIds: string[] = [];
+    const metas: string[] = [];
 
-    const query = {
-      text: `
-        WITH lowest_incentive AS (
-          SELECT min(dtz) AS datetime
-          FROM UNNEST($2::timestamp with time zone[]) AS x(dtz)
-        )
-        --
+    for (const i of filteredData) {
+      policyIds.push(i.policy_id);
+      datetimes.push(i.datetime);
+      statelessAmounts.push(i.statelessAmount);
+      statefulAmounts.push(i.statefulAmount);
+      statuses.push(i.status);
+      states.push(i.state);
+      operatorIds.push(i.operator_id);
+      operatorJourneyIds.push(i.operator_journey_id);
+      metas.push(JSON.stringify(i.meta));
+    }
 
-        INSERT INTO ${this.incentivesTable} (
-          policy_id,
-          carpool_id,
-          datetime,
-          result,
-          amount,
-          status,
-          state,
-          operator_id,
-          operator_journey_id,
-          meta
-        )
-        SELECT
-          unnest_data.policy_id,
-          null as carpool_id,
-          unnest_data.datetime,
-          unnest_data.result,
-          unnest_data.amount,
-          unnest_data.status,
-          unnest_data.state,
-          unnest_data.operator_id,
-          unnest_data.operator_journey_id,
-          unnest_data.meta
-        FROM UNNEST(
-          $1::int[],
-          $2::timestamp[],
-          $3::int[],
-          $4::int[],
-          $5::policy.incentive_status_enum[],
-          $6::policy.incentive_state_enum[],
-          $7::int[],
-          $8::varchar[],
-          $9::json[]
-        ) AS unnest_data(policy_id, datetime, result, amount, status, state, operator_id, operator_journey_id, meta)
-        ON CONFLICT (policy_id, operator_id, operator_journey_id)
-        DO UPDATE SET
-          result = excluded.result,
-          amount = excluded.amount,
-          status = excluded.status,
-          state = excluded.state,
-          meta = excluded.meta;
-      `,
-      values,
-    };
+    await this.pgConnection.query(sql`
+      WITH lowest_incentive AS (
+        SELECT min(dtz) AS datetime
+        FROM UNNEST(${datetimes}::timestamp with time zone[]) AS x(dtz)
+      )
+      --
 
-    await this.connection.getClient().query<any>(query);
-    return;
+      INSERT INTO ${raw(this.incentivesTable)} (
+        policy_id,
+        carpool_id,
+        datetime,
+        result,
+        amount,
+        status,
+        state,
+        operator_id,
+        operator_journey_id,
+        meta
+      )
+      SELECT
+        unnest_data.policy_id,
+        null as carpool_id,
+        unnest_data.datetime,
+        unnest_data.result,
+        unnest_data.amount,
+        unnest_data.status,
+        unnest_data.state,
+        unnest_data.operator_id,
+        unnest_data.operator_journey_id,
+        unnest_data.meta
+      FROM UNNEST(
+        ${policyIds}::int[],
+        ${datetimes}::timestamp[],
+        ${statelessAmounts}::int[],
+        ${statefulAmounts}::int[],
+        ${statuses}::policy.incentive_status_enum[],
+        ${states}::policy.incentive_state_enum[],
+        ${operatorIds}::int[],
+        ${operatorJourneyIds}::varchar[],
+        ${metas}::json[]
+      ) AS unnest_data(policy_id, datetime, result, amount, status, state, operator_id, operator_journey_id, meta)
+      ON CONFLICT (policy_id, operator_id, operator_journey_id)
+      DO UPDATE SET
+        result = excluded.result,
+        amount = excluded.amount,
+        status = excluded.status,
+        state = excluded.state,
+        meta = excluded.meta
+    `);
   }
 
   async latestDraft(): Promise<Date> {
-    const query = {
-      text: `
-        SELECT min(datetime) AS datetime
-        FROM ${this.incentivesTable}
-        WHERE status = $1::policy.incentive_status_enum
-          AND datetime > current_timestamp - interval '1 year'
-        `,
-      values: [IncentiveStatusEnum.Draft],
-    };
-
-    const res = await this.connection.getClient().query<any>(query);
-    return res.rows[0]?.datetime;
+    const rows = await this.pgConnection.query<{ datetime: Date }>(sql`
+      SELECT min(datetime) AS datetime
+      FROM ${raw(this.incentivesTable)}
+      WHERE status = ${IncentiveStatusEnum.Draft}::policy.incentive_status_enum
+        AND datetime > current_timestamp - interval '1 year'
+    `);
+    return rows[0]?.datetime;
   }
 
   // TODO dedup from PolicyRepositoryProvider.syncIncentiveSum
   async updateIncentiveSum(): Promise<void> {
-    await this.connection.getClient().query<any>(`
+    await this.pgConnection.query(sql`
       UPDATE policy.policies p
       SET incentive_sum = policy_incentive_sum.amount
       FROM

--- a/api/src/pdc/services/policy/providers/PolicyRepositoryProvider.integration.spec.ts
+++ b/api/src/pdc/services/policy/providers/PolicyRepositoryProvider.integration.spec.ts
@@ -1,6 +1,7 @@
 import { assert, assertEquals, assertNotEquals } from "dep:assert";
 import { afterAll, beforeAll, describe, it } from "dep:testing-bdd";
-import { LegacyDbContext, makeLegacyDbBeforeAfter } from "../../../providers/test/index.ts";
+import sql, { raw } from "../../../../lib/pg/sql.ts";
+import { DenoDbContext, makeDenoDbBeforeAfter } from "../../../providers/test/index.ts";
 
 import { PolicyStatusEnum } from "../contracts/common/interfaces/PolicyInterface.ts";
 import { SerializedPolicyInterface } from "../interfaces/index.ts";
@@ -10,7 +11,7 @@ describe("PolicyRepositoryProvider", () => {
   let repository: PolicyRepositoryProvider;
   let territory_id: number;
   let policy: SerializedPolicyInterface;
-  let db: LegacyDbContext;
+  let db: DenoDbContext;
 
   function makePolicy(
     data: Partial<SerializedPolicyInterface> = {},
@@ -34,7 +35,7 @@ describe("PolicyRepositoryProvider", () => {
       ...data,
     };
   }
-  const { before, after } = makeLegacyDbBeforeAfter();
+  const { before, after } = makeDenoDbBeforeAfter();
 
   beforeAll(async () => {
     territory_id = 1;
@@ -54,14 +55,13 @@ describe("PolicyRepositoryProvider", () => {
     const { _id, ...policyData } = policy;
     const policyL = await repository.create(policyData);
 
-    const result = await db.connection.getClient().query({
-      text: `SELECT * FROM ${repository.table} WHERE _id = $1`,
-      values: [policyL._id],
-    });
+    const rows = await db.connection.query<{ name: string; status: string }>(sql`
+      SELECT * FROM ${raw(repository.table)} WHERE _id = ${policyL._id}
+    `);
 
-    assertEquals(result.rowCount, 1);
-    assertEquals(result.rows[0].name, policyData.name);
-    assertEquals(result.rows[0].status, "draft");
+    assertEquals(rows.length, 1);
+    assertEquals(rows[0].name, policyData.name);
+    assertEquals(rows[0].status, "draft");
     policy._id = policyL._id;
   });
 
@@ -103,27 +103,25 @@ describe("PolicyRepositoryProvider", () => {
       name,
     });
 
-    const result = await db.connection.getClient().query({
-      text: `SELECT * FROM ${repository.table} WHERE _id = $1`,
-      values: [policyL._id],
-    });
+    const rows = await db.connection.query<{ name: string }>(sql`
+      SELECT * FROM ${raw(repository.table)} WHERE _id = ${policyL._id}
+    `);
 
     assertNotEquals(policy.name, policyL.name);
     assertEquals(policyL.name, name);
-    assertEquals(result.rowCount, 1);
-    assertEquals(result.rows[0].name, name);
+    assertEquals(rows.length, 1);
+    assertEquals(rows[0].name, name);
     policy.name = name;
   });
 
   it("Should delete policy", async () => {
     await repository.delete(policy._id);
 
-    const result = await db.connection.getClient().query({
-      text: `SELECT deleted_at FROM ${repository.table} WHERE _id = $1`,
-      values: [policy._id],
-    });
+    const rows = await db.connection.query<{ deleted_at: Date | null }>(sql`
+      SELECT deleted_at FROM ${raw(repository.table)} WHERE _id = ${policy._id}
+    `);
 
-    assertEquals(result.rowCount, 1);
-    assertNotEquals(result.rows[0].deleted_at, null);
+    assertEquals(rows.length, 1);
+    assertNotEquals(rows[0].deleted_at, null);
   });
 });

--- a/api/src/pdc/services/policy/providers/PolicyRepositoryProvider.ts
+++ b/api/src/pdc/services/policy/providers/PolicyRepositoryProvider.ts
@@ -1,6 +1,7 @@
-import { NotFoundException, provider } from "../../../../ilos/common/index.ts";
-import { LegacyPostgresConnection } from "../../../../ilos/connection-postgres/index.ts";
-import { logger } from "../../../../lib/logger/index.ts";
+import { NotFoundException, provider } from "@/ilos/common/index.ts";
+import { DenoPostgresConnection } from "@/ilos/connection-postgres/index.ts";
+import { logger } from "@/lib/logger/index.ts";
+import sql, { empty, join, raw, Sql } from "@/lib/pg/sql.ts";
 import { PolicyStatusEnum } from "../contracts/common/interfaces/PolicyInterface.ts";
 import { toISOString } from "../helpers/index.ts";
 import { PolicyRepositoryProviderInterfaceResolver, SerializedPolicyInterface } from "../interfaces/index.ts";
@@ -13,160 +14,119 @@ export class PolicyRepositoryProvider implements PolicyRepositoryProviderInterfa
   public readonly getTerritorySelectorFn = "territory.get_selector_by_territory_id";
   private readonly tableTerritory = "territory.territory_group";
 
-  constructor(protected connection: LegacyPostgresConnection) {}
+  constructor(protected pgConnection: DenoPostgresConnection) {}
 
   async find(id: number, territoryId?: number): Promise<SerializedPolicyInterface | undefined> {
-    const query = {
-      text: `
-        SELECT
-          pp._id,
-          sel.selector as territory_selector,
-          pp.name,
-          pp.descriptive_sheet_url,
-          pp.start_date,
-          pp.end_date,
-          pp.tz,
-          pp.handler,
-          pp.status,
-          pp.territory_id,
-          pp.incentive_sum,
-          pp.max_amount
-        FROM ${this.table} as pp,
-        LATERAL (
-          SELECT * FROM ${this.getTerritorySelectorFn}(ARRAY[pp.territory_id])
-        ) as sel
-        WHERE pp._id = $1
-        AND pp.deleted_at IS NULL
-        ${!!territoryId ? "AND pp.territory_id = $2" : ""}
-        LIMIT 1
-      `,
-      values: [id, ...(territoryId ? [territoryId] : [])],
-    };
+    const territoryFilter = territoryId !== undefined
+      ? sql`AND pp.territory_id = ${territoryId}`
+      : empty;
 
-    const result = await this.connection.getClient().query(query);
+    const rows = await this.pgConnection.query<SerializedPolicyInterface>(sql`
+      SELECT
+        pp._id,
+        sel.selector as territory_selector,
+        pp.name,
+        pp.descriptive_sheet_url,
+        pp.start_date,
+        pp.end_date,
+        pp.tz,
+        pp.handler,
+        pp.status,
+        pp.territory_id,
+        pp.incentive_sum,
+        pp.max_amount
+      FROM ${raw(this.table)} as pp,
+      LATERAL (
+        SELECT * FROM ${raw(this.getTerritorySelectorFn)}(ARRAY[pp.territory_id])
+      ) as sel
+      WHERE pp._id = ${id}
+      AND pp.deleted_at IS NULL
+      ${territoryFilter}
+      LIMIT 1
+    `);
 
-    if (result.rowCount === 0) {
-      return undefined;
-    }
-
-    return result.rows[0];
+    return rows[0];
   }
 
   async create(data: Omit<SerializedPolicyInterface, "_id">): Promise<SerializedPolicyInterface> {
-    const query = {
-      text: `
-        INSERT INTO ${this.table} (
-          territory_id,
-          start_date,
-          end_date,
-          name,
-          status,
-          handler
-        ) VALUES (
-          $1,
-          $2,
-          $3,
-          $4,
-          $5,
-          $6
-        )
-        RETURNING _id
-      `,
-      values: [
-        data.territory_id,
-        data.start_date,
-        data.end_date,
-        data.name,
-        data.status,
-        data.handler,
-      ],
-    };
-
-    const result = await this.connection.getClient().query(query);
-    if (result.rowCount !== 1) {
+    const rows = await this.pgConnection.query<{ _id: number }>(sql`
+      INSERT INTO ${raw(this.table)} (
+        territory_id,
+        start_date,
+        end_date,
+        name,
+        status,
+        handler
+      ) VALUES (
+        ${data.territory_id},
+        ${data.start_date},
+        ${data.end_date},
+        ${data.name},
+        ${data.status},
+        ${data.handler}
+      )
+      RETURNING _id
+    `);
+    if (rows.length !== 1) {
       throw new Error(`Unable to create campaign (${JSON.stringify(data)})`);
     }
 
-    return await this.find(result.rows[0]._id);
+    return await this.find(rows[0]._id);
   }
 
   async patch(data: SerializedPolicyInterface): Promise<SerializedPolicyInterface> {
-    const query = {
-      text: `
-      UPDATE ${this.table}
+    const rows = await this.pgConnection.query<{ _id: number }>(sql`
+      UPDATE ${raw(this.table)}
         SET
-           name = $2,
-           start_date = $3,
-           end_date = $4,
-           handler = $5,
-           status = $6
-        WHERE _id = $1
+           name = ${data.name},
+           start_date = ${data.start_date},
+           end_date = ${data.end_date},
+           handler = ${data.handler},
+           status = ${data.status}
+        WHERE _id = ${data._id}
         AND deleted_at IS NULL
         RETURNING _id
-      `,
-      values: [
-        data._id,
-        data.name,
-        data.start_date,
-        data.end_date,
-        data.handler,
-        data.status,
-      ],
-    };
-
-    const result = await this.connection.getClient().query(query);
-    if (result.rowCount !== 1) {
+    `);
+    if (rows.length !== 1) {
       throw new NotFoundException(`campaign not found (${data._id})`);
     }
 
-    return await this.find(result.rows[0]._id);
+    return await this.find(rows[0]._id);
   }
 
   async delete(id: number): Promise<void> {
-    const query = {
-      text: `
-      UPDATE ${this.table}
+    const rows = await this.pgConnection.query<{ _id: number }>(sql`
+      UPDATE ${raw(this.table)}
         SET deleted_at = NOW()
-        WHERE _id = $1 AND deleted_at IS NULL
-      `,
-      values: [id],
-    };
+        WHERE _id = ${id} AND deleted_at IS NULL
+        RETURNING _id
+    `);
 
-    const result = await this.connection.getClient().query(query);
-
-    if (result.rowCount !== 1) {
+    if (rows.length !== 1) {
       throw new NotFoundException(`Campaign not found (${id})`);
     }
-
-    return;
   }
 
-  async updateDescriptiveSheetUrl(id: number, descriptiveSheetUrl: string | null): Promise<void>{
-    const query = {
-      text: `
-      UPDATE ${this.table}
-        SET descriptive_sheet_url = $2
-        WHERE _id = $1
+  async updateDescriptiveSheetUrl(id: number, descriptiveSheetUrl: string | null): Promise<void> {
+    const rows = await this.pgConnection.query<{ _id: number }>(sql`
+      UPDATE ${raw(this.table)}
+        SET descriptive_sheet_url = ${descriptiveSheetUrl}
+        WHERE _id = ${id}
         AND deleted_at IS NULL
         RETURNING _id
-      `,
-      values: [id, descriptiveSheetUrl],
-    };
+    `);
 
-    const result = await this.connection.getClient().query(query);
-
-    if (result.rowCount !== 1) {
+    if (rows.length !== 1) {
       throw new NotFoundException(`Campaign not found (${id})`);
     }
   }
 
   async listApplicablePoliciesId(): Promise<number[]> {
-    const results = await this.connection.getClient().query({
-      text: "SELECT _id FROM policy.policies WHERE status = $1",
-      values: [PolicyStatusEnum.ACTIVE],
-    });
+    const rows = await this.pgConnection.query<{ _id: number }>(sql`
+      SELECT _id FROM policy.policies WHERE status = ${PolicyStatusEnum.ACTIVE}
+    `);
 
-    return results.rows.map((r: { _id: number }) => r._id);
+    return rows.map((r) => r._id);
   }
 
   async findWhere(search: {
@@ -177,76 +137,64 @@ export class PolicyRepositoryProvider implements PolicyRepositoryProviderInterfa
     ends_in_the_future?: boolean;
     search?: string;
   }): Promise<SerializedPolicyInterface[]> {
-    const values = [];
-    const whereClauses = ["pp.deleted_at IS NULL and handler is not null"];
+    const filters: Sql[] = [sql`pp.deleted_at IS NULL and handler is not null`];
     for (const key of Reflect.ownKeys(search)) {
       switch (key) {
         case "_id":
-          values.push(search[key]);
-          whereClauses.push(`pp._id = $${values.length}`);
+          filters.push(sql`pp._id = ${search[key]}`);
           break;
         case "status":
-          values.push(search[key]);
-          whereClauses.push(`pp.status = $${values.length}`);
+          filters.push(sql`pp.status = ${search[key]}`);
           break;
         case "territory_id": {
           const tid = search[key];
           if (tid === null) {
-            whereClauses.push("pp.territory_id IS NULL");
+            filters.push(sql`pp.territory_id IS NULL`);
           } else if (Array.isArray(tid)) {
-            values.push(tid);
-            whereClauses.push(
-              `pp.territory_id = ANY($${values.length}::int[])`,
-            );
+            filters.push(sql`pp.territory_id = ANY(${tid}::int[])`);
           } else {
-            values.push(tid);
-            whereClauses.push(`pp.territory_id = $${values.length}::int`);
+            filters.push(sql`pp.territory_id = ${tid}::int`);
           }
           break;
         }
-        case "datetime":
-          values.push(search[key]);
-          whereClauses.push(
-            `pp.start_date <= $${values.length}::timestamp AND pp.end_date >= $${values.length}::timestamp`,
-          );
+        case "datetime": {
+          const dt = search[key];
+          filters.push(sql`pp.start_date <= ${dt}::timestamp AND pp.end_date >= ${dt}::timestamp`);
           break;
+        }
         case "ends_in_the_future":
-          whereClauses.push(`pp.end_date ${search[key] ? ">" : "<"} NOW()`);
+          filters.push(search[key] ? sql`pp.end_date > NOW()` : sql`pp.end_date < NOW()`);
           break;
-        case "search":
-          values.push(`%${search[key]}%`);
-          whereClauses.push(`(pp.name ILIKE $${values.length} OR tg.name ILIKE $${values.length})`);
+        case "search": {
+          const pattern = `%${search[key]}%`;
+          filters.push(sql`(pp.name ILIKE ${pattern} OR tg.name ILIKE ${pattern})`);
           break;
+        }
         default:
           break;
       }
     }
-    const query = {
-      values,
-      text: `
-        SELECT
-          pp._id,
-          sel.selector as territory_selector,
-          pp.name,
-          pp.descriptive_sheet_url,
-          pp.start_date,
-          pp.end_date,
-          pp.handler,
-          pp.status,
-          pp.territory_id,
-          pp.incentive_sum,
-          pp.max_amount
-        FROM ${this.table} as pp
-        LEFT JOIN ${this.tableTerritory} as tg ON tg._id = pp.territory_id
-        CROSS JOIN LATERAL (
-          SELECT * FROM ${this.getTerritorySelectorFn}(ARRAY[pp.territory_id])
-        ) as sel
-        WHERE ${whereClauses.join(" AND ")}
-      `,
-    };
 
-    const result = await this.connection.getClient().query(query);
-    return result.rows;
+    return await this.pgConnection.query<SerializedPolicyInterface>(sql`
+      SELECT
+        pp._id,
+        sel.selector as territory_selector,
+        pp.name,
+        pp.descriptive_sheet_url,
+        pp.start_date,
+        pp.end_date,
+        pp.handler,
+        pp.status,
+        pp.territory_id,
+        pp.incentive_sum,
+        pp.max_amount
+      FROM ${raw(this.table)} as pp
+      LEFT JOIN ${raw(this.tableTerritory)} as tg ON tg._id = pp.territory_id
+      CROSS JOIN LATERAL (
+        SELECT * FROM ${raw(this.getTerritorySelectorFn)}(ARRAY[pp.territory_id])
+      ) as sel
+      WHERE ${join(filters, " AND ")}
+    `);
   }
 
   /**
@@ -260,25 +208,20 @@ export class PolicyRepositoryProvider implements PolicyRepositoryProviderInterfa
    * TODO de-duplicate with api/services/trip/src/providers/TripRepositoryProvider.ts:529
    */
   async activeOperators(policy_id: number): Promise<number[]> {
-    const query = {
-      text: `
-        SELECT pi.operator_id
-        FROM policy.incentives pi
-        JOIN carpool_v2.carpools cc ON cc.operator_id = pi.operator_id AND cc.operator_journey_id = pi.operator_journey_id
-        JOIN policy.policies pp ON pp._id = $1
-        WHERE
-              cc.start_datetime >= pp.start_date
-          AND cc.start_datetime <  pp.end_date
-          AND pi.policy_id = $1
-          AND pi.state = 'regular'
-        GROUP BY cc.operator_id
-        ORDER BY cc.operator_id
-      `,
-      values: [policy_id],
-    };
-
-    const result = await this.connection.getClient().query(query);
-    return result.rowCount ? result.rows.map((o: { operator_id: number }) => o.operator_id) : [];
+    const rows = await this.pgConnection.query<{ operator_id: number }>(sql`
+      SELECT pi.operator_id
+      FROM policy.incentives pi
+      JOIN carpool_v2.carpools cc ON cc.operator_id = pi.operator_id AND cc.operator_journey_id = pi.operator_journey_id
+      JOIN policy.policies pp ON pp._id = ${policy_id}
+      WHERE
+            cc.start_datetime >= pp.start_date
+        AND cc.start_datetime <  pp.end_date
+        AND pi.policy_id = ${policy_id}
+        AND pi.state = 'regular'
+      GROUP BY cc.operator_id
+      ORDER BY cc.operator_id
+    `);
+    return rows.map((o) => o.operator_id);
   }
 
   /**
@@ -296,47 +239,41 @@ export class PolicyRepositoryProvider implements PolicyRepositoryProviderInterfa
 
     // update the campaign with the sum of validated incentives
     // get the key
-    const res = await this.connection.getClient().query<{ _id: number; datetime: Date }>({
-      text: `
-          SELECT _id, datetime FROM policy.policy_metas
-          WHERE policy_id = $1 AND key = $2
-          ORDER BY datetime DESC
-          LIMIT 1
-        `,
-      values: [campaign_id, key_name],
-    });
+    const metaRows = await this.pgConnection.query<{ _id: number; datetime: Date }>(sql`
+      SELECT _id, datetime FROM policy.policy_metas
+      WHERE policy_id = ${campaign_id} AND key = ${key_name}
+      ORDER BY datetime DESC
+      LIMIT 1
+    `);
 
-    if (!res.rowCount) {
+    if (!metaRows.length) {
       logger.warn(`${pf} ${key_name} key not found for campaign ${campaign_id}`);
       return;
     }
 
-    const { _id: key_id, datetime } = res.rows[0];
+    const { _id: key_id, datetime } = metaRows[0];
 
     // compute incentive_sum
-    const resSum = await this.connection.getClient().query<{ incentive_sum: number }>({
-      text: `
-          WITH latest_incentive AS (
-            SELECT MAX(datetime)
-            FROM policy.incentives
-            WHERE policy_id = $1
-              AND status = 'validated'
-          )
-          SELECT COALESCE(SUM(amount)::int, 0) AS incentive_sum
-          FROM policy.incentives
-          WHERE policy_id = $1
-            AND datetime <= (SELECT max FROM latest_incentive)
-            AND status = 'validated'
-          `,
-      values: [campaign_id],
-    });
+    const sumRows = await this.pgConnection.query<{ incentive_sum: number }>(sql`
+      WITH latest_incentive AS (
+        SELECT MAX(datetime)
+        FROM policy.incentives
+        WHERE policy_id = ${campaign_id}
+          AND status = 'validated'
+      )
+      SELECT COALESCE(SUM(amount)::int, 0) AS incentive_sum
+      FROM policy.incentives
+      WHERE policy_id = ${campaign_id}
+        AND datetime <= (SELECT max FROM latest_incentive)
+        AND status = 'validated'
+    `);
 
-    if (!resSum.rowCount) {
+    if (!sumRows.length) {
       logger.warn(`${pf} Could not calculate incentive sum for campaign ${campaign_id}`);
       return;
     }
 
-    const { incentive_sum } = resSum.rows[0];
+    const { incentive_sum } = sumRows[0];
 
     // update max_amount_restriction.global.campaign.global
     logger.info(
@@ -346,17 +283,15 @@ export class PolicyRepositoryProvider implements PolicyRepositoryProviderInterfa
         `for campaign ${campaign_id}`,
     );
 
-    await this.connection.getClient().query({
-      text: `UPDATE policy.policy_metas SET value = $2 WHERE _id = $1`,
-      values: [key_id, incentive_sum],
-    });
+    await this.pgConnection.query(sql`
+      UPDATE policy.policy_metas SET value = ${incentive_sum} WHERE _id = ${key_id}
+    `);
 
     // update incentive_sum in the policy
     logger.info(`${pf} Set incentive_sum ${incentive_sum} in policy ${campaign_id}`);
-    await this.connection.getClient().query({
-      text: `UPDATE policy.policies SET incentive_sum = LEAST(max_amount, $2) WHERE _id = $1`,
-      values: [campaign_id, incentive_sum],
-    });
+    await this.pgConnection.query(sql`
+      UPDATE policy.policies SET incentive_sum = LEAST(max_amount, ${incentive_sum}) WHERE _id = ${campaign_id}
+    `);
   }
 
   /**
@@ -365,12 +300,9 @@ export class PolicyRepositoryProvider implements PolicyRepositoryProviderInterfa
    * For each campaign, check if it is still active and update its status
    */
   async updateAllCampaignStatuses(): Promise<void> {
-    await this.connection.getClient().query({
-      text: `
-        UPDATE ${this.table} SET status = $1
-        WHERE end_date < CURRENT_TIMESTAMP AND status = $2
-      `,
-      values: [PolicyStatusEnum.FINISHED, PolicyStatusEnum.ACTIVE],
-    });
+    await this.pgConnection.query(sql`
+      UPDATE ${raw(this.table)} SET status = ${PolicyStatusEnum.FINISHED}
+      WHERE end_date < CURRENT_TIMESTAMP AND status = ${PolicyStatusEnum.ACTIVE}
+    `);
   }
 }

--- a/api/src/pdc/services/policy/providers/TerritoryRepositoryProvider.ts
+++ b/api/src/pdc/services/policy/providers/TerritoryRepositoryProvider.ts
@@ -1,6 +1,7 @@
 import { NotFoundException, provider } from "@/ilos/common/index.ts";
-import { LegacyPostgresConnection } from "@/ilos/connection-postgres/index.ts";
+import { DenoPostgresConnection } from "@/ilos/connection-postgres/index.ts";
 import { logger } from "@/lib/logger/index.ts";
+import sql, { raw } from "@/lib/pg/sql.ts";
 import {
   TerritoryCodeEnum,
   TerritoryCodeInterface,
@@ -21,92 +22,79 @@ export class TerritoryRepositoryProvider implements TerritoryRepositoryProviderI
   protected readonly operatorTable = "operator.operators";
   protected readonly companyTable = "company.companies";
 
-  constructor(protected connection: LegacyPostgresConnection) {}
+  constructor(protected pgConnection: DenoPostgresConnection) {}
 
   async findByPoint(
     { lon, lat }: { lon: number; lat: number },
   ): Promise<TerritoryCodeInterface> {
     try {
-      const result = await this.connection.getClient().query<any>({
-        text: `
-          SELECT * FROM ${this.getByPointFunction}($1::float, $2::float)
-        `,
-        values: [lon, lat],
-      });
+      const rows = await this.pgConnection.query<TerritoryCodeInterface>(sql`
+        SELECT * FROM ${raw(this.getByPointFunction)}(${lon}::float, ${lat}::float)
+      `);
 
-      if (result.rowCount < 1) {
+      if (!rows.length) {
         throw new NotFoundException();
       }
-      return result.rows[0];
+      return rows[0];
     } catch (e) {
-      logger.error(e.message, e);
+      const message = e instanceof Error ? e.message : String(e);
+      logger.error(message, e);
       return null;
     }
   }
 
   async findUUIDByOperatorId(_id: number): Promise<string> {
-    const query = {
-      text: `
-        SELECT
-          o._id, c.uuid
-        FROM ${this.operatorTable} AS o
-        LEFT JOIN ${this.companyTable} AS c
-          ON c._id = o.company_id
-        WHERE o._id = $1 LIMIT 1
-      `,
-      values: [_id],
-    };
-    const result = await this.connection.getClient().query<any>(query);
+    const rows = await this.pgConnection.query<{ _id: number; uuid: string }>(sql`
+      SELECT
+        o._id, c.uuid
+      FROM ${raw(this.operatorTable)} AS o
+      LEFT JOIN ${raw(this.companyTable)} AS c
+        ON c._id = o.company_id
+      WHERE o._id = ${_id} LIMIT 1
+    `);
 
-    if (result.rowCount < 1) {
+    if (!rows.length) {
       throw new NotFoundException();
     }
 
-    return result.rows[0]?.uuid;
+    return rows[0]?.uuid;
   }
 
   async findUUIDById(
     _id: number | number[],
   ): Promise<{ _id: number; uuid: string }[]> {
-    const query = {
-      text: `
-        SELECT
-          t._id, c.uuid
-        FROM ${this.territoryGroupTable} AS t
-        LEFT JOIN ${this.companyTable} AS c
-          ON c._id = t.company_id
-        WHERE t._id = ${Array.isArray(_id) ? "ANY($1)" : "$1"}
-      `,
-      values: [_id],
-    };
-    const result = await this.connection.getClient().query<any>(query);
-    return result.rows;
+    const idFilter = Array.isArray(_id)
+      ? sql`t._id = ANY(${_id})`
+      : sql`t._id = ${_id}`;
+
+    return await this.pgConnection.query<{ _id: number; uuid: string }>(sql`
+      SELECT
+        t._id, c.uuid
+      FROM ${raw(this.territoryGroupTable)} AS t
+      LEFT JOIN ${raw(this.companyTable)} AS c
+        ON c._id = t.company_id
+      WHERE ${idFilter}
+    `);
   }
 
   async findBySelector(
     data: Partial<TerritoryCodeInterface>,
   ): Promise<number[]> {
-    const result = await this.connection.getClient().query<any>({
-      text: `SELECT _id FROM ${this.getBySelectorFunction}($1::varchar, $2::varchar)`,
-      values: [
-        data[TerritoryCodeEnum.Arr] || data[TerritoryCodeEnum.City],
-        data[TerritoryCodeEnum.Mobility],
-      ],
-    });
-    return result.rows.map((r) => r._id);
+    const arr = data[TerritoryCodeEnum.Arr] || data[TerritoryCodeEnum.City];
+    const mobility = data[TerritoryCodeEnum.Mobility];
+    const rows = await this.pgConnection.query<{ _id: number }>(sql`
+      SELECT _id FROM ${raw(this.getBySelectorFunction)}(${arr}::varchar, ${mobility}::varchar)
+    `);
+    return rows.map((r) => r._id);
   }
 
   async findSelectorFromId(id: number): Promise<TerritorySelectorsInterface> {
-    const query = {
-      text: `
-        SELECT * FROM ${this.getTerritorySelectorFn}($1) 
-      `,
-      values: [[id]],
-    };
-    const result = await this.connection.getClient().query<any>(query);
-    if (result.rowCount !== 1) {
+    const rows = await this.pgConnection.query<{ selector: TerritorySelectorsInterface }>(sql`
+      SELECT * FROM ${raw(this.getTerritorySelectorFn)}(${[id]})
+    `);
+    if (rows.length !== 1) {
       throw new NotFoundException();
     }
-    return result.rows[0].selector;
+    return rows[0].selector;
   }
 }

--- a/api/src/pdc/services/policy/providers/TripRepositoryProvider.ts
+++ b/api/src/pdc/services/policy/providers/TripRepositoryProvider.ts
@@ -1,6 +1,6 @@
 import { provider } from "@/ilos/common/index.ts";
-import { LegacyPostgresConnection } from "@/ilos/connection-postgres/index.ts";
-import { logger } from "@/lib/logger/index.ts";
+import { DenoPostgresConnection } from "@/ilos/connection-postgres/index.ts";
+import sql, { empty, raw } from "@/lib/pg/sql.ts";
 import { CarpoolInterface, PolicyInterface, TripRepositoryProviderInterfaceResolver } from "../interfaces/index.ts";
 
 @provider({
@@ -15,7 +15,7 @@ export class TripRepositoryProvider implements TripRepositoryProviderInterfaceRe
   public readonly getComFunction = "territory.get_com_by_territory_id";
   public readonly getMillesimeFunction = "geo.get_latest_millesime";
 
-  constructor(protected connection: LegacyPostgresConnection) {}
+  constructor(protected pgConnection: DenoPostgresConnection) {}
 
   async *findTripByGeo(
     coms: string[],
@@ -25,71 +25,72 @@ export class TripRepositoryProvider implements TripRepositoryProviderInterfaceRe
     override = true,
     policy_id?: number,
   ): AsyncGenerator<CarpoolInterface[], void, void> {
-    const query = {
-      text: `
-        SELECT
-          oo.uuid as operator_uuid,
-          cc.operator_trip_id,
-          cc.operator_id,
-          cc.operator_journey_id,
-          cc.operator_class,
-          cc.passenger_contribution,
-          cc.passenger_identity_key,
-          cc.passenger_travelpass_user_id IS NOT NULL as passenger_has_travel_pass,
-          cc.passenger_over_18 as passenger_is_over_18,
-          cc.passenger_seats as seats,
-          cc.driver_revenue,
-          cc.driver_identity_key,
-          cc.driver_travelpass_user_id IS NOT NULL as driver_has_travel_pass,
-          cc.start_datetime as datetime,
-          cc.distance,
-          row_to_json(
-            geo.get_by_code(
-              co.start_geo_code::varchar,
-              geo.get_latest_millesime_or(EXTRACT(year FROM cc.start_datetime)::smallint)
-            )
-          ) as start,
-          row_to_json(
-            geo.get_by_code(
-              co.end_geo_code::varchar,
-              geo.get_latest_millesime_or(EXTRACT(year FROM cc.start_datetime)::smallint)
-            )
-          ) as end,
-          ST_X(cc.start_position::geometry)::numeric as start_lon,
-          ST_Y(cc.start_position::geometry)::numeric as start_lat,
-          ST_X(cc.end_position::geometry)::numeric as end_lon,
-          ST_Y(cc.end_position::geometry)::numeric as end_lat
-        FROM ${this.table} cc
-        JOIN ${this.geoTable} co
-          ON co.carpool_id = cc._id
-        JOIN ${this.operatorTable} oo
-          ON oo._id = cc.operator_id
-        JOIN ${this.statusTable} cs
-          ON cs.carpool_id = cc._id
-        ${
-        override ? "" : `
-              LEFT JOIN ${this.incentiveTable} pi
-                ON
-                  cc.operator_journey_id = pi.operator_journey_id
-                  AND cc.operator_id = pi.operator_id
-                  AND pi.policy_id = $4::int
-            `
-      }
-        WHERE
-          cc.start_datetime >= $2::timestamp
-          AND cc.start_datetime < $3::timestamp
-          AND (
-            co.start_geo_code = ANY($1::varchar[])
-            OR co.end_geo_code = ANY($1::varchar[])
+    const overrideJoin = override ? empty : sql`
+      LEFT JOIN ${raw(this.incentiveTable)} pi
+        ON
+          cc.operator_journey_id = pi.operator_journey_id
+          AND cc.operator_id = pi.operator_id
+          AND pi.policy_id = ${policy_id}::int
+    `;
+    const overrideFilter = override ? empty : sql`AND pi._id IS NULL`;
+
+    const query = sql`
+      SELECT
+        oo.uuid as operator_uuid,
+        cc.operator_trip_id,
+        cc.operator_id,
+        cc.operator_journey_id,
+        cc.operator_class,
+        cc.passenger_contribution,
+        cc.passenger_identity_key,
+        cc.passenger_travelpass_user_id IS NOT NULL as passenger_has_travel_pass,
+        cc.passenger_over_18 as passenger_is_over_18,
+        cc.passenger_seats as seats,
+        cc.driver_revenue,
+        cc.driver_identity_key,
+        cc.driver_travelpass_user_id IS NOT NULL as driver_has_travel_pass,
+        cc.start_datetime as datetime,
+        cc.distance,
+        row_to_json(
+          geo.get_by_code(
+            co.start_geo_code::varchar,
+            geo.get_latest_millesime_or(EXTRACT(year FROM cc.start_datetime)::smallint)
           )
-          ${override ? "" : "AND pi._id IS NULL"}
-        ORDER BY cc.start_datetime ASC
-      `,
-      values: [coms, from, to, ...(!override && policy_id ? [policy_id] : [])],
-    };
+        ) as start,
+        row_to_json(
+          geo.get_by_code(
+            co.end_geo_code::varchar,
+            geo.get_latest_millesime_or(EXTRACT(year FROM cc.start_datetime)::smallint)
+          )
+        ) as end,
+        ST_X(cc.start_position::geometry)::numeric as start_lon,
+        ST_Y(cc.start_position::geometry)::numeric as start_lat,
+        ST_X(cc.end_position::geometry)::numeric as end_lon,
+        ST_Y(cc.end_position::geometry)::numeric as end_lat
+      FROM ${raw(this.table)} cc
+      JOIN ${raw(this.geoTable)} co
+        ON co.carpool_id = cc._id
+      JOIN ${raw(this.operatorTable)} oo
+        ON oo._id = cc.operator_id
+      JOIN ${raw(this.statusTable)} cs
+        ON cs.carpool_id = cc._id
+      ${overrideJoin}
+      WHERE
+        cc.start_datetime >= ${from}::timestamp
+        AND cc.start_datetime < ${to}::timestamp
+        AND (
+          co.start_geo_code = ANY(${coms}::varchar[])
+          OR co.end_geo_code = ANY(${coms}::varchar[])
+        )
+        ${overrideFilter}
+      ORDER BY cc.start_datetime ASC
+    `;
     // TODO status
 
-    yield* this.queryAndYieldRows(query, batchSize);
+    await using cursor = await this.pgConnection.cursor<CarpoolInterface>(query);
+    for await (const rows of cursor.read(batchSize)) {
+      yield rows;
+    }
   }
 
   async *findTripByPolicy(
@@ -99,48 +100,17 @@ export class TripRepositoryProvider implements TripRepositoryProviderInterfaceRe
     batchSize = 100,
     override = false,
   ): AsyncGenerator<CarpoolInterface[], void, void> {
-    const yearResult = await this.connection.getClient().query(
-      `SELECT * from ${this.getMillesimeFunction}() as year`,
-    );
-    const year = yearResult.rows[0]?.year;
+    const yearRows = await this.pgConnection.query<{ year: number }>(sql`
+      SELECT * from ${raw(this.getMillesimeFunction)}() as year
+    `);
+    const year = yearRows[0]?.year;
 
-    const comRes = await this.connection.getClient().query({
-      text: `
-        SELECT * FROM ${this.getComFunction}($1::int, $2::smallint)
-      `,
-      values: [policy.territory_id, year],
-    });
+    const comRows = await this.pgConnection.query<{ com: string }>(sql`
+      SELECT * FROM ${raw(this.getComFunction)}(${policy.territory_id}::int, ${year}::smallint)
+    `);
 
-    const com: string[] = comRes.rowCount ? comRes.rows.map((r) => r.com) : [];
+    const com: string[] = comRows.map((r) => r.com);
 
     yield* this.findTripByGeo(com, from, to, batchSize, override, policy._id);
-  }
-
-  private async *queryAndYieldRows(
-    query: { text: string; values: (number | Date | string[])[] },
-    batchSize: number,
-  ): AsyncGenerator<CarpoolInterface[], void, void> {
-    const cursor = await this.connection.getNativeCursor<CarpoolInterface>(query.text, query.values);
-    let count = 0;
-
-    try {
-      do {
-        const rows = await cursor.read(batchSize);
-        count = rows.length;
-        if (count > 0) {
-          yield rows;
-        }
-      } while (count > 0);
-    } catch (e) {
-      if (e instanceof Error) {
-        logger.error(`[queryAndYieldRows] ${e.message}`);
-        logger.debug(e.stack);
-      } else {
-        logger.error("[queryAndYieldRows] An unknown error occurred");
-      }
-      throw e;
-    } finally {
-      await cursor.release();
-    }
   }
 }


### PR DESCRIPTION
Refs #3179

## Description

Next slice of the LegacyPostgresConnection migration: swap the four remaining policy repository providers and their integration specs over to DenoPostgresConnection.

- **TerritoryRepositoryProvider**: five simple function-call queries (`geo.get_latest_by_point`, `policy.get_territory_id_by_selector`, `territory.get_selector_by_territory_id`, plus two table lookups). All converted to `sql` tagged templates with `raw()` table interpolation. `findUUIDById` branches the `int` vs `int[]` predicate via two `sql` fragments rather than the previous string substitution.
- **PolicyRepositoryProvider**: thirteen queries covering full CRUD on `policy.policies` plus the `syncIncentiveSum` / `activeOperators` / `updateAllCampaignStatuses` paths. The dynamic `findWhere` builder now appends `Sql` fragments to a filters array and joins with `" AND "` instead of hand-numbering `$N` placeholders. `delete()` and `updateDescriptiveSheetUrl()` pick up `RETURNING _id` so `rows.length` can replace the legacy `rowCount` guard (same trick as `CompanyRepositoryProvider.updateOrCreate`).
- **TripRepositoryProvider**: two function-call lookups plus the `findTripByGeo` cursor. The cursor moves from `getNativeCursor(text, values)` to `pgConnection.cursor(sql)`, consumed via `for await (const rows of cursor.read(batchSize))`. Optional override join / filter are passed in as `empty` / `Sql` fragments instead of string substitution.
- **IncentiveRepositoryProvider**: seven queries plus the `findDraftIncentive` cursor. All five UNNEST array INSERTs / UPDATEs (statefulAmount bulk update, `createOrUpdateMany` bulk upsert with nine parallel arrays) are now interpolated as `${arr}::type[]` expressions in `sql` templates; deno-postgres serialises JS arrays as PG arrays so the generated SQL is structurally identical to the previous parameterised shape. Cursor pattern matches `TripRepositoryProvider`.

## Tests

Both pre-existing integration specs (`PolicyRepositoryProvider` and `IncentiveRepositoryProvider`) are flipped from `makeLegacyDbBeforeAfter` to `makeDenoDbBeforeAfter`; the raw assertion queries that previously went through `db.connection.getClient().query({ text, values })` are rewritten as `db.connection.query<T>(sql)` so the spec runs end-to-end against the new connection.

All 15 integration test steps pass:
- `IncentiveRepositoryProvider`: 3
- `MetadataRepositoryProvider`: 5
- `PolicyRepositoryProvider`: 7

## Checklist

- [x] j'ai suivi les guidelines du "clean code"
- [ ] j'ai mis à jour la documentation technique dans `/api/specs` (n/a - internal repository wiring only)
- [x] ajout ou mise à jour des tests unitaires (n/a)
- [x] ajout ou mise à jour des tests d'intégration

## Test plan

- [x] `just dc` stack up
- [x] `deno test ... 'src/pdc/services/policy/providers/*.integration.spec.ts'` -> 3 / 3 spec files, 15 / 15 test steps pass
- [x] `deno check --allow-import src/pdc/services/policy` -> 0 new errors introduced (pre-existing errors in pre-migration files are unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)