### PR TITLE
chore(ci): harden release flow and changelog generation

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,42 @@
+name: PR Title
+
+# Squash-merge means the PR title becomes the commit subject, which feeds
+# semantic-release. Enforce Conventional Commits on the title so every merge
+# produces a clean, parseable changelog line and the correct version bump.
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  pull-requests: read
+
+concurrency:
+  group: pr-title-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    name: (chore) validate title
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate Conventional Commit title
+        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Validate the type only. Scope is free-form on purpose: the repo uses
+          # many domain scopes (apdf, carpool, campaign, honor, policy, ...).
+          types: |
+            feat
+            fix
+            perf
+            refactor
+            docs
+            chore
+            test
+            ci
+            build
+            style
+            revert
+          requireScope: false

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -304,10 +304,37 @@ jobs:
   #
   # ###########################################################################################
 
+  changes:
+    name: (chore) detect app changes
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      app: ${{ steps.filter.outputs.app }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8
+        with:
+          persist-credentials: false
+      - name: Detect app-stack changes
+        id: filter
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d
+        with:
+          filters: |
+            app:
+              - 'api/**'
+              - 'app-partners/**'
+              - 'app-observatory/**'
+              - 'shared/**'
+
   release:
     name: (chore) release
     runs-on: ubuntu-latest
+    # Only release when the app stack (api / front-ends) changed. Data-only
+    # merges (dbt / sqlmesh / datalake / cms) must not cut an app version.
+    if: github.ref == 'refs/heads/main' && needs.changes.outputs.app == 'true'
     needs:
+      - changes
       - api-lint
       - api-unit
       - api-integration
@@ -334,5 +361,9 @@ jobs:
         uses: cycjimmy/semantic-release-action@9cc899c47e6841430bbaedb43de1560a568dfd16
         with:
           branch: main
+          # Required by the conventionalcommits preset used in .releaserc
+          # (semantic-release 24 ships only the angular preset by default).
+          extra_plugins: |
+            conventional-changelog-conventionalcommits@8
         env:
           GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN_RELEASE }}

--- a/.releaserc
+++ b/.releaserc
@@ -1,8 +1,39 @@
 {
   "branches": ["main"],
   "plugins": [
-    "@semantic-release/commit-analyzer",
-    "@semantic-release/release-notes-generator",
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "preset": "conventionalcommits",
+        "releaseRules": [
+          { "scope": "dbt", "release": false },
+          { "scope": "sqlmesh", "release": false },
+          { "scope": "datalake", "release": false },
+          { "scope": "cms", "release": false }
+        ]
+      }
+    ],
+    [
+      "@semantic-release/release-notes-generator",
+      {
+        "preset": "conventionalcommits",
+        "presetConfig": {
+          "types": [
+            { "type": "feat", "section": "Nouveautés" },
+            { "type": "fix", "section": "Corrections" },
+            { "type": "perf", "section": "Performances" },
+            { "type": "refactor", "section": "Refactorisations" },
+            { "type": "revert", "section": "Annulations" },
+            { "type": "docs", "section": "Documentation", "hidden": true },
+            { "type": "style", "hidden": true },
+            { "type": "chore", "hidden": true },
+            { "type": "test", "hidden": true },
+            { "type": "build", "hidden": true },
+            { "type": "ci", "hidden": true }
+          ]
+        }
+      }
+    ],
     "@semantic-release/github"
   ]
 }


### PR DESCRIPTION
## Why

Audit of the changelog/release setup found three gaps:

1. **No scoping** - semantic-release runs on every push to `main` with no path filter, so a `dbt`/`sqlmesh`/`datalake`/`cms`-only merge cuts an app version (e.g. v3.95.1 = `fix(sqlmesh)`, v3.94.0 = `feat: dbt-osmosis`).
2. **No input enforcement** - Conventional Commits are assumed but not checked; non-conforming subjects (`Datalake dbt`, `Fix dl anomaly carpools`, `make POSTGRES_PORT configurable`) produce wrong/no version bumps and empty changelog lines.
3. **Thin release notes** - only Features/Bug Fixes surface; perf/refactor/revert are dropped.

GitHub Releases remain the single source of truth (no in-repo CHANGELOG.md, no CI commit-back, no backfill).

## What

- **`pr-title.yml` (new)** - lints PR titles as Conventional Commits (type only; scope free-form since the repo uses many domain scopes). Built-in `GITHUB_TOKEN`, `pull-requests: read`.
- **`.releaserc`** - `conventionalcommits` preset with French sections (Nouveautes/Corrections/Performances/Refactorisations/Annulations); `releaseRules` exclude `dbt`/`sqlmesh`/`datalake`/`cms` scopes from bumps.
- **`quality.yml`** - new `changes` job (dorny/paths-filter) gates `release` on app-stack changes (`api`/`app-partners`/`app-observatory`/`shared`). Test-gating preserved. Adds `conventional-changelog-conventionalcommits@8` via `extra_plugins` (required by the preset on semantic-release 24).

All third-party actions SHA-pinned.

## Follow-up (manual)

- Make the **PR Title** check **required** in branch protection on `main`, otherwise the gate is advisory.
- Watch the first post-merge release: confirm the preset plugin resolves and the FR sections render.

## Caveats

- Two-layer scoping (path gate + scope-exclude) is belt-and-braces: the path gate is robust; scope-exclude only fires on correctly-scoped data PRs.
- Next release notes will look different (French section headers) - expected.