### PR TITLE
feat(apdf): ajoute la colonne passenger_contribution à l'export IDFM

### DIFF
--- a/api/src/pdc/services/apdf/helpers/normalizeAPDFData.helper.ts
+++ b/api/src/pdc/services/apdf/helpers/normalizeAPDFData.helper.ts
@@ -54,6 +54,9 @@ export function normalize(src: APDFTripInterface, config: ExcelCampaignConfig): 
 
     // incentives in euros
     rpc_incentive: src.rpc_incentive / 100,
+
+    // passenger contribution in euros
+    passenger_contribution: src.passenger_contribution == null ? null : src.passenger_contribution / 100,
   };
 
   return data;

--- a/api/src/pdc/services/apdf/helpers/normalizeAPDFData.unit.spec.ts
+++ b/api/src/pdc/services/apdf/helpers/normalizeAPDFData.unit.spec.ts
@@ -1,0 +1,49 @@
+import { assertEquals } from "dep:assert";
+import { describe, it } from "dep:testing-bdd";
+import { ExcelCampaignConfig } from "../interfaces/ExcelTypes.ts";
+import { APDFTripInterface } from "../interfaces/APDFTripInterface.ts";
+import { normalize } from "./normalizeAPDFData.helper.ts";
+
+describe("normalizeAPDFData", () => {
+  const config: ExcelCampaignConfig = {
+    tz: "Europe/Paris",
+    booster_dates: new Set<string>(),
+    extras: {},
+  };
+
+  function fakeTrip(overrides: Partial<APDFTripInterface> = {}): APDFTripInterface {
+    return {
+      distance: 1000,
+      driver_operator_user_id: "driver",
+      duration: 600,
+      end_datetime: "2024-01-15T08:30:00+01:00",
+      end_epci: "end_epci",
+      end_insee: "75056",
+      end_location: "Paris",
+      incentive_type: "normale",
+      operator_class: "C",
+      operator_journey_id: "ojid",
+      operator_trip_id: "otid",
+      operator: "Operator",
+      passenger_contribution: 180,
+      passenger_operator_user_id: "passenger",
+      rpc_incentive: 200,
+      rpc_journey_id: "rjid",
+      start_datetime: "2024-01-15T08:00:00+01:00",
+      start_epci: "start_epci",
+      start_insee: "75056",
+      start_location: "Paris",
+      ...overrides,
+    };
+  }
+
+  it("converts passenger_contribution from cents to euros", () => {
+    const result = normalize(fakeTrip({ passenger_contribution: 180 }), config);
+    assertEquals(result.passenger_contribution, 1.8);
+  });
+
+  it("keeps null passenger_contribution as null", () => {
+    const result = normalize(fakeTrip({ passenger_contribution: null }), config);
+    assertEquals(result.passenger_contribution, null);
+  });
+});

