### PR TITLE
chore(skills): documente les contraintes de release dans pr-prep

### DIFF
--- a/.claude/skills/notion-debrief/SKILL.md
+++ b/.claude/skills/notion-debrief/SKILL.md
@@ -39,10 +39,12 @@ sur la data source pour relire les noms exacts avant d'écrire.
   spéciaux corrects (é è à ù â ê î ô û ç ë ï ü œ ...). Jamais d'ASCII appauvri, jamais
   de mode caveman, y compris les accents sur les majuscules (État, À, Écrire).
 - **Langage** : **français correct et idiomatique** - invoquer le skill `french` avant
-  de rédiger, simple et direct. Proscrire les calques de l'anglais : ne pas écrire
-  "couper une version" ni "couper une release" (dire « taguer une nouvelle version » ou
-  « créer une nouvelle version »), ni "release coupée". Relire l'orthographe et les
-  accents avant de montrer le contenu.
+  de rédiger, simple et direct. Les anglicismes techniques précis du métier sont **admis**
+  (release, scope, merge, snapshot, backfill, runbook, commit...). Ce qui est proscrit, ce
+  sont les **calques** : les traductions littérales mot à mot de tournures anglaises. Ex. :
+  ne pas écrire « couper une version » / « release coupée » (calque de *cut a release*) ;
+  écrire « taguer/publier une release » ou « créer une nouvelle version ». Relire
+  l'orthographe et les accents avant de montrer le contenu.
 - **Historique** : en réutilisation, on **ajoute** une section datée en fin de page.
   On n'écrase jamais le contenu existant - l'historique doit s'accumuler.
 - **Action sortante** : Notion est un service externe. Toujours montrer le contenu et
@@ -108,7 +110,7 @@ et le système*, pas comment on a manipulé l'outillage.
   exécutions de routine (lint, fmt, install), allers-retours d'outillage.
 
 La fusion d'une PR ou un changement d'état peut être mentionné en une ligne s'il
