### PR TITLE
fix(carpool): le batch geo n'écrase plus terms_violation_error (GEN-602)

### DIFF
--- a/api/src/pdc/providers/carpool/providers/CarpoolAcquisitionService.integration.spec.ts
+++ b/api/src/pdc/providers/carpool/providers/CarpoolAcquisitionService.integration.spec.ts
@@ -356,4 +356,70 @@ describe("CarpoolAcquisitionService", () => {
       ],
     );
   });
+
+  it("Should keep terms_violation_error status when geo batch processes the carpool", async () => {
+    const service = getService({});
+
+    const data = {
+      ...insertableCarpool,
+      operator_journey_id: "tve_geo_guard",
+      distance: 100, // triggers distance_too_short
+    };
+
+    const res = await service.registerRequest({ ...data, api_version: "3" });
+    assert(res.terms_violation_error_labels.includes("distance_too_short"));
+
+    const before = await statusRepository.getStatusByOperatorJourneyId(
+      data.operator_id,
+      data.operator_journey_id,
+    );
+    assertEquals(before?.acquisition_status, "terms_violation_error");
+
+    // The geo batch must geocode the carpool WITHOUT downgrading its status.
+    await service.processGeo({
+      batchSize: 1000,
+      from: new Date(Date.now() - 86_400_000),
+      to: new Date(Date.now() + 86_400_000),
+      failedOnly: false,
+    });
+
+    const after = await statusRepository.getStatusByOperatorJourneyId(
+      data.operator_id,
+      data.operator_journey_id,
+    );
+    assertEquals(after?.acquisition_status, "terms_violation_error");
+  });
+
+  it("Should move a received carpool to processed when geo batch runs", async () => {
+    const service = getService({});
+
+    const data = {
+      ...insertableCarpool,
+      operator_journey_id: "geo_no_violation",
+      driver_identity_key: "2".repeat(64),
+      passenger_identity_key: "3".repeat(64),
+    };
+
+    const res = await service.registerRequest({ ...data, api_version: "3" });
+    assertEquals(res.terms_violation_error_labels, []);
+
+    const before = await statusRepository.getStatusByOperatorJourneyId(
+      data.operator_id,
+      data.operator_journey_id,
+    );
+    assertEquals(before?.acquisition_status, "received");
+
+    await service.processGeo({
+      batchSize: 1000,
+      from: new Date(Date.now() - 86_400_000),
+      to: new Date(Date.now() + 86_400_000),
+      failedOnly: false,
+    });
+
+    const after = await statusRepository.getStatusByOperatorJourneyId(
+      data.operator_id,
+      data.operator_journey_id,
+    );
+    assertEquals(after?.acquisition_status, "processed");
+  });
 });

--- a/api/src/pdc/providers/carpool/providers/CarpoolAcquisitionService.ts
+++ b/api/src/pdc/providers/carpool/providers/CarpoolAcquisitionService.ts
@@ -273,17 +273,19 @@ export class CarpoolAcquisitionService {
             end_geo_code: end,
           }, conn);
 