--- a/api/src/pdc/services/apdf/interfaces/APDFTripInterface.ts
+++ b/api/src/pdc/services/apdf/interfaces/APDFTripInterface.ts
@@ -11,6 +11,7 @@ export interface APDFTripInterface {
   operator_journey_id: string;
   operator_trip_id: string;
   operator: string;
+  passenger_contribution: number | null;
   passenger_operator_user_id: string;
   rpc_incentive: number;
   rpc_journey_id: string;

--- a/api/src/pdc/services/apdf/providers/DataRepositoryProvider.ts
+++ b/api/src/pdc/services/apdf/providers/DataRepositoryProvider.ts
@@ -171,6 +171,7 @@ export class DataRepositoryProvider implements DataRepositoryInterface {
 
         cc.driver_operator_user_id,
         cc.passenger_operator_user_id,
+        cc.passenger_contribution,
 
         pi.amount as rpc_incentive,
 

--- a/api/src/pdc/services/apdf/providers/excel/SlicesWorksheetWriter.ts
+++ b/api/src/pdc/services/apdf/providers/excel/SlicesWorksheetWriter.ts
@@ -12,12 +12,14 @@ export class SlicesWorksheetWriter extends AbstractWorksheetWriter {
     "Incitations RPC",
     "Tous les trajets",
     "Trajets incités",
+    "Contribution passagers",
   ];
   public readonly COLUMN_HEADERS_BOOSTER = [
     'Tranche "période booster"',
     "Incitations RPC",
     "Tous les trajets",
     "Trajets incités",
+    "Contribution passagers",
   ];
 
   async call(
@@ -47,6 +49,9 @@ export class SlicesWorksheetWriter extends AbstractWorksheetWriter {
     ws.getColumn("C").font = font;
     ws.getColumn("D").width = 20;
     ws.getColumn("D").font = font;
+    ws.getColumn("E").width = 20;
+    ws.getColumn("E").font = font;
+    ws.getColumn("E").numFmt = "# ##0.00€";
 
     // --------------------------------------------------------------------------------
     // Data
@@ -140,6 +145,10 @@ export class SlicesWorksheetWriter extends AbstractWorksheetWriter {
     ws.getCell("A40").value = "incentive_type";
     ws.mergeCells("B40:D40");
     ws.getCell("B40").value = "Type d'incitation (normale ou booster)";
+
+    ws.getCell("A41").value = "passenger_contribution";
+    ws.mergeCells("B41:D41");
+    ws.getCell("B41").value = "Contribution financière du passager en euros";
 
     // --------------------------------------------------------------------------------
     // Rules
@@ -256,6 +265,7 @@ export class SlicesWorksheetWriter extends AbstractWorksheetWriter {
     // S : incentive_type
     // M : distance
     // R : rpc_incentive
+    // T : passenger_contribution
     for (const s of slices) {
       const { start, end } = s.slice;
       const mode_criteria = `Trajets!S:S,"${mode}"`;
@@ -275,6 +285,10 @@ export class SlicesWorksheetWriter extends AbstractWorksheetWriter {
         {
           date1904: false,
           formula: `COUNTIFS(Trajets!R:R,">0",${mode_criteria},${slice_criteria})`,
+        },
+        {
+          date1904: false,
+          formula: `SUMIFS(Trajets!T:T,${mode_criteria},${slice_criteria})`,
         },
       ]);
       r.height = 20;
@@ -301,6 +315,11 @@ export class SlicesWorksheetWriter extends AbstractWorksheetWriter {
       date1904: false,
     };
     ws.getCell(`D${last + 1}`).border = border;
+    ws.getCell(`E${last + 1}`).value = {
+      formula: `SUM(E${first}:E${last})`,
+      date1904: false,
+    };
+    ws.getCell(`E${last + 1}`).border = border;
   }
 
   private pad(ws: excel.Worksheet, n: number): void {

--- a/api/src/pdc/services/apdf/providers/excel/TripsWorksheetWriter.ts
+++ b/api/src/pdc/services/apdf/providers/excel/TripsWorksheetWriter.ts
@@ -32,6 +32,7 @@ export class TripsWorksheetWriter extends AbstractWorksheetWriter {
     "passenger_operator_user_id",
     "rpc_incentive",
     "incentive_type",
+    "passenger_contribution",
   ].map((header) => ({ header, key: header }));
 
   async call(
@@ -67,6 +68,7 @@ export class TripsWorksheetWriter extends AbstractWorksheetWriter {
       Q: { width: 29, font },
       R: { width: 12, font },
       S: { width: 12, font },
+      T: { width: 12, font },
     };
 
     Object.entries(columns).forEach(([key, value]) => {


### PR DESCRIPTION
Ref GEN-594

## Description

Ajout de la contribution financière du passager (`passenger_contribution`) dans l'export APDF d'IDFM.

- **Onglet « Trajets »** : nouvelle colonne `passenger_contribution`, convertie de centimes en euros comme `rpc_incentive`.
- **Onglet « Synthèse par tranche »** : nouvelle colonne « Contribution passagers » présentant la somme des contributions par tranche de distance, avec le total en bas de tableau.
- Mise à jour de la requête du curseur (`DataRepositoryProvider`), de l'interface `APDFTripInterface` et de la normalisation.
- Ajout d'une définition de champ dans la documentation de l'onglet de synthèse.

### Note sur le placement

Le ticket prévoyait la colonne *entre* `passenger_operator_user_id` et `rpc_incentive`. Après arbitrage, elle est placée **en fin de tableau** (colonne T). Ce choix évite de décaler les références de colonnes (`R` = rpc_incentive, `S` = incentive_type) utilisées par les formules `SUMIFS`/`COUNTIFS` de l'onglet de synthèse.

## Checklist

- [x] [j'ai suivi les guidelines du "clean code"](https://gist.github.com/wojteklu/73c6914cc446146b8b533c0988cf8d29)
- [ ] j'ai mis à jour la documentation technique dans `/api/specs` (aucune colonne APDF n'y est listée ; documentation publique bump.sh à compléter séparément si besoin)
- [x] ajout ou mise à jour des tests unitaires
- [ ] ajout ou mise à jour des tests d'intégration
