### PR TITLE
chore(api): corrige le cache deno en dev et rend --cached-only opt-out

### DIFF
--- a/api/justfile
+++ b/api/justfile
@@ -7,7 +7,11 @@ docker_compose_dev_file:=join(parent_directory(justfile_directory()),"docker-com
 docker_compose_e2e_file:=join(parent_directory(justfile_directory()),"docker-compose.e2e.yml")
 docker_compose_base_file:=join(parent_directory(justfile_directory()),"docker-compose.base.yml")
 docker_compose_proxy_file:=join(parent_directory(justfile_directory()),"docker-compose.proxy.yml")
-deno_flags := "--allow-net --allow-env --allow-read --allow-write --allow-ffi --allow-sys --allow-run --unstable-fs --cached-only"
+# `--cached-only` by default (CI/image-safe). Override with `DENO_CACHED_ONLY=`
+# (empty) locally to allow Deno to auto-fetch missing deps.
+deno_cached_only := env_var_or_default("DENO_CACHED_ONLY", "--cached-only")
+deno_allow_import := "--allow-import=cdn.sheetjs.com:443,cdn.esm.sh:443,deno.land:443,raw.githubusercontent.com:443,jsr.io:443"
+deno_flags := "--allow-net --allow-env --allow-read --allow-write --allow-ffi --allow-sys --allow-run --unstable-fs " + deno_allow_import + " " + deno_cached_only
 
 # List available just commands
 default:
@@ -347,26 +351,26 @@ add-hosts:
 # install
 [group('deno')]
 install:
-  deno install --frozen=true --allow-import=cdn.sheetjs.com:443,cdn.esm.sh:443,deno.land:443,raw.githubusercontent.com:443,jsr.io:443
+  deno install --frozen=true {{ deno_allow_import }}
 
 # cache all dependencies for src/mains.ts
 [group('deno')]
 cache:
-  deno cache --quiet --frozen=true --allow-import=cdn.esm.sh:443,deno.land:443,raw.githubusercontent.com:443,jsr.io:443 src/main.ts
+  deno cache --quiet --frozen=true {{ deno_allow_import }} src/main.ts
 
 # cache all dependencies for src/db/cmd-migrate.ts
 [group('deno')]
 cache-migrator:
-  deno cache --quiet --frozen=true --allow-import=cdn.sheetjs.com:443,cdn.esm.sh:443,deno.land:443,raw.githubusercontent.com:443,jsr.io:443 src/db/cmd-migrate.ts
+  deno cache --quiet --frozen=true {{ deno_allow_import }} src/db/cmd-migrate.ts
 
 # refresh the deno.lock file
 [group('deno')]
 lock:
   #!/usr/bin/env bash
-  deno install --frozen=false --allow-import=cdn.sheetjs.com:443,cdn.esm.sh:443,deno.land:443,raw.githubusercontent.com:443,jsr.io:443
-  deno cache --frozen=false --allow-import=cdn.sheetjs.com:443,cdn.esm.sh:443,deno.land:443,raw.githubusercontent.com:443,jsr.io:443 ./**/*.spec.ts
-  deno cache --frozen=false --allow-import=cdn.sheetjs.com:443,cdn.esm.sh:443,deno.land:443,raw.githubusercontent.com:443,jsr.io:443 ./**/*.test.ts
-  deno cache --frozen=false --allow-import=cdn.sheetjs.com:443,cdn.esm.sh:443,deno.land:443,raw.githubusercontent.com:443,jsr.io:443 ./src/lib/logger/index.ts
+  deno install --frozen=false {{ deno_allow_import }}
+  deno cache --frozen=false {{ deno_allow_import }} ./**/*.spec.ts
+  deno cache --frozen=false {{ deno_allow_import }} ./**/*.test.ts
+  deno cache --frozen=false {{ deno_allow_import }} ./src/lib/logger/index.ts
 
 # Eval and run a file
 [group('development')]
@@ -374,7 +378,7 @@ eval *filepath:
   deno eval \
     --allow-net \
     --allow-env \
-    --cached-only \
+    {{ deno_cached_only }} \
     # --allow-read \
     # --allow-write \
     # --allow-ffi \

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -39,11 +39,14 @@ services:
       APP_REQUEST_TIMEOUT: 0
       APP_APDF_S3_UPLOAD_ENABLED: false
       DENO_DIR: /app/api/.cache
+      # Opt out of `--cached-only` so dev auto-fetches missing deps into the mounted cache.
+      DENO_CACHED_ONLY: ''
     ports:
       - ${PORT:-8080}:${PORT:-8080}
     volumes:
       - ./api:/app/api
-      - ./api/.cache:/app/api/.cache:rw
+      # Named volume avoids the host/container uid mismatch that would block cache writes.
+      - deno_cache:/app/api/.cache
       - ./tmp:/tmp
 
   # cms:
@@ -64,3 +67,6 @@ services:
   s3:
     ports:
       - 9000:9000
+
+volumes:
+  deno_cache:


### PR DESCRIPTION
## Résumé

Le démarrage local de l'API (`just up api`) échouait avec `error: ... --cached-only is specified` dès qu'une dépendance manquait du cache Deno monté. La cause principale n'était pas le flag lui-même : le bind `./api/.cache:/app/api/.cache:rw` était possédé par l'uid de l'hôte (1000) en mode 755, et le conteneur tourne sous l'uid `deno` (1993). Deno ne pouvait donc pas écrire dans le cache, ce qui se traduisait par une erreur masquée par `--cached-only`.

Cette PR rend `--cached-only` opt-out via variable d'environnement, et remplace le bind par un volume nommé pour éliminer le conflit d'uid. CI et image de production restent en mode scellé par défaut.

## Changements

- `api/justfile` — `deno_cached_only` lu depuis `DENO_CACHED_ONLY` (défaut `--cached-only`, donc CI/image inchangées). `deno_allow_import` extrait en variable et réutilisé par `install` / `cache` / `cache-migrator` / `lock` / `deno_flags` / `eval`. Au passage, `just cache` reçoit `cdn.sheetjs.com:443` qu'il lui manquait (élargissement d'autorisation, jamais déclencheur de fetch).
- `docker-compose.dev.yml` — `DENO_CACHED_ONLY: ''` côté service `api` pour permettre l'auto-fetch des deps manquantes au premier démarrage. Bind `./api/.cache` remplacé par le volume nommé `deno_cache`, propriété du user `deno` du conteneur, persisté entre les recreations.

