### PR TITLE
docs: terms_violation_error ecrase par le batch geo (GEN-602)

### DIFF
--- a/docs/fixes/backfill-terms-violation-status.sql
+++ b/docs/fixes/backfill-terms-violation-status.sql
@@ -1,0 +1,100 @@
+-- =============================================================================
+-- BACKFILL : rétablir acquisition_status = 'terms_violation_error'
+--            sur les trajets dont le statut a été écrasé par le batch géo.
+--
+-- Contexte  : voir docs/fixes/terms-violation-status-clobber.md
+-- Cible     : carpool_v2.status
+-- Volume    : ~213 376 lignes au 2026-06-03
+-- Idempotent: oui (les lignes déjà en terms_violation_error sont exclues)
+--
+-- /!\ NE PAS câbler comme migration auto (api/src/db/migrations).
+--     À exécuter DÉLIBÉRÉMENT, après revue + décision équipe (cf. AVERTISSEMENT).
+-- =============================================================================
+
+-- -----------------------------------------------------------------------------
+-- AVERTISSEMENT (à trancher AVANT exécution)
+-- -----------------------------------------------------------------------------
+-- 1. Effets aval : est-ce que le moteur d'incitations / paiements relit
+--    acquisition_status ? Des trajets passés à tort en 'processed' ont pu être
+--    incités/payés. Repasser en 'terms_violation_error' a posteriori peut créer
+--    des incohérences comptables. Confirmer avec l'équipe métier (IDFM, Karos,
+--    OuestGo cités dans le thread).
+-- 2. Conciliations manuelles : le process manuel « valider + supprimer les
+--    labels » sort ces trajets du périmètre (labels vides => exclus). Restent
+--    donc les « ratés » (statut forcé à OK mais labels non supprimés), qu'on veut
+--    bien repasser en violation. Comportement voulu.
+-- 3. Lancer le backfill APRÈS le déploiement du fix code, pour ne pas ré-écraser.
+--    (Sans risque immédiat : un trajet déjà géocodé n'est plus repris par
+--     findProcessable, mais l'ordre reste la règle de prudence.)
+-- -----------------------------------------------------------------------------
+
+
+-- == 1) DRY RUN : compter le périmètre exact avant de toucher quoi que ce soit ==
+SELECT
+  s.acquisition_status,
+  count(*) AS n
+FROM carpool_v2.status s
+JOIN carpool_v2.terms_violation_error_labels l ON l.carpool_id = s.carpool_id
+WHERE cardinality(l.labels) > 0
+  AND s.acquisition_status <> 'terms_violation_error'
+GROUP BY s.acquisition_status
+ORDER BY n DESC;
+-- Attendu (2026-06-03) : processed = 213376, failed = 1
+
+
+-- == 2) SAUVEGARDE de l'état avant backfill (audit / rollback) ==
+-- Garde une trace des carpool_id touchés et de leur ancien statut.
+CREATE TABLE IF NOT EXISTS carpool_v2._backfill_tve_20260603 AS
+SELECT
+  s.carpool_id,
+  s.acquisition_status AS old_status,
+  now()                AS captured_at
+FROM carpool_v2.status s
+JOIN carpool_v2.terms_violation_error_labels l ON l.carpool_id = s.carpool_id
+WHERE cardinality(l.labels) > 0
+  AND s.acquisition_status = 'processed';   -- on ne backfille QUE depuis 'processed'
+
+
+-- == 3) BACKFILL ==
+-- Option A (recommandée) : une seule transaction. ~213k lignes ciblées,
+-- verrouille uniquement les lignes concernées, suffisamment rapide.
+UPDATE carpool_v2.status s
+SET acquisition_status = 'terms_violation_error'
+FROM carpool_v2.terms_violation_error_labels l
+WHERE l.carpool_id = s.carpool_id
+  AND cardinality(l.labels) > 0
+  AND s.acquisition_status = 'processed';
+-- Note : updated_at se met à jour seul si un trigger l'impose ; sinon ajouter
+--        ", updated_at = now()" ci-dessus selon la convention de la table.
+
+-- Option B (prudence / forte concurrence) : par lots de 10 000, à lancer
+-- en boucle (psql) jusqu'à 0 ligne affectée. Décommenter si besoin.
+-- WITH cte AS (
+--   SELECT s.carpool_id
+--   FROM carpool_v2.status s
+--   JOIN carpool_v2.terms_violation_error_labels l ON l.carpool_id = s.carpool_id
+--   WHERE cardinality(l.labels) > 0
+--     AND s.acquisition_status = 'processed'
+--   LIMIT 10000
+-- )
+-- UPDATE carpool_v2.status s
+-- SET acquisition_status = 'terms_violation_error'
+-- FROM cte
+-- WHERE s.carpool_id = cte.carpool_id;
+
+
+-- == 4) VÉRIFICATION post-backfill ==
+-- Doit renvoyer 0 (plus aucun trajet 'processed' avec label de violation).
+SELECT count(*) AS restant
+FROM carpool_v2.status s
+JOIN carpool_v2.terms_violation_error_labels l ON l.carpool_id = s.carpool_id
+WHERE cardinality(l.labels) > 0
+  AND s.acquisition_status = 'processed';
+
+
+-- == 5) ROLLBACK (si besoin, depuis la sauvegarde) ==
+-- UPDATE carpool_v2.status s
+-- SET acquisition_status = b.old_status
+-- FROM carpool_v2._backfill_tve_20260603 b
+-- WHERE s.carpool_id = b.carpool_id
+--   AND s.acquisition_status = 'terms_violation_error';

