### PR TITLE
refactor(api): migrate LocalGeoProvider to DenoPostgresConnection

### DIFF
--- a/api/src/pdc/providers/geo/providers/LocalGeoProvider.ts
+++ b/api/src/pdc/providers/geo/providers/LocalGeoProvider.ts
@@ -1,5 +1,6 @@
 import { NotFoundException, provider } from "@/ilos/common/index.ts";
-import { LegacyPostgresConnection } from "@/ilos/connection-postgres/index.ts";
+import { DenoPostgresConnection } from "@/ilos/connection-postgres/index.ts";
+import sql, { raw } from "@/lib/pg/sql.ts";
 import { logger } from "@/lib/logger/index.ts";
 import { InseeCoderInterface, PointInterface } from "../interfaces/index.ts";
 
@@ -9,58 +10,43 @@ export class LocalGeoProvider implements InseeCoderInterface {
   protected fb = "geo.get_closest_country";
   protected fbclose = "geo.get_closest_com";
 
-  constructor(protected connection: LegacyPostgresConnection) {}
+  constructor(protected connection: DenoPostgresConnection) {}
 
   async positionToInsee(geo: PointInterface): Promise<string> {
     const { lat, lon } = geo;
-    const pool = this.connection.getClient();
-    const client = await pool.connect();
 
     try {
-      const resultInCom = await client.query({
-        text: `
+      const inCom = await this.connection.query<{ arr: string }>(sql`
         SELECT arr
-        FROM ${this.fn}($1::float, $2::float)
+        FROM ${raw(this.fn)}(${lon}::float, ${lat}::float)
         WHERE arr NOT IN ('XXXXX','99100')
-      `,
-        values: [lon, lat],
-      });
-
-      if (resultInCom.rowCount > 0) {
-        return resultInCom.rows[0].arr;
+      `);
+      if (inCom.length > 0) {
+        return inCom[0].arr;
       }
 
-      const resultOutFr = await client.query({
-        text: `
+      const outFr = await this.connection.query<{ arr: string }>(sql`
         SELECT arr
-        FROM ${this.fb}($1::float, $2::float)
+        FROM ${raw(this.fb)}(${lon}::float, ${lat}::float)
         WHERE com IS NULL
-      `,
-        values: [lon, lat],
-      });
-
-      if (resultOutFr.rowCount > 0) {
-        return resultOutFr.rows[0].arr;
+      `);
+      if (outFr.length > 0) {
+        return outFr[0].arr;
       }
 
-      const resultCloseCom = await client.query({
-        text: `
+      const closeCom = await this.connection.query<{ arr: string }>(sql`
         SELECT arr
-        FROM ${this.fbclose}($1::float, $2::float,1000)
-      `,
-        values: [lon, lat],
-      });
-
-      if (resultCloseCom.rowCount === 0) {
+        FROM ${raw(this.fbclose)}(${lon}::float, ${lat}::float, 1000)
+      `);
+      if (closeCom.length === 0) {
         throw new NotFoundException();
       }
 
-      return resultCloseCom.rows[0].arr;
+      return closeCom[0].arr;
     } catch (e) {
-      logger.error(`[LocalGeoProvider] (${lon},${lat}) ${e.message}`);
+      const message = e instanceof Error ? e.message : String(e);
+      logger.error(`[LocalGeoProvider] (${lon},${lat}) ${message}`);
       throw e;
-    } finally {
-      client.release();
     }
   }
 }

--- a/api/src/pdc/providers/geo/tests/LocalGeoProvider.integration.spec.ts
+++ b/api/src/pdc/providers/geo/tests/LocalGeoProvider.integration.spec.ts
@@ -1,0 +1,34 @@
+import { assertEquals, assertRejects } from "dep:assert";
+import { afterAll, beforeAll, describe, it } from "dep:testing-bdd";
+
+import { NotFoundException } from "@/ilos/common/index.ts";
+import { DenoDbContext, makeDenoDbBeforeAfter } from "@/pdc/providers/test/dbMacro.ts";
+
+import { LocalGeoProvider } from "../providers/LocalGeoProvider.ts";
+
+describe("LocalGeoProvider", () => {
+  let db: DenoDbContext;
+  let provider: LocalGeoProvider;
+  const { before, after } = makeDenoDbBeforeAfter();
+
+  beforeAll(async () => {
+    db = await before();
+    provider = new LocalGeoProvider(db.connection);
+  });
+
+  afterAll(async () => {
+    await after(db);
+  });
+
+  it("positionToInsee returns the commune INSEE for a point inside a seeded polygon", async () => {
+    const arr = await provider.positionToInsee({ lat: 48.721505, lon: 2.26188 });
+    assertEquals(arr, "91377");
+  });
+
+  it("positionToInsee throws NotFoundException when no polygon nor closest-com fixture matches", async () => {
+    await assertRejects(
+      () => provider.positionToInsee({ lat: 0, lon: 0 }),
+      NotFoundException,
+    );
+  });
+});

--- a/api/src/pdc/tests/acquisition/patch.integration.spec.ts
+++ b/api/src/pdc/tests/acquisition/patch.integration.spec.ts
@@ -1,6 +1,6 @@
 import { assert, assertEquals } from "dep:assert";
 import { afterAll, beforeAll, describe, it } from "dep:testing-bdd";
-import { LegacyPostgresConnection } from "@/ilos/connection-postgres/index.ts";
+import { DenoPostgresConnection, LegacyPostgresConnection } from "@/ilos/connection-postgres/index.ts";
 import {
   CarpoolAcquisitionService,
   CarpoolGeoRepository,
@@ -34,6 +34,7 @@ describe("Operator patches a journey", () => {
   // ---------------------------------------------------------------------------
 
   let db: LegacyDbContext;
+  let denoConnection: DenoPostgresConnection;
   let kc: KernelContext;
   let carpoolRepository: CarpoolRepository;
   let statusRepository: CarpoolStatusRepository;
@@ -73,10 +74,13 @@ describe("Operator patches a journey", () => {
       .rebind(LegacyPostgresConnection)
       .toConstantValue(db.connection);
 
+    denoConnection = new DenoPostgresConnection(db.db.currentConnectionString);
+    await denoConnection.up();
+
     geoProvider = new GeoProvider(
       new EtalabAPIGeoProvider(),
       new EtalabBaseAdresseNationaleProvider(),
-      new LocalGeoProvider(db.connection),
+      new LocalGeoProvider(denoConnection),
       new OSRMProvider(),
     );
     carpoolRepository = new CarpoolRepository(db.connection);
@@ -88,6 +92,7 @@ describe("Operator patches a journey", () => {
   });
 
   afterAll(async () => {
+    await denoConnection?.down();
     await kernelAfter(kc);
     await dbAfter(db);
   });


### PR DESCRIPTION
## Summary

- Swap `LegacyPostgresConnection` for `DenoPostgresConnection` in `api/src/pdc/providers/geo/providers/LocalGeoProvider.ts`.
- Three reads (`geo.get_latest_by_point`, `geo.get_closest_country`, `geo.get_closest_com`) move to `sql` template literals via `connection.query<T>(...)`; the pool / client checkout / `try/finally release` is gone (no transaction, no held client).
- Tightens the `catch` block so the unknown error narrows to `Error.message` before logging, otherwise falls back to `String(e)`.

## Test plan

- [x] `deno test -A --no-check --env-file=.env src/pdc/providers/geo/tests/LocalGeoProvider.integration.spec.ts`
  - in-polygon point -> returns `91377` (Massy from seeded `geo.csv`)
  - mid-ocean point -> rejects with `NotFoundException`
- [x] `deno check --allow-import` on the changed files: no new errors (only pre-existing TS noise unchanged).

Refs #3179.