-porte un fait utile (ex. "déployé en prod", "nouvelle version taguée / non taguée"),
+porte un fait utile (ex. "déployé en prod", "release publiée / non publiée"),
 mais ce n'est jamais le sujet de la section.
 
 Exemple (cas réel PR #3211, à resserrer) :
@@ -117,7 +119,7 @@ Exemple (cas réel PR #3211, à resserrer) :
   supprimé ; branche `worktree-chore+release-hardening` supprimée en local et côté
   distant ; 12 checks requis confirmés."
 - Resserré : "Périmétrage du versionnage validé en conditions réelles : un merge
-  CI-only n'a pas tagué de nouvelle version applicative (tag inchangé `v3.97.2`)."
+  CI-only n'a pas publié de release applicative (tag inchangé `v3.97.2`)."
 
 ### 5. Confirmer
 Montrer à l'utilisateur le titre, les propriétés (Personne, État) et le contenu.

--- a/.claude/skills/notion-debrief/SKILL.md
+++ b/.claude/skills/notion-debrief/SKILL.md
@@ -35,8 +35,14 @@ sur la data source pour relire les noms exacts avant d'écrire.
 
 - **Undercover** : aucune mention de Claude, d'IA ou d'assistant dans le titre ou le
   contenu Notion. On écrit à la première personne de l'équipe.
-- **Langage** : français correct (invoquer le skill `french`), simple et direct.
-  Pas de mode caveman dans le contenu Notion.
+- **Encodage** : tout le contenu Notion en **UTF-8**, avec les accents et caractères
+  spéciaux corrects (é è à ù â ê î ô û ç ë ï ü œ ...). Jamais d'ASCII appauvri, jamais
+  de mode caveman, y compris les accents sur les majuscules (État, À, Écrire).
+- **Langage** : **français correct et idiomatique** - invoquer le skill `french` avant
+  de rédiger, simple et direct. Proscrire les calques de l'anglais : ne pas écrire
+  "couper une version" ni "couper une release" (dire « taguer une nouvelle version » ou
+  « créer une nouvelle version »), ni "release coupée". Relire l'orthographe et les
+  accents avant de montrer le contenu.
 - **Historique** : en réutilisation, on **ajoute** une section datée en fin de page.
   On n'écrase jamais le contenu existant - l'historique doit s'accumuler.
 - **Action sortante** : Notion est un service externe. Toujours montrer le contenu et
@@ -102,8 +108,8 @@ et le système*, pas comment on a manipulé l'outillage.
   exécutions de routine (lint, fmt, install), allers-retours d'outillage.
 
 La fusion d'une PR ou un changement d'état peut être mentionné en une ligne s'il
-porte un fait utile (ex. "déployé en prod", "release coupée/non coupée"), mais ce
-n'est jamais le sujet de la section.
+porte un fait utile (ex. "déployé en prod", "nouvelle version taguée / non taguée"),
+mais ce n'est jamais le sujet de la section.
 
 Exemple (cas réel PR #3211, à resserrer) :
 
@@ -111,7 +117,7 @@ Exemple (cas réel PR #3211, à resserrer) :
   supprimé ; branche `worktree-chore+release-hardening` supprimée en local et côté
   distant ; 12 checks requis confirmés."
 - Resserré : "Périmétrage du versionnage validé en conditions réelles : un merge
-  CI-only n'a pas coupé de release applicative (tag inchangé `v3.97.2`)."
+  CI-only n'a pas tagué de nouvelle version applicative (tag inchangé `v3.97.2`)."
 
 ### 5. Confirmer
 Montrer à l'utilisateur le titre, les propriétés (Personne, État) et le contenu.

--- a/.claude/skills/pr-prep/SKILL.md
+++ b/.claude/skills/pr-prep/SKILL.md
@@ -37,6 +37,7 @@ or asks me to open one. It is the only path that should create a PR for this pro
 
 - `git branch --show-current`. If on `main`, infer `<type>/<scope-kebab>` from the diff paths
   and `git switch -c <type>/<scope-kebab>` (ASCII, no accents). Otherwise keep current branch.
+- Pick a release-appropriate `<type>`/`<scope>` per step 2b when the diff touches app-stack code.
 
 ### 2. Commit
 
@@ -47,6 +48,50 @@ or asks me to open one. It is the only path that should create a PR for this pro
   accents. Body in French if useful.
 - Commit with **no `Co-Authored-By` trailer** and no Claude mention.
 - Many local commits are fine (squash-merge later). Commit before checks so the diff is stable.
+- Choose `<type>(<scope>)` **release-aware** per step 2b below - the squash-merge uses the
+  PR title as the commit subject, so this token decides whether the app deploys.
+
+### 2b. Release-aware type & scope
+
+The release/deploy pipeline has **two independent gates**; **both** must pass for
+semantic-release to cut a version and the app to deploy. Because squash-merge turns the PR
+title into the commit subject, the PR title's `<type>(<scope>)` is decisive - get it wrong
+and merged app code never ships.
+
+**Gate 1 - file filter** (`.github/workflows/quality.yml`, `changes` job, `dorny/paths-filter`):
+sets `app=true` only when the diff touches `api/**`, `app-partners/**`, `app-observatory/**`,
+or `shared/**`. The `release` job is gated on `app=true`. A **data-only** PR (sqlmesh / dbt /
+datalake / cms / docker / .github ...) can **never** cut a release, whatever the title says.
+
+**Gate 2 - commit-analyzer** (`.releaserc`, `conventionalcommits` preset):
+
+- Releasing types: `feat` -> minor, `fix` / `perf` / `revert` -> patch, `BREAKING CHANGE` (or `!`) -> major.
+- Non-releasing types: `chore`, `docs`, `refactor`, `style`, `test`, `build`, `ci` -> **no release**.
+- Scope override (`releaseRules`): scope `dbt`, `sqlmesh`, `datalake`, `cms` -> **no release**,
+  even with a `feat`/`fix` type.
+
+**Naming rule:**
+
+- Diff touches **app-stack code** (`api` / `app-partners` / `app-observatory` / `shared`) **and
+  must deploy** -> title MUST be a releasing type (`feat`/`fix`/`perf`) with a **non-data scope**
+  reflecting the app area (e.g. `export`, `api`, `partners`, `observatory`). **Never** scope app
+  code with `sqlmesh`/`dbt`/`datalake`/`cms`.
+- PR **mixes** app code with data files -> do not use a data scope (it suppresses the release and
+  the app code never deploys). Use an app scope, or split the data-only part into its own PR.
+- PR is **data-only** or intentionally non-deploying (docs/CI/chore) -> use the honest
+  type/scope; it will correctly **not** cut a release.
+
+**Pitfalls (both seen in practice):**
+
+- `fix(sqlmesh)` on a PR that also edits `api/**`: files pass gate 1, but the `sqlmesh` scope
+  trips gate 2 -> no release -> API not deployed.
+- A data-only PR retitled `fix(api)` to force a release: gate 2 ok, but gate 1 sees no app
+  files -> `release` job skipped -> still no release.
+
+**Why it matters:** `deploy-api` / `deploy-partner` / `deploy-observatory` fire on
+`release: published` and build an image tagged with the **release tag**, which the cluster
+deploys. A manual `workflow_dispatch` builds a `github.sha`-tagged image the cluster does not
+reference -> no rollout. A real release is the only way to deploy app code.
 
 ### 3. CGU freshness (refresh if stale)
 
@@ -92,7 +137,8 @@ checklist** rather than invoking the command.
   - `pr-body.md` - French PR description: summary, what changed, and a section per check
     embedding its French report (`## Sécurité`, `## CGU`). **No** "Generated with Claude" line,
     no Claude mention.
-- PR title = the commit subject (French description, ASCII conventional token).
+- PR title = the commit subject (French description, ASCII conventional token). The
+  `<type>(<scope>)` must follow step 2b - on app-stack PRs that should deploy, never a data scope.
 
 ### 7. Create the PR (with confirmation)
 
@@ -104,5 +150,6 @@ checklist** rather than invoking the command.
 
 ## Output
 
-Report: branch, commit subject, each check's verdict (PASS/FAIL + count), and the PR URL once
-created - or the blocking reason if halted at the gate.
+Report: branch, commit subject, each check's verdict (PASS/FAIL + count), the PR URL once
+created - or the blocking reason if halted at the gate - and the **release verdict** per step 2b
+(will this PR cut a version and deploy, or not, and why).


### PR DESCRIPTION
## Résumé

Documente dans le skill `pr-prep` les contraintes du pipeline de release, pour qu'une
PR touchant du code applicatif reçoive toujours un nom qui déclenche bien le déploiement.

## Ce qui change

- `.claude/skills/pr-prep/SKILL.md` : nouvelle étape **2b - Release-aware type & scope**.

Le skill explicite désormais les **deux gardes** qui décident d'une release (les deux
doivent passer) :

1. **Filtre de fichiers** (`quality.yml`, job `changes`, `dorny/paths-filter`) :
   `app=true` seulement si le diff touche `api/**`, `app-partners/**`,
   `app-observatory/**` ou `shared/**`. Une PR data-only ne coupe jamais de version.
2. **Analyse de commit** (`.releaserc`, preset `conventionalcommits`) : types
   releasables `feat`/`fix`/`perf`, et override de scope `dbt`/`sqlmesh`/`datalake`/`cms`
   -> pas de release.

Règle de nommage ajoutée : une PR qui touche du code applicatif **et doit être
déployée** porte un type releasable avec un **scope non-data** (ex. `export`, `api`,
`partners`, `observatory`), jamais `sqlmesh`/`dbt`/`datalake`/`cms`. Les deux pièges
réels sont documentés (`fix(sqlmesh)` sur une PR qui édite aussi `api/**` ; PR data-only
renommée `fix(api)`).

La contrainte est câblée dans les étapes Branch, Commit et Titre, et un **verdict de
release** est ajouté à la sortie du skill.

## Contexte release

Changement de documentation de skill (`.claude/`), hors filtre applicatif et scope
`chore` : ne coupe **pas** de version (comportement attendu).

## Sécurité

**Verdict : PASS** (non bloquant)

RAS. Modification markdown uniquement, aucune surface de code, secret ou donnée.

## CGU

**Verdict : PASS** (bloquant)

RAS. Aucune règle CGU concernée (documentation interne d'outillage).