### PR TITLE
revert: #3208 export API cutover to dbt views

### DIFF
--- a/api/src/pdc/services/export/repositories/queries/carpoolCountQuery.ts
+++ b/api/src/pdc/services/export/repositories/queries/carpoolCountQuery.ts
@@ -2,7 +2,7 @@ import sql, { raw, Sql } from "@/lib/pg/sql.ts";
 import { ExportParams } from "@/pdc/services/export/models/ExportParams.ts";
 
 export function carpoolCountQuery(params: ExportParams): Sql {
-  const table = "dbt_exposed.export_partners";
+  const table = "refined_zone.export_carpool_list";
   const { start_at, end_at } = params.get();
   const geo_selectors = params.geoToSQL();
   const operator_id = params.operatorToSQL();

--- a/api/src/pdc/services/export/repositories/queries/carpoolListQuery.ts
+++ b/api/src/pdc/services/export/repositories/queries/carpoolListQuery.ts
@@ -97,7 +97,7 @@ export type CarpoolListType = {
 };
 
 export function carpoolListQuery(params: ExportParams): Sql {
-  const table = "dbt_exposed.export_partners";
+  const table = "refined_zone.export_carpool_list";
   const { start_at, end_at } = params.get();
   const geo_selectors = params.geoToSQL();
   const operator_id = params.operatorToSQL();

--- a/api/src/pdc/services/export/repositories/queries/datagouvListQuery.ts
+++ b/api/src/pdc/services/export/repositories/queries/datagouvListQuery.ts
@@ -36,7 +36,7 @@ export type DataGouvListType = {
 };
 
 export function datagouvListQuery(params: ExportParams, config: DataGouvQueryConfig): Sql {
-  const table = "dbt_exposed.export_opendata";
+  const table = "refined_zone.export_opendata_list";
   const { start_at, end_at } = params.get();
   const { min_occurrences } = config;
 

--- a/sqlmesh/models/3_refined_zone/export/export_carpool_list.sql
+++ b/sqlmesh/models/3_refined_zone/export/export_carpool_list.sql
@@ -1,0 +1,145 @@
+MODEL (
+  name refined_zone.export_carpool_list,
+  kind VIEW,
+  tags ['refined', 'export'],
+);
+
+WITH latest_perimeters AS (
+  SELECT DISTINCT ON (arr)
+    arr,
+    com,
+    dep,
+    l_dep,
+    epci,
+    l_epci,
+    aom,
+    l_aom,
+    reg,
+    l_reg,
+    country,
+    CASE WHEN arr <> country THEN l_arr    ELSE NULL  END AS l_arr,
+    CASE WHEN arr <> country THEN l_country ELSE l_arr END AS l_country,
+    CASE
+      WHEN surface > 0 AND (pop::float / (surface / 100.0)) > 40 THEN 3
+      ELSE 2
+    END AS precision
+  FROM trusted_zone.perimeters
+  ORDER BY arr, year DESC
+)
+
+SELECT
+  j.legacy_id                                                    AS journey_id,
+  j.operator_trip_id,
+  j.operator_journey_id,
+  j.operator_class,
+  j.acquisition_status,
+  j.fraud_status,
+  j.anomaly_status,
+  j.operator_id,
+
+  -- date filtering column (raw DATE in Europe/Paris)
+  j.start_datetime_tz::date                                     AS start_date_filter,
+
+  -- formatted dates (rounded to 10 min, Europe/Paris)
+  to_char(ts_ceil(j.start_datetime_tz, 600), 'YYYY-MM-DD HH24:MI:SS') AS start_datetime,
+  to_char(ts_ceil(j.start_datetime_tz, 600), 'YYYY-MM-DD')            AS start_date,
+  to_char(ts_ceil(j.start_datetime_tz, 600), 'HH24:MI:SS')            AS start_time,
+  to_char(ts_ceil(j.end_datetime_tz,   600), 'YYYY-MM-DD HH24:MI:SS') AS end_datetime,
+  to_char(ts_ceil(j.end_datetime_tz,   600), 'YYYY-MM-DD')            AS end_date,
+  to_char(ts_ceil(j.end_datetime_tz,   600), 'HH24:MI:SS')            AS end_time,
+  to_char((j.duration || ' seconds')::interval, 'HH24:MI:SS')   AS duration,
+
+  j.distance::float / 1000                                       AS distance,
+
+  TRUNC(ST_Y(j.start_position)::numeric, gps.precision)         AS start_lat,
+  TRUNC(ST_X(j.start_position)::numeric, gps.precision)         AS start_lon,
+  TRUNC(ST_Y(j.end_position)::numeric,   gpe.precision)         AS end_lat,
+  TRUNC(ST_X(j.end_position)::numeric,   gpe.precision)         AS end_lon,
+
+  j.start_geo_code                                               AS start_insee,
+  gps.arr                                                        AS start_arr,
+  gps.com                                                        AS start_com,
+  gps.dep                                                        AS start_dep,
+  gps.epci                                                       AS start_epci_code,
+  gps.aom                                                        AS start_aom_code,
+  gps.reg                                                        AS start_reg,
+  gps.country                                                    AS start_country,
+
+  j.end_geo_code                                                 AS end_insee,
+  gpe.arr                                                        AS end_arr,
+  gpe.com                                                        AS end_com,
+  gpe.dep                                                        AS end_dep,
+  gpe.epci                                                       AS end_epci_code,
+  gpe.aom                                                        AS end_aom_code,
+  gpe.reg                                                        AS end_reg,
+  gpe.country                                                    AS end_country,
+
+  gps.l_arr                                                      AS start_commune,
+  gps.l_dep                                                      AS start_departement,
+  gps.l_epci                                                     AS start_epci,
+  gps.l_aom                                                      AS start_aom,
+  gps.l_reg                                                      AS start_region,
+  gps.l_country                                                  AS start_pays,
+
+  gpe.l_arr                                                      AS end_commune,
+  gpe.l_dep                                                      AS end_departement,
+  gpe.l_epci                                                     AS end_epci,
+  gpe.l_aom                                                      AS end_aom,
+  gpe.l_reg                                                      AS end_region,
+  gpe.l_country                                                  AS end_pays,
+
+  j.operator_name                                                AS operator,
+  j.passenger_operator_user_id                                   AS operator_passenger_id,
+  j.passenger_identity_key,
+  j.driver_operator_user_id                                      AS operator_driver_id,
+  j.driver_identity_key,
+
+  j.driver_revenue::float / 100                                  AS driver_revenue,
+  j.passenger_contribution::float / 100                          AS passenger_contribution,
+  j.passenger_seats,
+
+  cee.cee_application_id IS NOT NULL                              AS cee_application,
+
+  -- operator incentives (spread from JSONB array)
+  j.operator_incentives[0]->>'siret'                             AS incentive_0_siret,
+  j.operator_incentives[0]->>'name'                              AS incentive_0_name,
+  j.operator_incentives[0]->>'amount'                            AS incentive_0_amount,
+
+  j.operator_incentives[1]->>'siret'                             AS incentive_1_siret,
+  j.operator_incentives[1]->>'name'                              AS incentive_1_name,
+  j.operator_incentives[1]->>'amount'                            AS incentive_1_amount,
+
+  j.operator_incentives[2]->>'siret'                             AS incentive_2_siret,
+  j.operator_incentives[2]->>'name'                              AS incentive_2_name,
+  j.operator_incentives[2]->>'amount'                            AS incentive_2_amount,
+
+  -- RPC incentives (spread from JSONB array)
+  j.campaigns[0]->>'campaign_id'                       AS incentive_rpc_0_campaign_id,
+  j.campaigns[0]->>'campaign_name'                     AS incentive_rpc_0_campaign_name,
+  j.campaigns[0]->>'siret'                             AS incentive_rpc_0_siret,
+  j.campaigns[0]->>'name'                              AS incentive_rpc_0_name,
+  j.campaigns[0]->>'amount'                            AS incentive_rpc_0_amount,
+
+  j.campaigns[1]->>'campaign_id'                       AS incentive_rpc_1_campaign_id,
+  j.campaigns[1]->>'campaign_name'                     AS incentive_rpc_1_campaign_name,
+  j.campaigns[1]->>'siret'                             AS incentive_rpc_1_siret,
+  j.campaigns[1]->>'name'                              AS incentive_rpc_1_name,
+  j.campaigns[1]->>'amount'                            AS incentive_rpc_1_amount,
+
+  j.campaigns[2]->>'campaign_id'                       AS incentive_rpc_2_campaign_id,
+  j.campaigns[2]->>'campaign_name'                     AS incentive_rpc_2_campaign_name,
+  j.campaigns[2]->>'siret'                             AS incentive_rpc_2_siret,
+  j.campaigns[2]->>'name'                              AS incentive_rpc_2_name,
+  j.campaigns[2]->>'amount'                            AS incentive_rpc_2_amount,
+
+  -- offer (placeholders)
+  TRUE                                                           AS offer_public,
+  j.start_datetime                                               AS offer_accepted_at
+
+FROM trusted_zone.journeys j
+
+LEFT JOIN latest_perimeters gps ON j.start_geo_code = gps.arr
+LEFT JOIN latest_perimeters gpe ON j.end_geo_code   = gpe.arr
+LEFT JOIN trusted_zone.cee_grouped_journeys cee ON cee.carpool_v2_id = j._id
+
+WHERE j.valid_acquisition_status = TRUE

--- a/sqlmesh/models/3_refined_zone/export/export_opendata_list.sql
+++ b/sqlmesh/models/3_refined_zone/export/export_opendata_list.sql
@@ -1,0 +1,73 @@
+MODEL (
+  name refined_zone.export_opendata_list,
+  kind VIEW,
+  tags ['refined', 'export', 'opendata'],
+);
+
+WITH latest_perimeters AS (
+  SELECT DISTINCT ON (arr)
+    arr,
+    dep,
+    country,
+    CASE WHEN arr <> country THEN l_arr    ELSE NULL  END AS l_arr,
+    l_epci,
+    CASE WHEN arr <> country THEN l_country ELSE l_arr END AS l_country,
+    CASE
+      WHEN surface > 0 AND (pop::float / (surface / 100.0)) > 40 THEN 3
+      ELSE 2
+    END AS precision
+  FROM trusted_zone.perimeters
+  ORDER BY arr, year DESC
+)
+
+SELECT
+  j.legacy_id                                                              AS journey_id,
+  COALESCE(j.operator_trip_id::text, gen_random_uuid()::text)              AS trip_id,
+
+  -- date filtering column (raw DATE in Europe/Paris)
+  (j.start_datetime AT TIME ZONE 'Europe/Paris')::date                     AS start_date_filter,
+
+  -- start
+  to_char(ts_ceil(j.start_datetime_tz, 600) AT TIME ZONE 'Europe/Paris', 'YYYY-MM-DD HH24:MI:SS') AS journey_start_datetime,
+  to_char(ts_ceil(j.start_datetime_tz, 600) AT TIME ZONE 'Europe/Paris', 'YYYY-MM-DD') AS journey_start_date,
+  to_char(ts_ceil(j.start_datetime_tz, 600) AT TIME ZONE 'Europe/Paris', 'HH24:MI:SS') AS journey_start_time,
+  TRUNC(ST_X(j.start_position)::numeric, gps.precision)                    AS journey_start_lon,
+  TRUNC(ST_Y(j.start_position)::numeric, gps.precision)                    AS journey_start_lat,
+  gps.arr                                                                  AS journey_start_insee,
+  gps.dep                                                                  AS journey_start_department,
+  gps.l_arr                                                                AS journey_start_town,
+  gps.l_epci                                                               AS journey_start_towngroup,
+  gps.l_country                                                            AS journey_start_country,
+
+  -- end
+  to_char(ts_ceil(j.end_datetime_tz, 600) AT TIME ZONE 'Europe/Paris', 'YYYY-MM-DD HH24:MI:SS') AS journey_end_datetime,
+  to_char(ts_ceil(j.end_datetime_tz, 600) AT TIME ZONE 'Europe/Paris', 'YYYY-MM-DD') AS journey_end_date,
+  to_char(ts_ceil(j.end_datetime_tz, 600) AT TIME ZONE 'Europe/Paris', 'HH24:MI:SS') AS journey_end_time,
+  TRUNC(ST_X(j.end_position)::numeric, gpe.precision)                      AS journey_end_lon,
+  TRUNC(ST_Y(j.end_position)::numeric, gpe.precision)                      AS journey_end_lat,
+  gpe.arr                                                                  AS journey_end_insee,
+  gpe.dep                                                                  AS journey_end_department,
+  gpe.l_arr                                                                AS journey_end_town,
+  gpe.l_epci                                                               AS journey_end_towngroup,
+  gpe.l_country                                                            AS journey_end_country,
+
+  j.passenger_seats,
+  j.operator_class,
+  j.distance                                                               AS journey_distance,
+  ROUND(j.duration / 60.0)                                                 AS journey_duration,
+
+  EXISTS (
+    SELECT 1 FROM trusted_zone.campaigns ci
+    WHERE ci.carpool_v2_id = j._id AND ci.status = 'validated'
+  )                                                                        AS has_incentive,
+
+  -- INSEE occurrence counts (for filtering by API)
+  ic.start_insee_count,
+  ic.end_insee_count
+
+FROM trusted_zone.journeys j
+JOIN trusted_zone.insee_counters ic ON j._id = ic._id
+LEFT JOIN latest_perimeters gps ON j.start_geo_code = gps.arr
+LEFT JOIN latest_perimeters gpe ON j.end_geo_code   = gpe.arr
+
+WHERE j.valid_acquisition_status = TRUE


### PR DESCRIPTION
## Objectif

Revert de #3208 (commit `e567d98be`).

PR #3208 avait bascule le service d'export de l'API des vues sqlmesh `refined_zone` vers les vues dbt `dbt_exposed`, puis supprime les modeles sqlmesh correspondants. Ce revert annule ces changements.

## Modifications

- **API** : les requetes d'export repointent vers `refined_zone` :
  - `carpoolListQuery.ts` / `carpoolCountQuery.ts` -> `refined_zone.export_carpool_list`
  - `datagouvListQuery.ts` -> `refined_zone.export_opendata_list`
- **sqlmesh** : restauration de `export_carpool_list.sql` et `export_opendata_list.sql` sous `models/3_refined_zone/export/`.

5 fichiers, +221 / -3 (inverse exact de #3208).

## Prerequis de deploiement

L'API d'export lit de nouveau les vues sqlmesh `refined_zone`. Si ces vues ont deja ete retirees de l'entrepot deploye, elles doivent etre redeployees (`sqlmesh plan`) avant que ce revert ne prenne du trafic.

Reverts #3208

Generated with Claude Code