### PR TITLE
fix(sqlmesh): restore 'aom' type column across UNION branches

### DIFF
--- a/sqlmesh/models/2_trusted_zone/geo/perimeters_agg.sql
+++ b/sqlmesh/models/2_trusted_zone/geo/perimeters_agg.sql
@@ -30,7 +30,7 @@ UNION ALL
 SELECT
   year,
   aom AS code,
-  
+  'aom' AS type,
   l_aom AS libelle,
   ST_Multi(ST_Union(geom_simple)) AS geom,
   ST_PointOnSurface(ST_Union(geom_simple)) AS centroid

--- a/sqlmesh/models/3_refined_zone/observatoire/directions/obs_directions_day.sql
+++ b/sqlmesh/models/3_refined_zone/observatoire/directions/obs_directions_day.sql
@@ -92,7 +92,7 @@ directions_exploded AS (
     j.is_new_driver, j.is_new_passenger,
     j.incentive_collectivite, j.incentive_operator,
     j.incentive_others, j.no_incentive,
-    d.direction,  d.code,
+    d.direction, 'aom' AS type, d.code,
     (d.code IS NOT NULL AND d.code = d.end_code) AS is_intra
   FROM journeys_enriched j
   CROSS JOIN LATERAL (
@@ -113,7 +113,7 @@ directions_exploded AS (
     j.is_new_driver, j.is_new_passenger,
     j.incentive_collectivite, j.incentive_operator,
     j.incentive_others, j.no_incentive,
-    'from' AS direction,  ar.aom AS code,
+    'from' AS direction, 'aom' AS type, ar.aom AS code,
     (j.start_reg = j.end_reg AND j.start_aom <> j.end_aom) AS is_intra
   FROM journeys_enriched j
   INNER JOIN trusted_zone.aom_region ar ON ar.reg = j.start_reg
@@ -129,7 +129,7 @@ directions_exploded AS (
     j.is_new_driver, j.is_new_passenger,
     j.incentive_collectivite, j.incentive_operator,
     j.incentive_others, j.no_incentive,
-    'to' AS direction,  ar.aom AS code,
+    'to' AS direction, 'aom' AS type, ar.aom AS code,
     (j.start_reg = j.end_reg AND j.start_aom <> j.end_aom) AS is_intra
   FROM journeys_enriched j
   INNER JOIN trusted_zone.aom_region ar ON ar.reg = j.end_reg

--- a/sqlmesh/models/3_refined_zone/observatoire/od/obs_od_month.sql
+++ b/sqlmesh/models/3_refined_zone/observatoire/od/obs_od_month.sql
@@ -89,7 +89,7 @@ od_agg AS (
   UNION
   -- aom classiques
   SELECT
-    a.year, a.month, 
+    a.year, a.month, 'aom' AS type,
     least(b.aom, c.aom) AS territory_1,
     greatest(b.aom, c.aom) AS territory_2,
     sum(journeys) AS journeys,
@@ -107,7 +107,7 @@ od_agg AS (
   UNION
   -- aom regionales
   SELECT
-    a.year, a.month, 
+    a.year, a.month, 'aom' AS type,
     least(b.aom_r, c.aom_r) AS territory_1,
     greatest(b.aom_r, c.aom_r) AS territory_2,
     sum(journeys) AS journeys,

--- a/sqlmesh/models/3_refined_zone/observatoire/od/obs_od_quarter.sql
+++ b/sqlmesh/models/3_refined_zone/observatoire/od/obs_od_quarter.sql
@@ -89,7 +89,7 @@ od_agg AS (
   UNION
   -- aom classiques
   SELECT
-    a.year, a.quarter, 
+    a.year, a.quarter, 'aom' AS type,
     least(b.aom, c.aom) AS territory_1,
     greatest(b.aom, c.aom) AS territory_2,
     sum(journeys) AS journeys,
@@ -107,7 +107,7 @@ od_agg AS (
   UNION
   -- aom regionales
   SELECT
-    a.year, a.quarter, 
+    a.year, a.quarter, 'aom' AS type,
     least(b.aom_r, c.aom_r) AS territory_1,
     greatest(b.aom_r, c.aom_r) AS territory_2,
     sum(journeys) AS journeys,

--- a/sqlmesh/models/3_refined_zone/observatoire/od/obs_od_semester.sql
+++ b/sqlmesh/models/3_refined_zone/observatoire/od/obs_od_semester.sql
@@ -89,7 +89,7 @@ od_agg AS (
   UNION
   -- aom classiques
   SELECT
-    a.year, a.semester, 
+    a.year, a.semester, 'aom' AS type,
     least(b.aom, c.aom) AS territory_1,
     greatest(b.aom, c.aom) AS territory_2,
     sum(journeys) AS journeys,
@@ -107,7 +107,7 @@ od_agg AS (
   UNION
   -- aom regionales
   SELECT
-    a.year, a.semester, 
+    a.year, a.semester, 'aom' AS type,
     least(b.aom_r, c.aom_r) AS territory_1,
     greatest(b.aom_r, c.aom_r) AS territory_2,
     sum(journeys) AS journeys,

--- a/sqlmesh/models/3_refined_zone/observatoire/od/obs_od_year.sql
+++ b/sqlmesh/models/3_refined_zone/observatoire/od/obs_od_year.sql
@@ -88,7 +88,7 @@ od_agg AS (
   UNION
   -- aom classiques
   SELECT
-    a.year, 
+    a.year, 'aom' AS type,
     least(b.aom, c.aom) AS territory_1,
     greatest(b.aom, c.aom) AS territory_2,
     sum(journeys) AS journeys,
@@ -106,7 +106,7 @@ od_agg AS (
   UNION
   -- aom regionales
   SELECT
-    a.year, 
+    a.year, 'aom' AS type,
     least(b.aom_r, c.aom_r) AS territory_1,
     greatest(b.aom_r, c.aom_r) AS territory_2,
     sum(journeys) AS journeys,


### PR DESCRIPTION
## Description

Commit 5f113518a (#3164) "fix: remove type column" accidentally stripped the literal `'aom' AS type,` from several UNION branches across the geo / observatoire models. The deletion produced two distinct failure modes in production:

### 1. UNION column-count mismatch (immediate plan failure)

- `trusted_zone.perimeters_agg` -- AOM branch reduced to 5 cols vs 6 in the other 5 branches.
- `refined_zone.obs_directions_day` -- 3 AOM `UNION ALL` branches reduced to 16 cols vs 17 in the non-AOM branch.

Error: `each UNION query must have the same number of columns`.

### 2. GROUP BY ordinal shift in `obs_od_*` (silent corruption, then UniqueViolation)

In `refined_zone.obs_od_month / quarter / semester / year`, the AOM SELECT lists use `GROUP BY 1, 2, 4, 5` referencing `(year, period, territory_1, territory_2)`. Removing the `type` literal shifted positions 4 and 5 onto `territory_2` and `SUM(journeys)`. The AOM aggregation then collapsed all rows with the same `territory_2` (regardless of `territory_1`) into a single group, while the SELECT continued to emit `least(b.aom, c.aom) AS territory_1`. Inserts collided on the unique index:

```
duplicate key value violates unique constraint
"uq_month_date_type_territory_1_territory_2"
DETAIL: Key (month_date, type, territory_1, territory_2)=(2026-03-01, aom, 200052264, 200052264) already exists.
```

### Why `aom` (column) and `'aom'` (literal) are not duplicates

| Identifier | Source | Meaning |
|---|---|---|
| `aom` column | `trusted_zone.perimeters` | 9-digit SIREN identifier of the AOM |
| `'aom'` literal | hardcoded in SELECT | type discriminator for the UNION branch |

Downstream code depends on `type = 'aom'` filtering / joining:
- `refined_zone.obs_journeys_incentives`: `SELECT DISTINCT code FROM trusted_zone.perimeters_agg WHERE type = 'aom'`
- `api/.../IncentiveCampaignsRepositoryProvider.ts`: `LEFT JOIN trusted_zone.perimeters_agg b ON a.type = b.type AND left(a.code,9) = b.code`

## Files changed

- `sqlmesh/models/2_trusted_zone/geo/perimeters_agg.sql` (AOM branch)
- `sqlmesh/models/3_refined_zone/observatoire/od/obs_od_{month,quarter,semester,year}.sql` (AOM classiques + AOM regionales)
- `sqlmesh/models/3_refined_zone/observatoire/directions/obs_directions_day.sql` (AOM classiques + AOM regionales from + AOM regionales to)

## Checklist

- [x] j'ai suivi les guidelines du "clean code"
- [ ] j'ai mis a jour la documentation technique dans `/api/specs` (n/a)
- [ ] ajout ou mise a jour des tests unitaires (n/a)
- [ ] ajout ou mise a jour des tests d'integration (n/a)

## Test plan

- [x] `sqlmesh render` on each touched model -- column counts align, GROUP BY ordinals resolve to `(year, period, territory_1, territory_2)`
- [ ] Production `sqlmesh plan` reaches the virtual layer update without UNION or UniqueViolation errors on `perimeters_agg`, `obs_od_*`, `obs_directions_day`

🤖 Generated with [Claude Code](https://claude.com/claude-code)