### PR TITLE
chore(skills): ajoute les skills notion-debrief et pr-preparer

### DIFF
--- a/.claude/skills/notion-debrief/SKILL.md
+++ b/.claude/skills/notion-debrief/SKILL.md
@@ -1,0 +1,151 @@
+---
+name: notion-debrief
+description: Use when documenting/journaling finished work into the Notion "Suivi des tâches Data" board - triggers on "documente la tâche dans Notion", "post task", "débrief Notion", "note le travail dans le suivi des tâches", "journalise dans Notion", or any request to record what was done after finishing a chantier. Reuses an existing task or creates one, writes a French debrief (contexte, travail réalisé, ressources liées, hors-scope, prochaines étapes), and returns the Notion URL.
+allowed-tools: Read, Bash, Grep, Glob, Skill, mcp__claude_ai_Notion__notion-fetch, mcp__claude_ai_Notion__notion-search, mcp__claude_ai_Notion__notion-create-pages, mcp__claude_ai_Notion__notion-update-page, mcp__claude_ai_Notion__notion-query-database-view, mcp__github__search_pull_requests, mcp__github__pull_request_read
+---
+
+# Notion Debrief
+
+Documente le travail livré dans le suivi Notion de l'équipe Data, pour garder un
+historique fouillable plus tard (bugs, évolutions, décisions). Réutilise une tâche
+existante ou en crée une, rédige un débrief en français clair, puis renvoie l'URL.
+
+## But
+
+Construire, tâche après tâche, une mémoire détaillée des changements de l'app RPC.
+Chaque débrief doit pouvoir être relu dans six mois pour comprendre *pourquoi* et
+*comment* un changement a été fait. Privilégier l'utilité de l'historique sur la
+brièveté : mieux vaut un contexte explicite qu'une note cryptique.
+
+## Cible Notion (constantes)
+
+- Data source (parent des tâches) : `collection://2759b461-218e-4764-ae17-0025d728193c`
+- Propriété titre : `Tâche`
+- Statut `État` (type status) -> **`Tâches priorisées`** par défaut.
+  Ne jamais écrire `Done` : l'utilisateur passe la tâche en `Done` après relecture.
+- Assignee `Personne` (person, tableau JSON d'IDs) -> par défaut l'utilisateur courant.
+  - Jonathan Fallon = `cea451b0-d0ea-48ed-9fb0-240a95de8739` (jonathan@scopopop.com).
+  - Si quelqu'un d'autre lance le skill, résoudre son ID via `notion-search`
+    (`query_type: "user"`, requête = son email).
+
+Si le schéma a changé (propriété renommée, nouvel `État`), faire un `notion-fetch`
+sur la data source pour relire les noms exacts avant d'écrire.
+
+## Règles transverses
+
+- **Undercover** : aucune mention de Claude, d'IA ou d'assistant dans le titre ou le
+  contenu Notion. On écrit à la première personne de l'équipe.
+- **Langage** : français correct (invoquer le skill `french`), simple et direct.
+  Pas de mode caveman dans le contenu Notion.
+- **Historique** : en réutilisation, on **ajoute** une section datée en fin de page.
+  On n'écrase jamais le contenu existant - l'historique doit s'accumuler.
+- **Action sortante** : Notion est un service externe. Toujours montrer le contenu et
+  **confirmer avec l'utilisateur avant d'écrire**.
+
+## Procédure
+
+### 1. Préparer
+- Invoquer le skill `french`.
+- Récupérer la date du jour : `date -I` (sert à dater les entrées d'historique).
+
+### 2. Rassembler le contexte
+Réunir la matière du débrief depuis :
+- la conversation courante (ce qui a été fait, décisions, points laissés de côté) ;
+- git : `git branch --show-current`, `git log --oneline -15`, et la PR liée -
+  `mcp__github__search_pull_requests` sur la branche (sinon `gh pr view --json url,title,number`) ;
+- les liens fournis par l'utilisateur : PR GitHub, tickets, tickets Zammad, autres
+  tâches Notion. Demander s'il en manque un évident.
+
+### 3. Réutiliser ou créer
+- Chercher une tâche existante liée au sujet via `notion-search`
+  (`data_source_url` = la data source ci-dessus, requête = mots-clés du sujet).
+- **Match clair** -> réutiliser la tâche (étape 6, mise à jour).
+- **Ambigu** (plusieurs candidates, ou correspondance faible) -> demander à
+  l'utilisateur via `AskUserQuestion` : réutiliser laquelle, ou créer une nouvelle.
+- **Aucun match** -> créer une nouvelle tâche (étape 6, création).
+
+### 4. Rédiger le débrief
+Contenu en Markdown Notion, français, avec **ce gabarit exact** (garder ces 5
+titres ; laisser une section vide avec "_RAS_" plutôt que la supprimer) :
+
+```markdown
+## Contexte
+Pourquoi ce travail : besoin, problème, demande à l'origine, résultat visé.
+
+## Travail réalisé
+Les changements qui comptent pour le métier, la tech ou l'infra (voir "Niveau de
+détail" ci-dessous). Synthèse, pas journal d'opérations.
+
+## Ressources liées
+- PR : [#1234 - titre](url)
+- Ticket : [ref](url)
+- Zammad : [#ticket](url)
+- Notion : [tâche liée](url)
+
+## Hors-scope / remarques
+Ce qui a été volontairement écarté, limites connues, dette laissée, pièges.
+
+## Prochaines étapes
+- [ ] étape suivante
+```
+
+**Niveau de détail de "Travail réalisé"**
+
+Objectif : qu'une relecture dans six mois comprenne *ce qui a changé pour le produit
+et le système*, pas comment on a manipulé l'outillage.
+
+- **Inclure** : changements de comportement métier, d'architecture, de schéma de
+  données, de configuration CI/infra, de contrats d'API, de règles ; impacts et
+  effets de bord ; décisions structurantes.
+- **Exclure** : la mécanique technique sans valeur de relecture - opérations git
+  (commit, branche, worktree, merge, squash, tags), nettoyage d'environnement local,
+  exécutions de routine (lint, fmt, install), allers-retours d'outillage.
+
+La fusion d'une PR ou un changement d'état peut être mentionné en une ligne s'il
+porte un fait utile (ex. "déployé en prod", "release coupée/non coupée"), mais ce
+n'est jamais le sujet de la section.
+
+Exemple (cas réel PR #3211, à resserrer) :
+
+- Trop verbeux : "Fusion confirmée sur `main` (squash `1368c4709`) ; worktree local
+  supprimé ; branche `worktree-chore+release-hardening` supprimée en local et côté
+  distant ; 12 checks requis confirmés."
+- Resserré : "Périmétrage du versionnage validé en conditions réelles : un merge
+  CI-only n'a pas coupé de release applicative (tag inchangé `v3.97.2`)."
+
+### 5. Confirmer
+Montrer à l'utilisateur le titre, les propriétés (Personne, État) et le contenu.
+Indiquer s'il s'agit d'une création ou d'une mise à jour, et de quelle tâche.
+Attendre son accord avant d'écrire.
+
+### 6. Écrire dans Notion
+
+**Création** (`notion-create-pages`) :
+- parent : `{ "type": "data_source_id", "data_source_id": "2759b461-218e-4764-ae17-0025d728193c" }`
+- `content` : le débrief de l'étape 4 (sans répéter le titre en tête).
+- `properties` :
+  - `Tâche` : titre court et parlant (FR, ASCII des refs techniques toléré) ;
+  - `Personne` : `["cea451b0-d0ea-48ed-9fb0-240a95de8739"]` (ou l'ID résolu) ;
+  - `État` : `Tâches priorisées`.
+
+**Réutilisation** (`notion-update-page`) :
+- `command: "insert_content"`, `position: { "type": "end" }`.
+- `content` : un séparateur puis une section datée, pour empiler l'historique :
+
+  ```markdown
+  ---
+  ### Mise à jour - AAAA-MM-JJ
+  ```
+  suivie du même gabarit (Contexte / Travail réalisé / Ressources liées /
+  Hors-scope / Prochaines étapes) pour cette itération.
+- Mettre à jour `Personne`/`État` (`command: "update_properties"`) seulement si
+  nécessaire ; ne jamais repasser en `Done`.
+
+### 7. Renvoyer l'URL
+Toujours afficher à l'utilisateur l'URL Notion de la tâche créée ou mise à jour,
+et rappeler qu'il la passe en `Done` après relecture.
+
+## Sortie
+
+Rapport bref : création ou mise à jour, titre de la tâche, propriétés posées
+(Personne, État), et l'URL Notion cliquable.

--- a/.claude/skills/pr-preparer/SKILL.md
+++ b/.claude/skills/pr-preparer/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: pr-preparer
+description: Use when creating a pull request for this project - triggers on "open a PR", "create a PR", "gh pr create", or any request to open/create a PR. Commits pending work, runs parallel CGU + security checks, writes a French PR description, then creates the PR with confirmation.
+allowed-tools: Bash, Read, Grep, Glob, Edit, Write, WebFetch, Agent, Skill
+---
+
+# PR Preparer
+
+Pre-flight gate that wraps PR creation: commit pending work, run blocking/non-blocking
+checks in parallel, write a French PR, then create it with confirmation.
+
+> ## Authorised CLAUDE.md overrides - DO NOT "fix" these
+> This skill deliberately overrides two repo/global rules, on explicit user instruction:
+> 1. **It commits.** CLAUDE.md says "Claude cannot commit". Here, committing is the
+>    intended behaviour (squash-merge cleans history later, so many local commits are fine).
+> 2. **It scrubs attribution.** Global rules say append `Co-Authored-By: Claude` and a
+>    "Generated with Claude Code" line. This skill is **undercover**: never add either, and
+>    never mention Claude in any commit, branch, or PR text.
+
+## When this runs
+
+Fires on PR-creation intent: the user says "open a PR" / "create a PR", runs `gh pr create`,
+or asks me to open one. It is the only path that should create a PR for this project.
+
+## Preconditions
+
+- Must be in a git repo with a working tree. If clean AND no unpushed commits on a feature
+  branch -> nothing to do; stop and say so.
+- If on `main` with uncommitted changes -> the skill creates the branch itself (step 1).
+- Requires `$DATABASE_URL` is NOT needed; requires network for the CGU refresh and `gh`/MCP.
+
+## Procedure
+
+### 1. Branch
+- `git branch --show-current`. If on `main`, infer `<type>/<scope-kebab>` from the diff paths
+  and `git switch -c <type>/<scope-kebab>` (ASCII, no accents). Otherwise keep current branch.
+
+### 2. Commit
+- Stage all intended changes (`git add -A`, or a targeted subset if the user scoped it).
+- Invoke the **`french`** skill, then write a conventional-commit message:
+  `<type>(<scope>): <description en français>` - the `<type>(<scope>)` token stays ASCII
+  English (`feat`, `fix`, `chore`, `refactor`, ...); the description is French with proper
+  accents. Body in French if useful.
+- Commit with **no `Co-Authored-By` trailer** and no Claude mention.
+- Many local commits are fine (squash-merge later). Commit before checks so the diff is stable.
+
+### 3. CGU freshness (refresh if stale)
+- Read `cgu-rules.md` frontmatter `last_synced`. Compute age with `date`.
+- If missing or **older than 7 days** -> mark stale:
+  - `WebFetch` the canonical CGU URL in `cgu-rules.md`'s header.
+  - Rewrite `cgu-rules.md` from the fetched content, preserving the rule structure (id /
+    section / severity / what-to-flag), and restamp `last_synced` to today (`date -I`).
+  - Keep human `# TODO extend` markers.
+- The CGU guard (step 4) always runs against the refreshed file.
+
+### 4. Parallel checks (registry-driven)
+Dispatch **every registry row as a parallel read-only `Explore` subagent in one batch**.
+Each subagent reads its `source` checklist + the PR diff
+(`git diff $(git merge-base main HEAD)`) and returns a structured report **in French**:
+verdict `PASS`/`FAIL`, severity, and findings (`fichier:ligne`, problème, recommandation).
+
+**Check registry** (extend by appending a row - no orchestration change):
+
+| name            | blocking | source (checklist read by the subagent)          |
+| --------------- | -------- | ------------------------------------------------ |
+| `cgu-guard`     | **yes**  | `.claude/skills/pr-preparer/cgu-rules.md`        |
+| `check-security`| no       | `.claude/skills/check-security/SKILL.md`         |
+
+`check-security` stays slash-only and untouched; the subagent **reads its SKILL.md as a
+checklist** rather than invoking the command.
+
+### 5. Gate
+- Wait for all subagents.
+- If any **blocking** check returns `FAIL`:
+  - Write the draft PR body to `tmp/pr/pr-body.md` with the blocking violation flagged at the
+    very top (`## BLOQUANT - CGU`).
+  - **Leave the local commit(s) in place** (squashed later), do **NOT** create the PR.
+  - Report the violation and stop. The user fixes, then re-triggers.
+- Else continue.
+
+### 6. Artifacts (French, undercover)
+- Invoke the **`french`** skill. Write to `tmp/pr/`:
+  - `commit-msg.txt` (already committed in step 2; keep for reference).
+  - `pr-body.md` - French PR description: summary, what changed, and a section per check
+    embedding its French report (`## Sécurité`, `## CGU`). **No** "Generated with Claude" line,
+    no Claude mention.
+- PR title = the commit subject (French description, ASCII conventional token).
+
+### 7. Create the PR (with confirmation)
+- Ensure the branch is pushed: `git push -u origin <branch>` (confirm first - outward-facing).
+- Create the PR, **base `main`**, with the title + `tmp/pr/pr-body.md`, via either:
+  - `mcp__github__create_pull_request` (preferred per CLAUDE.md), or
+  - `gh pr create --base main --title "<titre>" -F tmp/pr/pr-body.md`.
+- **Always confirm with the user before pushing and before opening the PR** (outward-facing).
+
+## Output
+
+Report: branch, commit subject, each check's verdict (PASS/FAIL + count), and the PR URL once
+created - or the blocking reason if halted at the gate.

--- a/.claude/skills/pr-preparer/cgu-rules.md
+++ b/.claude/skills/pr-preparer/cgu-rules.md
@@ -1,0 +1,76 @@
+---
+name: cgu-rules
+description: Cached, machine-checkable distillation of the RPC CGU - read by the pr-preparer cgu-guard check.
+canonical_url: https://doc.covoiturage.beta.gouv.fr/nos-services/le-registre-de-preuve-de-covoiturage/cgu-conditions-generales-dutilisation-de-covoiturage.beta.gouv
+last_synced: 2026-06-08
+ttl_days: 7
+---
+
+# CGU rules - guard checklist
+
+Cached distillation of the CGU for automated checking. **Auto-maintained**: `pr-preparer`
+refreshes this file from `canonical_url` when `last_synced` is older than `ttl_days` (7).
+Each rule has an id, the CGU section, a severity, and what a diff must be flagged for.
+
+`cgu-guard` is a **blocking** check: any `blocker` FAIL halts PR creation.
+
+<!-- TODO extend: add rules as the CGU evolves. Keep ids stable; cite the CGU section. -->
+
+## CGU-1 - Status definitiveness after 48h  (CGU 2.1.1)  [severity: blocker]
+
+> "the status associated with a trip by the carpool proof registry becomes definitive after
+> 48h (trip completion time)."
+
+The status of a trip becomes **final and immutable 48h after trip completion**
+(`carpool_v2.carpools.end_datetime`). Classification cannot change past that window.
+
+**Flag the diff if it:**
+- mutates `carpool_v2.status` (`acquisition_status`, or `fraud_status`/`anomaly_status` where
+  it changes incentive eligibility) without a window guard restricting it to trips whose
+  completion is within 48h of the operation;
+- adds a batch / migration / backfill / reclassification job over `carpool_v2.status` lacking a
+  predicate equivalent to `end_datetime + interval '48 hours' >= <operation_time>`;
+- reclassifies historical trips to `terms_violation_error` (or any non-`processed` state) in
+  bulk without the 48h filter.
+
+**Reference incident:** 2026-06-07 a batch flipped 213,498 trips `processed ->
+terms_violation_error` ignoring this window; all were already definitive. This rule exists to
+catch that class of change before merge.
+
+## CGU-2 - Personal data retention limits  (CGU - données personnelles)  [severity: blocker]
+
+Personal data is kept only for the retention period stated in the CGU; beyond it, data is
+deleted or anonymised.
+
+**Flag the diff if it:**
+- extends or removes a retention / TTL / purge boundary on personal data
+  (`driver_*`/`passenger_*` phone, `*_identity_key`, `*_travelpass_*`);
+- disables or weakens an anonymisation / purge job;
+- persists raw personal data into a store that has no retention enforcement.
+
+## CGU-3 - PII minimisation and exposure  (CGU - données personnelles)  [severity: high]
+
+Personal and identifying data must not be exposed beyond what the CGU permits.
+
+**Flag the diff if it:**
+- logs, returns in an API response, or writes to an export raw `*_phone`, `*_identity_key`,
+  or `*_travelpass_*` where a truncated/hashed form is expected
+  (`driver_phone_trunc`, `passenger_phone_trunc`, ...);
+- widens the fields exposed by an export, public stat, or attestation beyond the documented set;
+- removes truncation/hashing applied to identifying fields.
+
+## How the guard reports
+
+Return French, structured:
+
+```
+Verdict: PASS | FAIL
+Pour chaque constat:
+  - Règle: CGU-<n>
+  - Gravité: blocker | high | ...
+  - Emplacement: fichier:ligne
+  - Problème: <description>
+  - Recommandation: <correctif>
+```
+
+A `blocker` FAIL must halt PR creation.


### PR DESCRIPTION
## Résumé

Ajoute deux skills projet dans `.claude/skills/` pour outiller le suivi et la
livraison du travail sur le dépôt.

## Ce qui change

- **`notion-debrief`** : journalise le travail livré dans la base Notion
  « Suivi des tâches Data ». Réutilise une tâche existante ou en crée une,
  rédige un débrief en français (Contexte, Travail réalisé, Ressources liées,
  Hors-scope, Prochaines étapes) et renvoie l'URL. La section « Travail réalisé »
  est cadrée pour synthétiser les changements métier/tech/infra, pas la mécanique
  d'outillage (git, nettoyage, lint).
- **`pr-preparer`** : prépare et ouvre une PR (création de branche, commit,
  contrôles CGU + sécurité en parallèle, description en français), avec
  confirmation avant toute action sortante. Inclut `cgu-rules.md`, distillation
  cache et vérifiable des CGU, rafraîchie automatiquement quand elle dépasse 7 jours.

Documentation uniquement (`.claude/`), aucun code applicatif ni schéma de données
touché.
