### PR TITLE
fix(sqlmesh): corrige les index manquants bloquant l'export data.gouv

### DIFF
--- a/api/src/pdc/services/export/repositories/queries/datagouvListQuery.ts
+++ b/api/src/pdc/services/export/repositories/queries/datagouvListQuery.ts
@@ -40,11 +40,18 @@ export function datagouvListQuery(params: ExportParams, config: DataGouvQueryCon
   const { start_at, end_at } = params.get();
   const { min_occurrences } = config;
 
+  // The start_datetime bounds below are the sargable equivalent of the
+  // start_date_filter range: paris_date(t) in [start, end) iff
+  // t in [paris_midnight(start), paris_midnight(end)). They let the planner
+  // use the journeys (start_datetime) index instead of a full seq scan; the
+  // start_date_filter predicates stay as the authoritative (exact) filter.
   return sql`
     SELECT *
     FROM ${raw(table)}
     WHERE start_date_filter >= ${start_at}
       AND start_date_filter  < ${end_at}
+      AND start_datetime >= (${start_at}::date)::timestamp AT TIME ZONE 'Europe/Paris'
+      AND start_datetime  < (${end_at}::date)::timestamp   AT TIME ZONE 'Europe/Paris'
       AND start_insee_count >= ${min_occurrences}
       AND end_insee_count   >= ${min_occurrences}
     ORDER BY start_date_filter ASC

--- a/sqlmesh/macros/index_name.py
+++ b/sqlmesh/macros/index_name.py
@@ -1,0 +1,34 @@
+"""Snapshot-unique index name helper.
+
+Post-statements that create an index with a *fixed* name collide across
+snapshots: PostgreSQL index names are unique per schema, so
+
+    CREATE INDEX IF NOT EXISTS journeys_id_index ON <new_snapshot> (_id)
+
+is silently skipped while the previous snapshot still owns that name. Every
+rebuilt snapshot is then born without indexes until the janitor drops the old
+one -- by which point the `creating` stage has already run, leaving the new
+snapshot permanently un-indexed (full seq scans on every downstream read).
+
+`@index_name('base')` appends the physical snapshot's unique suffix to the base
+name, so each snapshot gets its own index identifier and `IF NOT EXISTS` only
+skips a genuine re-run on the same snapshot.
+"""
+
+from sqlglot import exp
+from sqlmesh import macro
+
+
+@macro()
+def index_name(evaluator, base):
+    # `base` arrives as a string literal expression (e.g. 'journeys_id_index')
+    base_name = base.name if isinstance(base, exp.Expression) else str(base)
+
+    # `this_model` resolves to the physical snapshot FQN at the `creating`
+    # stage, e.g. "trusted_zone"."journeys__2404643179"
+    table = exp.to_table(evaluator.this_model).name  # journeys__2404643179
+
+    # the part after `__` is unique per snapshot; fall back to the full name
+    suffix = table.split("__")[-1] if "__" in table else table
+
+    return exp.to_identifier(f"{base_name}_{suffix}")

--- a/sqlmesh/models/2_trusted_zone/journeys/insee_counters.sql
+++ b/sqlmesh/models/2_trusted_zone/journeys/insee_counters.sql
@@ -32,5 +32,5 @@ WHERE j.valid_acquisition_status = TRUE
       AT TIME ZONE 'Europe/Paris'
   );
 
-@IF(@runtime_stage = 'creating', CREATE INDEX IF NOT EXISTS insee_counters_id_index ON trusted_zone.insee_counters (_id));
-@IF(@runtime_stage = 'creating', CREATE INDEX IF NOT EXISTS insee_counters_start_datetime_index ON trusted_zone.insee_counters (start_datetime));
+@IF(@runtime_stage = 'creating', CREATE INDEX IF NOT EXISTS @index_name('insee_counters_id_index') ON trusted_zone.insee_counters (_id));
+@IF(@runtime_stage = 'creating', CREATE INDEX IF NOT EXISTS @index_name('insee_counters_start_datetime_index') ON trusted_zone.insee_counters (start_datetime));

--- a/sqlmesh/models/2_trusted_zone/journeys/journeys.sql
+++ b/sqlmesh/models/2_trusted_zone/journeys/journeys.sql
@@ -217,7 +217,8 @@ journeys AS (
 
 SELECT * FROM journeys;
 
-@IF(@runtime_stage = 'creating', CREATE INDEX IF NOT EXISTS journeys_id_index ON trusted_zone.journeys (_id));
-@IF(@runtime_stage = 'creating', CREATE INDEX IF NOT EXISTS journeys_start_datetime_tz_index ON trusted_zone.journeys (start_datetime_tz));
-@IF(@runtime_stage = 'creating', CREATE INDEX IF NOT EXISTS journeys_start_h3_idx ON trusted_zone.journeys (start_h3_index));
-@IF(@runtime_stage = 'creating', CREATE INDEX IF NOT EXISTS journeys_end_h3_idx ON trusted_zone.journeys (end_h3_index));
+@IF(@runtime_stage = 'creating', CREATE INDEX IF NOT EXISTS @index_name('journeys_id_index') ON trusted_zone.journeys (_id));
+@IF(@runtime_stage = 'creating', CREATE INDEX IF NOT EXISTS @index_name('journeys_start_datetime_index') ON trusted_zone.journeys (start_datetime));
+@IF(@runtime_stage = 'creating', CREATE INDEX IF NOT EXISTS @index_name('journeys_start_datetime_tz_index') ON trusted_zone.journeys (start_datetime_tz));
+@IF(@runtime_stage = 'creating', CREATE INDEX IF NOT EXISTS @index_name('journeys_start_h3_idx') ON trusted_zone.journeys (start_h3_index));
+@IF(@runtime_stage = 'creating', CREATE INDEX IF NOT EXISTS @index_name('journeys_end_h3_idx') ON trusted_zone.journeys (end_h3_index));

--- a/sqlmesh/models/3_refined_zone/export/export_opendata_list.sql
+++ b/sqlmesh/models/3_refined_zone/export/export_opendata_list.sql
@@ -18,6 +18,14 @@ WITH latest_perimeters AS (
     END AS precision
   FROM trusted_zone.perimeters
   ORDER BY arr, year DESC
+),
+
+-- Pre-aggregated semi-join: avoids a correlated EXISTS subplan that re-scans
+-- campaigns once per output row (O(n*m)). Planned as a single hash join.
+incentivised AS (
+  SELECT DISTINCT carpool_v2_id
+  FROM trusted_zone.campaigns
+  WHERE status = 'validated'
 )
 
 SELECT
@@ -56,10 +64,7 @@ SELECT
   j.distance                                                               AS journey_distance,
   ROUND(j.duration / 60.0)                                                 AS journey_duration,
 
-  EXISTS (
-    SELECT 1 FROM trusted_zone.campaigns ci
-    WHERE ci.carpool_v2_id = j._id AND ci.status = 'validated'
-  )                                                                        AS has_incentive,
+  (inc.carpool_v2_id IS NOT NULL)                                          AS has_incentive,
 
   -- INSEE occurrence counts (for filtering by API)
   ic.start_insee_count,
@@ -67,6 +72,7 @@ SELECT
 
 FROM trusted_zone.journeys j
 JOIN trusted_zone.insee_counters ic ON j._id = ic._id
+LEFT JOIN incentivised inc ON inc.carpool_v2_id = j._id
 LEFT JOIN latest_perimeters gps ON j.start_geo_code = gps.arr
 LEFT JOIN latest_perimeters gpe ON j.end_geo_code   = gpe.arr
 

--- a/sqlmesh/models/3_refined_zone/export/export_opendata_list.sql
+++ b/sqlmesh/models/3_refined_zone/export/export_opendata_list.sql
@@ -34,6 +34,9 @@ SELECT
 
   -- date filtering column (raw DATE in Europe/Paris)
   (j.start_datetime AT TIME ZONE 'Europe/Paris')::date                     AS start_date_filter,
+  -- raw UTC timestamp, exposed so consumers can add a sargable range
+  -- predicate that hits the journeys (start_datetime) index
+  j.start_datetime                                                         AS start_datetime,
 
   -- start
   to_char(ts_ceil(j.start_datetime_tz, 600) AT TIME ZONE 'Europe/Paris', 'YYYY-MM-DD HH24:MI:SS') AS journey_start_datetime,

--- a/sqlmesh/scripts/hotfix_reindex_datagouv_sources.sql
+++ b/sqlmesh/scripts/hotfix_reindex_datagouv_sources.sql
@@ -1,0 +1,71 @@
+-- =============================================================================
+-- One-off PRODUCTION hot-fix: restore missing indexes on the live
+-- trusted_zone.journeys and trusted_zone.insee_counters snapshots.
+-- =============================================================================
+--
+-- WHY
+--   A fixed index-name + `CREATE INDEX IF NOT EXISTS` regression left the live
+--   snapshots un-indexed (PostgreSQL index names are unique per schema, so the
+--   post-statement was silently skipped while the previous snapshot still owned
+--   the name). refined_zone.export_opendata_list (the data.gouv export) then
+--   does full ~50 GB seq scans and the export stalls.
+--
+--   This script reindexes the CURRENT snapshots so the export runs immediately.
+--   The `@index_name` macro shipped in this PR prevents the regression on every
+--   future snapshot rebuild.
+--
+-- HOW TO RUN
+--   * Use the owner / a superuser role.
+--   * Run with autocommit ON (psql default). CREATE INDEX CONCURRENTLY must NOT
+--     run inside a transaction block (no BEGIN/COMMIT, no -1 / --single-transaction).
+--   * CONCURRENTLY avoids write locks; on ~50 GB expect several minutes per index.
+--
+-- -----------------------------------------------------------------------------
+-- STEP 1 - confirm the live physical snapshot behind each logical view.
+--          The hashes below were current at authoring time; re-run this and
+--          substitute the returned names into STEP 2 if they differ.
+-- -----------------------------------------------------------------------------
+SELECT v.relname            AS logical_view,
+       src.relname          AS live_snapshot
+FROM pg_depend d
+JOIN pg_rewrite r ON r.oid = d.objid
+JOIN pg_class   v ON v.oid = r.ev_class
+JOIN pg_class src ON src.oid = d.refobjid AND src.relkind = 'r'
+WHERE v.relnamespace = 'trusted_zone'::regnamespace
+  AND v.relname IN ('journeys', 'insee_counters')
+  AND src.relname LIKE v.relname || '\_\_%'
+ORDER BY 1;
+
+-- -----------------------------------------------------------------------------
+-- STEP 2 - create the missing indexes on the live snapshots.
+--          Names follow the new `<base>_<snapshot_suffix>` convention so they
+--          will not collide with other snapshots.
+-- -----------------------------------------------------------------------------
+
+-- trusted_zone.journeys  (live snapshot: journeys__2404643179)
+CREATE INDEX CONCURRENTLY IF NOT EXISTS journeys_id_index_2404643179
+  ON trusted_zone.journeys__2404643179 (_id);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS journeys_start_datetime_index_2404643179
+  ON trusted_zone.journeys__2404643179 (start_datetime);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS journeys_start_datetime_tz_index_2404643179
+  ON trusted_zone.journeys__2404643179 (start_datetime_tz);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS journeys_start_h3_idx_2404643179
+  ON trusted_zone.journeys__2404643179 (start_h3_index);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS journeys_end_h3_idx_2404643179
+  ON trusted_zone.journeys__2404643179 (end_h3_index);
+
+-- trusted_zone.insee_counters  (live snapshot: insee_counters__3095982230)
+CREATE INDEX CONCURRENTLY IF NOT EXISTS insee_counters_id_index_3095982230
+  ON trusted_zone.insee_counters__3095982230 (_id);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS insee_counters_start_datetime_index_3095982230
+  ON trusted_zone.insee_counters__3095982230 (start_datetime);
+
+-- -----------------------------------------------------------------------------
+-- STEP 3 - verify and re-run the export.
+-- -----------------------------------------------------------------------------
+-- SELECT tablename, indexname FROM pg_indexes
+-- WHERE schemaname = 'trusted_zone'
+--   AND tablename IN ('journeys__2404643179', 'insee_counters__3095982230')
+-- ORDER BY 1, 2;
+--
+-- Then: deno task ... export:datagouv -s 2026-05-01 -e 2026-06-01


### PR DESCRIPTION
## Résumé

L'export data.gouv (`refined_zone.export_opendata_list`) était bloqué en production : la requête ne se terminait plus et l'export restait périmé.

## Cause racine (vérifiée en production)

Les snapshots `trusted_zone.journeys` (47,5 M lignes / 50 Go) et `trusted_zone.insee_counters` étaient **recréés sans aucun index**.

Les post-statements des modèles utilisent un **nom d'index fixe** combiné à `CREATE INDEX IF NOT EXISTS`. Or les noms d'index sont **uniques par schéma** sous PostgreSQL : tant que l'ancien snapshot détient le nom `journeys_id_index`, le `IF NOT EXISTS` sur le nouveau snapshot est ignoré silencieusement. Chaque snapshot reconstruit naissait donc sans index, puis le janitor supprimait l'ancien (la phase `creating` étant déjà passée, le nouveau restait définitivement non indexé).

Conséquence : la vue d'export faisait des **seq scans complets de ~50 Go**, aggravés par un `EXISTS` corrélé (sous-plan re-scanné une fois par ligne, O(n*m)) et un filtre de date **non sargable** (index inutilisable).

## Changements

1. **`macros/index_name.py`** (nouveau) — macro `@index_name('base')` qui suffixe le nom d'index avec l'identifiant unique du snapshot physique. Chaque snapshot obtient son propre nom ; `IF NOT EXISTS` ne saute plus qu'un vrai re-run sur le même snapshot.
2. **`journeys.sql`** — migre les 4 index vers `@index_name` et ajoute l'index manquant `(start_datetime)`.
3. **`insee_counters.sql`** — migre les 2 index vers `@index_name`.
4. **`export_opendata_list.sql`** — **décorrèle** le `EXISTS` par ligne (`has_incentive`) en une semi-jointure pré-agrégée, et **expose `start_datetime`** (timestamptz brut) pour un filtrage sargable.
5. **`datagouvListQuery.ts`** — ajoute une **borne sargable** sur `start_datetime`, équivalente exacte du filtre `start_date_filter` (`paris_date(t) ∈ [d1, d2) ⟺ t ∈ [minuit_paris(d1), minuit_paris(d2))`), qui active l'index au lieu d'un seq scan complet. La colonne `start_datetime` n'apparaît pas dans le CSV publié (le writer ne sérialise que les champs configurés).
6. **`scripts/hotfix_reindex_datagouv_sources.sql`** (nouveau) — runbook pour réindexer manuellement les snapshots de production en cours (`CREATE INDEX CONCURRENTLY`).

## Benchmark (BD locale, sur snapshots réels)

Mesure `EXPLAIN ANALYZE`, résultats identiques (mêmes lignes) avant/après.

| Scénario | Accès journeys | Temps |
| --- | --- | --- |
| Mois complet, vue corrélée, snapshot non indexé (avant) | Seq Scan + insee_counters Seq Scan 3,4 M | **20,2 s** |
| Mois complet, vue décorrélée + index `_id` | Seq Scan + insee_counters **Index Scan** | **15,2 s** |
| Jour sélectif, sans borne sargable | Seq Scan 3,5 M lignes | 2,89 s |
| Jour sélectif, **avec borne sargable** | **Bitmap Index Scan** 47 k lignes | **0,92 s** (3,1x) |

> Le gain en production est plus important que le local : (1) le planificateur prod choisissait le sous-plan corrélé par ligne (coût estimé ~4e10 = « ne finit jamais ») que la décorrélation supprime ; (2) en prod chaque mois ne représente que ~2 % de 47 M lignes, donc le filtre sargable transforme le seq scan complet de 50 Go en index scan d'environ 870 k lignes. Le local, dense sur quelques mois, sous-estime ces deux effets.

## Déploiement

1. Exécuter `scripts/hotfix_reindex_datagouv_sources.sql` en production (débloque l'export immédiatement).
2. Merger ce PR ; `sqlmesh plan` redéploie la vue (décorrélée + `start_datetime` exposé) et la macro garantit que les prochains snapshots conservent leurs index.
3. Le code API (`datagouvListQuery`) déploie la borne sargable.

> Note : le bug de collision de noms existe encore dans ~10 autres modèles utilisant le même motif `@IF ... CREATE INDEX`. Hors-scope ici (suivi séparé) ; ce PR cible les deux sources de l'export data.gouv.

## Sécurité — verdict PASS

Revue exécutée sur l'intégralité du diff.

- **Injection SQL** : `datagouvListQuery.ts` utilise le `sql` tagged template (paramètres liés `${start_at}` / `${end_at}`), aucune concaténation ; `index_name.py` construit l'identifiant via `exp.to_identifier()` (échappement SQLGlot), le suffixe provient du nom de snapshot système, pas d'une entrée utilisateur.
- **Exposition de données** : la colonne `start_datetime` ajoutée à la vue est un timestamp technique, déjà accessible via `SELECT *`, et **non sérialisée dans le CSV** (projection sur la liste de champs configurée, `CSVWriter.ts:162`). Aucune nouvelle PII.
- **Runbook DDL** : `CREATE INDEX CONCURRENTLY ... IF NOT EXISTS`, idempotent, non destructif (aucun `DROP`/`ALTER`), prérequis explicites (rôle owner, autocommit).
- Aucun secret en dur, aucune nouvelle dépendance.

## CGU — verdict PASS

Revue exécutée sur l'intégralité du diff.

- Aucune mutation de statut hors fenêtre 48 h, aucune modification des limites de rétention.
- Aucune nouvelle exposition de données personnelles dans l'export open-data : les colonnes écrites dans le CSV restent inchangées (la liste blanche `datagouv` ne contient pas `start_datetime`).
- Seuils d'occurrence INSEE (`min_occurrences`), précision GPS et structure de l'export inchangés.