## Comportement attendu

| Contexte | Effet |
|---|---|
| Image prod (`docker build` + `just serve`) | `DENO_CACHED_ONLY` non défini → `--cached-only` actif. Aucun changement de comportement. |
| CI (`just cache && just ci_test_unit`) | Inchangé. |
| Dev local (`just up api`) | Premier démarrage : Deno télécharge dans le volume `deno_cache`. Démarrages suivants : cache chaud, immédiat. Plus aucune intervention manuelle après un `just lock`. |
| Mode scellé local (debug) | `DENO_CACHED_ONLY=--cached-only just serve`. |

Note : `./api/.cache` sur l'hôte devient inutilisé (toujours gitignored, suppression libre).

## Sécurité

**Verdict :** PASS — sévérité none

Aucun problème identifié :

- L'allowlist `--allow-import` est centralisée mais inchangée (cdn.sheetjs.com, cdn.esm.sh, deno.land, raw.githubusercontent.com, jsr.io).
- `--cached-only` reste le défaut pour la prod/CI → builds reproductibles préservés.
- Volume nommé Docker élimine les permissions hôte/conteneur fragiles.
- Variable d'opt-out limitée au compose dev, pas d'exposition de secret.

## CGU

**Verdict :** PASS — sévérité none

Modifications strictement infra/DX (workflow Deno, volume Docker). Aucun impact sur la logique métier, la rétention des données personnelles, ou les flux trajet.
