### PR TITLE
fix(export): abort data.gouv export when dataset empty

### DIFF
--- a/api/src/pdc/services/export/commands/DataGouvCommand.ts
+++ b/api/src/pdc/services/export/commands/DataGouvCommand.ts
@@ -13,6 +13,7 @@ import { NotificationService } from "@/pdc/services/export/services/Notification
 import { StorageService } from "@/pdc/services/export/services/StorageService.ts";
 import { ExportRepositoryInterfaceResolver } from "../repositories/ExportRepository.ts";
 import { DataGouvListType } from "../repositories/queries/datagouvListQuery.ts";
+import { DataGouvStatsType } from "../repositories/queries/datagouvStatsQuery.ts";
 import { DataGouvFileCreatorServiceInterfaceResolver } from "../services/DataGouvFileCreatorService.ts";
 import { FieldServiceInterfaceResolver } from "../services/FieldService.ts";
 import { LogServiceInterfaceResolver } from "../services/LogService.ts";
@@ -27,6 +28,24 @@ export type Options = {
 function defaultDate(offset = 0): Date {
   const now = today();
   return new Date(now.getFullYear(), now.getMonth() + offset, 1);
+}
+
+/**
+ * Guard against publishing an empty dataset on data.gouv.fr.
+ *
+ * The export depends on trusted_zone.insee_counters (sqlmesh @monthly model
+ * that withholds the current month until it is complete). If the export runs
+ * before that month is materialised, the INNER JOIN yields zero rows and we
+ * would otherwise upload an empty file. Abort loudly instead.
+ */
+export function assertDatagouvNotEmpty(stats: DataGouvStatsType, filename: string): void {
+  if (Number(stats?.count_exposed) >= 1) return;
+
+  throw new Error(
+    `[export:datagouv] Refusing to upload empty dataset ${filename} ` +
+      `(count_exposed=${stats?.count_exposed ?? 0}, count_total=${stats?.count_total ?? 0}). ` +
+      `Upstream data likely not ready (trusted_zone.insee_counters @monthly).`,
+  );
 }
 
 @command({
@@ -100,6 +119,7 @@ export class DataGouvCommand implements CommandInterface {
       // generate dataset description
       logger.info(`Generating metadata for ${filename}`);
       const stats = await this.carpoolRepository.datagouvStats(params);
+      assertDatagouvNotEmpty(stats, filename);
       const description = this.metadata.description(stats);
 
       // upload to storage

--- a/api/src/pdc/services/export/commands/DataGouvCommand.unit.spec.ts
+++ b/api/src/pdc/services/export/commands/DataGouvCommand.unit.spec.ts
@@ -1,0 +1,36 @@
+import { assertThrows } from "dep:assert";
+import { describe, it } from "dep:testing-bdd";
+import { DataGouvStatsType } from "../repositories/queries/datagouvStatsQuery.ts";
+import { assertDatagouvNotEmpty } from "./DataGouvCommand.ts";
+
+describe("assertDatagouvNotEmpty", () => {
+  function fakeStats(overrides: Partial<DataGouvStatsType> = {}): DataGouvStatsType {
+    return {
+      start_at: new Date("2025-05-01"),
+      end_at: new Date("2025-06-01"),
+      count_total: 100,
+      count_exposed: 100,
+      count_removed: 0,
+      count_removed_start: 0,
+      count_removed_end: 0,
+      count_removed_both: 0,
+      ...overrides,
+    };
+  }
+
+  it("throws when no rows are exposed (upstream data not ready)", () => {
+    assertThrows(() => assertDatagouvNotEmpty(fakeStats({ count_total: 0, count_exposed: 0 }), "f.csv"));
+  });
+
+  it("throws when total exists but everything is filtered out", () => {
+    assertThrows(() => assertDatagouvNotEmpty(fakeStats({ count_total: 50, count_exposed: 0 }), "f.csv"));
+  });
+
+  it("throws when count comes back as a string '0' (pg numeric)", () => {
+    assertThrows(() => assertDatagouvNotEmpty(fakeStats({ count_exposed: "0" as unknown as number }), "f.csv"));
+  });
+
+  it("does not throw when rows are exposed", () => {
+    assertDatagouvNotEmpty(fakeStats({ count_exposed: 1 }), "f.csv");
+  });
+});


### PR DESCRIPTION
## Problem

The data.gouv.fr opendata export of 2 June (covering May) was **empty**.

Root cause is a **scheduling race**, not a code logic bug:

- `refined_zone.export_opendata_list` (the view the export reads) `INNER JOIN`s `trusted_zone.insee_counters`.
- `insee_counters` is a sqlmesh `INCREMENTAL_BY_TIME_RANGE` model with `cron '@monthly'` that **deliberately withholds the current partial month** (so its per-month `COUNT(*) OVER (...)` is correct).
- A given month's rows only materialise once the sqlmesh `@monthly` run fires on/after the 1st of the next month.
- `journeys` (`@daily`) already had May, but `insee_counters` did not yet. The export ran before the monthly run -> INNER JOIN dropped every May row -> **empty CSV uploaded to data.gouv.fr**.

The API export cron and the sqlmesh/datalake cron (separate infra repo) have no ordering guarantee. Nothing failed loudly: the command uploaded whatever the cursor yielded, even 0 rows.

## Fix (this PR)

Minimal safety net: `assertDatagouvNotEmpty(stats, filename)` aborts the command before upload when no rows are exposed, instead of publishing an empty resource. The thrown error makes the job fail visibly.

Complementary actions handled separately:
1. Re-run the export for May now that the data is present.
2. Order the schedule so the API export runs after the sqlmesh monthly `insee_counters` run.

## Tests

`DataGouvCommand.unit.spec.ts` covers the guard (zero total, all-filtered-out, pg string `"0"`, and the happy path). `deno test` green; `deno lint`/`deno fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)