-          await this.statusRepository.saveAcquisitionStatus({
-            carpool_id: item.carpool_id,
-            status: CarpoolAcquisitionStatusEnum.Processed,
-          }, conn);
+          await this.statusRepository.setGeoProcessingStatus(
+            item.carpool_id,
+            CarpoolAcquisitionStatusEnum.Processed,
+            conn,
+          );
           await conn.query("COMMIT");
         } catch (e) {
           await conn.query("ROLLBACK");
-          await this.statusRepository.saveAcquisitionStatus({
-            carpool_id: item.carpool_id,
-            status: CarpoolAcquisitionStatusEnum.Failed,
-          }, conn);
+          await this.statusRepository.setGeoProcessingStatus(
+            item.carpool_id,
+            CarpoolAcquisitionStatusEnum.Failed,
+            conn,
+          );
 
           await this.geoRepository.upsert({
             carpool_id: item.carpool_id,

--- a/api/src/pdc/providers/carpool/repositories/CarpoolStatusRepository.ts
+++ b/api/src/pdc/providers/carpool/repositories/CarpoolStatusRepository.ts
@@ -1,7 +1,7 @@
 import { provider } from "@/ilos/common/index.ts";
 import { LegacyPostgresConnection, PoolClient } from "@/ilos/connection-postgres/index.ts";
 import sql, { join, raw } from "@/lib/pg/sql.ts";
-import { CarpoolFraudStatusEnum } from "@/pdc/providers/carpool/interfaces/common.ts";
+import { CarpoolAcquisitionStatusEnum, CarpoolFraudStatusEnum } from "@/pdc/providers/carpool/interfaces/common.ts";
 import { CarpoolStatus } from "../interfaces/database/label.ts";
 import { Id, InsertableCarpoolAcquisitionStatus } from "../interfaces/index.ts";
 
@@ -15,6 +15,26 @@ export class CarpoolStatusRepository {
 
   public async saveAcquisitionStatus(data: InsertableCarpoolAcquisitionStatus, client?: PoolClient): Promise<void> {
     await this.setStatus(data.carpool_id, "acquisition", data.status, client);
+  }
+
+  /**
+   * Advance the acquisition status after geo encoding WITHOUT downgrading a
+   * terminal status. The geo batch (processGeo) must geocode every carpool but
+   * must never overwrite a `terms_violation_error` (or `canceled`) status with
+   * `processed`/`failed`. Only geocodable statuses are eligible.
+   */
+  public async setGeoProcessingStatus(
+    carpool_id: Id,
+    status: CarpoolAcquisitionStatusEnum.Processed | CarpoolAcquisitionStatusEnum.Failed,
+    client?: PoolClient,
+  ): Promise<void> {
+    const cl = client ?? this.connection.getClient();
+    await cl.query(sql`
+      UPDATE ${raw(this.table)}
+      SET acquisition_status = ${status}
+      WHERE carpool_id = ${carpool_id}
+        AND acquisition_status IN ('received', 'updated', 'failed')
+    `);
   }
 
   public async saveFraudStatus(carpool_id: Id, status: CarpoolFraudStatusEnum, client?: PoolClient): Promise<void> {


### PR DESCRIPTION
## Problème

Ticket **GEN-602**. Metabase n'affiche plus de trajets refusés pour `terms_violation_error`. La règle de détection fonctionne (labels écrits en continu), mais `processGeo` **écrasait le statut**.

`processGeo` posait `acquisition_status = 'processed'` (ou `'failed'` sur erreur) **sans condition** après le géocodage -> le `terms_violation_error` posé à l'acquisition était ramené à `processed`. La table des labels n'étant jamais modifiée, on observait la divergence labels / statut (213 377 trajets en prod, cf. analyse PR #3203).

## Correctif

- `CarpoolStatusRepository.setGeoProcessingStatus(carpool_id, status, client)` : `UPDATE` gardé par **liste blanche** `received | updated | failed`. Préserve les statuts terminaux (`terms_violation_error`, `canceled` -- ce dernier était aussi exposé sur le chemin d'erreur).
- `processGeo` utilise cette méthode pour les deux transitions (`Processed` et `Failed`). Le géocodage (`geoRepository.upsert`) reste **inconditionnel** : la donnée géo est toujours écrite.

## Tests (TDD, intégration)

`CarpoolAcquisitionService.integration.spec.ts` :
- **rouge -> vert** : un trajet en violation garde `terms_violation_error` après `processGeo` (avant le fix : `processed`) ;
- **non-régression** : un trajet sans violation passe bien `received -> processed`.

Suite existante verte (9 steps), `CarpoolStatusRepository.integration.spec.ts` vert, `deno fmt`/`lint` OK sur les fichiers de prod.

## Suite

Les ~213 376 trajets historiques restent à corriger via le backfill (`docs/fixes/backfill-terms-violation-status.sql`, PR #3203), **à exécuter après décision équipe** sur les effets aval (incitations/paiements déjà versés).

Refs #3203.