### PR TITLE
perf(export): projette les colonnes utiles de l'export data.gouv

### DIFF
--- a/api/src/pdc/services/export/repositories/queries/datagouvListQuery.ts
+++ b/api/src/pdc/services/export/repositories/queries/datagouvListQuery.ts
@@ -40,13 +40,45 @@ export function datagouvListQuery(params: ExportParams, config: DataGouvQueryCon
   const { start_at, end_at } = params.get();
   const { min_occurrences } = config;
 
+  // Project only the columns the CSV export consumes (DataGouvListType). The
+  // view also exposes filter-only columns (start_date_filter, start_datetime,
+  // start_insee_count, end_insee_count) that the writer never publishes, so
+  // SELECT * would ship them over the wire for nothing.
+  //
   // The start_datetime bounds below are the sargable equivalent of the
   // start_date_filter range: paris_date(t) in [start, end) iff
   // t in [paris_midnight(start), paris_midnight(end)). They let the planner
   // use the journeys (start_datetime) index instead of a full seq scan; the
   // start_date_filter predicates stay as the authoritative (exact) filter.
   return sql`
-    SELECT *
+    SELECT
+      journey_id,
+      trip_id,
+      journey_start_datetime,
+      journey_start_date,
+      journey_start_time,
+      journey_start_lon,
+      journey_start_lat,
+      journey_start_insee,
+      journey_start_department,
+      journey_start_town,
+      journey_start_towngroup,
+      journey_start_country,
+      journey_end_datetime,
+      journey_end_date,
+      journey_end_time,
+      journey_end_lon,
+      journey_end_lat,
+      journey_end_insee,
+      journey_end_department,
+      journey_end_town,
+      journey_end_towngroup,
+      journey_end_country,
+      passenger_seats,
+      operator_class,
+      journey_distance,
+      journey_duration,
+      has_incentive
     FROM ${raw(table)}
     WHERE start_date_filter >= ${start_at}
       AND start_date_filter  < ${end_at}


### PR DESCRIPTION
## Résumé

Remplace `SELECT *` par une projection explicite des 27 colonnes consommées par
l'export data.gouv. Au-delà du gain de transfert, cette PR rétablit le versionnage
applicatif : elle touche `api/**` avec un scope releasable, ce qui coupe une version
et déclenche le déploiement de l'API (le prédicat sargable déjà fusionné en `#3213`
part avec l'image).

## Ce qui change

- `datagouvListQuery.ts` : `SELECT *` -> liste explicite des 27 colonnes de
  `DataGouvListType`.

La vue `refined_zone.export_opendata_list` expose 31 colonnes ; l'export n'en
consomme que 27. Les 4 restantes (`start_date_filter`, `start_datetime`,
`start_insee_count`, `end_insee_count`) servent uniquement au filtrage `WHERE` et
ne sont jamais écrites dans le CSV. `SELECT *` les transférait pourtant sur chaque
ligne. Le writer étant typé `CSVWriter<DataGouvListType>`, le CSV produit reste
identique.

## Vérification des dépendances

- Seul appelant : `CarpoolRepository.datagouvList` -> `DataGouvFileCreatorService`
  -> `DataGouvCommand`.
- Liste de champs (`config/datagouv.ts`) : exactement les 27 colonnes projetées,
  `filters` vide.
- Champs calculés du `CSVWriter` : ceux qui atterrissent dans le CSV (`has_incentive`,
  `journey_start_datetime`, `trip_id`) ne lisent que des colonnes conservées. La seule
  lecture de `start_datetime` (champ `incentive_type`) est du code mort ici (réduction
  sur `campaigns`, colonne jamais exposée par la vue).
- `WHERE` : filtre toujours sur les 4 colonnes retirées (valide, une colonne de vue
  n'a pas besoin d'être projetée), le prédicat sargable reste intact.
- Aucun test ne fige le SQL ni l'ensemble de colonnes.

## Contexte release

L'optimisation de l'export (#3213) avait été fusionnée sous le scope `sqlmesh`,
empêchant semantic-release de couper une version applicative. Cette PR, scope
`export`, satisfait à la fois le filtre de fichiers (`api/**`) et la règle de scope
du `.releaserc`, et coupe donc `v3.97.3`.

## Sécurité

**Verdict : PASS** (non bloquant)

RAS. Requête paramétrée (`sql\`...\``), `raw(table)` sur une constante codée en dur
(pas d'entrée utilisateur), aucune injection. La projection explicite réduit
l'exposition de données. Aucun secret, aucune PII en log.

## CGU

**Verdict : PASS** (bloquant)

RAS. La modification ne peut que réduire les colonnes renvoyées (jamais en ajouter).
Les 27 colonnes publiées ne contiennent que des données anonymisées (géolocalisation
tronquée, codes INSEE/département, indicateurs). Améliore la minimisation PII (CGU-3).