--- a/docs/fixes/terms-violation-status-clobber.md
+++ b/docs/fixes/terms-violation-status-clobber.md
@@ -1,0 +1,139 @@
+# Fix : le batch géo écrase `terms_violation_error` en `processed`
+
+## Contexte
+
+Constat équipe (ticket Notion GEN-602) : Metabase n'affiche plus de trajets
+refusés pour `terms_violation_error` depuis ~mars. Hypothèse initiale : la règle
+n'aurait pas été réactivée. **Cette hypothèse est fausse.**
+
+La règle fonctionne : `verifyTermsViolation` détecte bien les violations et écrit
+les labels dans `carpool_v2.terms_violation_error_labels` (labels présents chaque
+mois jusqu'à aujourd'hui). Le problème est en aval : le batch de géocodage
+(`processGeo`) **écrase le statut** d'acquisition.
+
+### Cause racine
+
+1. `registerRequest` détecte une violation -> écrit les labels ET met
+   `acquisition_status = terms_violation_error`. OK.
+2. Plus tard, `processGeo` traite le trajet. `CarpoolGeoRepository.findProcessable`
+   sélectionne les trajets **uniquement** sur l'absence de ligne géo
+   (`cg._id IS NULL`) dans une fenêtre de dates -- **sans filtrer sur
+   `acquisition_status`**.
+3. Après géocodage, `processGeo` appelle
+   `saveAcquisitionStatus(..., Processed)` **sans condition**
+   (`CarpoolAcquisitionService.ts:276-279`). `setStatus`
+   (`CarpoolStatusRepository.ts`) fait un upsert sans garde -> le
+   `terms_violation_error` devient `processed`.
+4. La table des labels n'est jamais modifiée -> divergence labels / statut.
+   Metabase lit la table `status` -> ne voit plus les violations.
+
+Le même défaut existe sur le chemin d'erreur (`processGeo:283` met `Failed`) et
+peut aussi écraser un trajet `canceled` qui n'aurait pas de ligne géo.
+
+### Preuves (prod, 2026-06-03)
+
+- 213 377 trajets ont un label de violation non vide mais un statut autre que
+  `terms_violation_error` (213 376 `processed` + 1 `failed`), depuis 2024-10-06.
+- 213 375 / 213 376 des `processed`-avec-label ont une ligne géo ; les survivants
+  `terms_violation_error` n'en ont pas (géo pas encore passé).
+- Délai label -> statut écrasé = backlog du batch géo (gros bloc < 48 h).
+- Exemple : carpool_id 50397374 (`39a55197-be64-4573-943b-cb10b92498cf`),
+  label `too_close_trips` à 08:30:34, `processed` 35 s plus tard.
+
+Historique : présent depuis l'arrivée de la feature (PR #2637, 2024-10-07).
+Ce n'est pas une régression récente. La PR #2657 a ajouté le flag
+`APP_DISABLE_TERMS_VALIDATION` (non actif en prod, sinon aucun label ne serait
+écrit).
+
+## Objectif
+
+Le géocodage doit continuer (la donnée géo est utile) mais **ne doit jamais
+dégrader** un statut terminal (`terms_violation_error`, `canceled`). Seuls les
+statuts géocodables (`received`, `updated`, `failed`) peuvent passer à
+`processed` / `failed`.
+
+## Implémentation (TDD)
+
+Branche depuis `main`, PR, squash.
+
+### 1. Test rouge d'abord
+
+Fichier : `api/src/pdc/providers/carpool/providers/CarpoolAcquisitionService.integration.spec.ts`
+(harnais existant : `makeLegacyDbBeforeAfter`, stub `GeoProvider`).
+
+Ajouter un cas :
+- enregistrer un trajet qui déclenche une violation (ex. `distance < 1000` ou
+  `expired`) via `registerRequest` -> statut attendu `terms_violation_error`,
+  labels écrits ;
+- stubber `geoService.positionToInsee` pour renvoyer un code INSEE ;
+- appeler `processGeo({ from, to, batchSize })` couvrant le trajet ;
+- **assert** : `acquisition_status` reste `terms_violation_error` ET une ligne
+  `carpool_v2.geo` existe pour le trajet.
+
+Ajouter aussi un cas non-violation : trajet `received` -> après `processGeo` ->
+`processed` (non-régression).
+
+### 2. Garde au niveau du repository
+
+Fichier : `api/src/pdc/providers/carpool/repositories/CarpoolStatusRepository.ts`
+
+Ajouter une méthode dédiée au chemin géo qui ne touche que les statuts
+géocodables (liste blanche) :
+
+```ts
+public async setGeoProcessingStatus(
+  carpool_id: Id,
+  status: CarpoolAcquisitionStatusEnum.Processed | CarpoolAcquisitionStatusEnum.Failed,
+  client?: PoolClient,
+): Promise<void> {
+  const cl = client ?? this.connection.getClient();
+  await cl.query(sql`
+    UPDATE ${raw(this.table)}
+    SET acquisition_status = ${status}
+    WHERE carpool_id = ${carpool_id}
+      AND acquisition_status IN ('received', 'updated', 'failed')
+  `);
+}
+```
+
+Note : la ligne `status` existe toujours à ce stade (créée par
+`registerRequest`), donc un `UPDATE` gardé suffit (pas d'upsert). La liste
+blanche `received|updated|failed` préserve `terms_violation_error` et `canceled`.
+
+### 3. Utiliser la garde dans `processGeo`
+
+Fichier : `api/src/pdc/providers/carpool/providers/CarpoolAcquisitionService.ts`
+(lignes 276-279 et 283-286)
+
+Remplacer les deux `saveAcquisitionStatus({ ..., Processed/Failed })` du bloc
+`processGeo` par `setGeoProcessingStatus(item.carpool_id, ...Processed/Failed)`.
+Ne pas toucher `geoRepository.upsert` (le géocodage doit rester inconditionnel).
+
+Laisser inchangés les `saveAcquisitionStatus` de `registerRequest`,
+`patchCarpool`, `cancelRequest`.
+
+### 4. Vérification
+
+```sh
+# tests ciblés (depuis api/)
+just test api/src/pdc/providers/carpool/providers/CarpoolAcquisitionService.integration.spec.ts
+# ou la commande deno test du repo
+```
+
+Vérif manuelle post-déploiement (lecture prod) : un nouveau trajet avec violation
+doit garder `acquisition_status = terms_violation_error` après passage du batch
+géo, et posséder une ligne `carpool_v2.geo`.
+
+## Données historiques
+
+Les 213 377 trajets déjà écrasés ne sont pas corrigés par ce changement de code.
+Voir `docs/fixes/backfill-terms-violation-status.sql` (à exécuter
+délibérément, **après** décision équipe sur les effets aval -- incitations déjà
+versées, etc.).
+
+## Référence
+
+- Ticket : Notion GEN-602 « Vérification bon fonctionnement
+  aquisition_terms_violation_error »
+- Metabase : Q716 (trajets term violation flaggés processed), Q444 (refus/mois)
+- PR historiques : #2637 (ajout feature), #2657 (flag de désactivation)


### PR DESCRIPTION
## Contexte

Ticket Notion **GEN-602**. Metabase n'affiche plus de trajets refusés pour `terms_violation_error` (~depuis mars). Hypothèse équipe : règle non réactivée. **Réfutée par l'analyse.**

## Cause racine

La règle fonctionne : `verifyTermsViolation` écrit bien les labels et pose `acquisition_status = terms_violation_error` à l'acquisition. Mais le batch géo **écrase le statut** :

- `CarpoolGeoRepository.findProcessable` sélectionne les trajets sur l'absence de ligne géo, **sans filtrer le statut** ;
- `processGeo` appelle `saveAcquisitionStatus(..., Processed)` **sans garde** (`CarpoolAcquisitionService.ts:276-279`), upsert sans condition -> `terms_violation_error` devient `processed`.

La table des labels n'est jamais modifiée -> divergence labels / statut. Metabase lit `status` -> ne voit plus les violations.

## Preuves (prod, 2026-06-03)

- **213 377** trajets avec label de violation mais statut != `terms_violation_error` (213 376 `processed` + 1 `failed`), depuis 2024-10-06.
- 213 375 / 213 376 des `processed`-avec-label ont une ligne géo ; les survivants `terms_violation_error` n'en ont pas.
- Exemple : carpool_id `50397374` (`39a55197-...`), label `too_close_trips` à 08:30:34, `processed` 35 s plus tard.
- Présent depuis la feature (PR #2637). Flag `APP_DISABLE_TERMS_VALIDATION` (PR #2657) non actif en prod.

## Contenu de la PR (docs uniquement)

- `docs/fixes/terms-violation-status-clobber.md` : analyse + plan de correction TDD (garde liste blanche `received|updated|failed` dans `CarpoolStatusRepository`, branchée dans `processGeo`).
- `docs/fixes/backfill-terms-violation-status.sql` : backfill historique idempotent (dry-run, sauvegarde, vérification, rollback), **hors** `migrations/`.

## Suite

- Implémentation du fix code : PR #3204.
- Backfill à exécuter délibérément après décision équipe sur les **effets aval** (incitations/paiements déjà versés).

🤖 Generated with [Claude Code](https://claude.com/claude-code)