### PR TITLE
fix(datalake): corrige la correction géo pour 2026 et fiabilise carpools_geo_correction

### DIFF
--- a/.github/workflows/quality-datalake.yml
+++ b/.github/workflows/quality-datalake.yml
@@ -135,6 +135,8 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
+          # Full history so we can compute the merge-base diff against the PR base.
+          fetch-depth: 0
       # The sqlfluff dbt templater opens a DB connection per file and can
       # leave them "idle in transaction"; a lint run bursts past the
       # default max_connections (100) -> "too many clients already".
@@ -164,6 +166,38 @@ jobs:
       - name: Install dbt packages
         working-directory: datalake
         run: uv run dbt deps --profiles-dir profiles
-      - name: Run sqlfluff lint
+      # Only lint the .sql files changed in this PR (merge-base diff vs the base
+      # branch). The dbt templater is serialized (processes = 1), so linting all
+      # ~495 models takes ~1h; scoping to the diff keeps the job to a few minutes.
+      - name: Determine changed SQL files
+        id: changed
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin "$BASE_REF"
+          # Allowlist filenames (safe charset only) so a malicious filename
+          # cannot inject into later steps via $GITHUB_OUTPUT.
+          mapfile -t files < <(
+            git diff --name-only --diff-filter=d \
+              "origin/${BASE_REF}...HEAD" \
+              -- datalake/models datalake/analyses \
+              | sed 's#^datalake/##' \
+              | grep -E '^[A-Za-z0-9_./-]+\.sql$' || true
+          )
+          if [ "${#files[@]}" -eq 0 ]; then
+            echo "Aucun .sql modifié sous models/ ou analyses/ — lint sauté."
+            echo "none=true" >> "$GITHUB_OUTPUT"
+          else
+            printf 'Fichiers à linter:\n'; printf '  %s\n' "${files[@]}"
+            { echo "files<<EOF"; printf '%s\n' "${files[@]}"; echo "EOF"; } >> "$GITHUB_OUTPUT"
+          fi
+      - name: Run sqlfluff lint (changed files only)
+        if: steps.changed.outputs.none != 'true'
         working-directory: datalake
-        run: uv run sqlfluff lint models/ analyses/
+        env:
+          CHANGED_FILES: ${{ steps.changed.outputs.files }}
+        run: |
+          set -euo pipefail
+          mapfile -t files <<< "$CHANGED_FILES"
+          uv run sqlfluff lint -- "${files[@]}"

--- a/datalake/justfile
+++ b/datalake/justfile
@@ -28,18 +28,13 @@ osmosis-dry-run layer *args:
 docs-serve *args:
   dbt docs serve --profiles-dir profiles {{args}}
 
-# Lint SQL models with sqlfluff (per-file to avoid dbt connection bursts)
+# Lint SQL models with sqlfluff
 lint *args:
-  #!/usr/bin/env bash
-  set -e
-  find models analyses -name '*.sql' -print0 \
-    | xargs -0 -I {} sh -c 'DBT_PROFILES_DIR=profiles sqlfluff lint --processes 1 "$1" {{args}}' _ {}
+  DBT_PROFILES_DIR=profiles sqlfluff lint --processes 1 models/ tests/ macros/ analyses/ {{args}}
 
-# Lint SQL models and auto-fix violations (per-file to avoid dbt connection bursts)
+# Lint SQL models and auto-fix violations (exit 1 = unfixable violations remain, not a failure)
 lint-fix *args:
-  #!/usr/bin/env bash
-  find models analyses -name '*.sql' -print0 \
-    | xargs -0 -I {} sh -c 'DBT_PROFILES_DIR=profiles sqlfluff fix --processes 1 "$1" {{args}}' _ {}
+  -DBT_PROFILES_DIR=profiles sqlfluff fix --processes 1 models/ tests/ macros/ analyses/ {{args}}
 
 # Seed data from S3 to Postgres
 seed config schema *args:

--- a/datalake/models/exposed/observatory/incentive_month.sql
+++ b/datalake/models/exposed/observatory/incentive_month.sql
@@ -20,13 +20,13 @@
 
 WITH
 {% if is_incremental() %}
-lookback AS (
-  SELECT max(year * 100 + month) - 1 AS min_ym FROM {{ this }}
-),
+  lookback AS (
+    SELECT max(year * 100 + month) - 1 AS min_ym FROM {{ this }}
+  ),
 {% endif %}
 
 max_perim_year AS (
-  SELECT MAX(year) AS y FROM {{ ref('perimeters_agg') }}
+  SELECT max(year) AS y FROM {{ ref('perimeters_agg') }}
 ),
 
 territory AS (
@@ -42,8 +42,8 @@ territory AS (
       no_oi                AS no_incentive
     FROM {{ ref('territory_month_' ~ model_type ~ '_both') }}
     {% if is_incremental() %}
-  WHERE year * 100 + month >= (SELECT min_ym FROM lookback)
-  {% endif %}
+      WHERE year * 100 + month >= (SELECT min_ym FROM lookback)
+    {% endif %}
     {% if not loop.last %}UNION ALL{% endif %}
   {% endfor %}
 )
@@ -61,4 +61,4 @@ SELECT
 FROM territory AS t
 LEFT JOIN {{ ref('perimeters_agg') }}
   AS p ON t.code = p.code AND t.type = p.type
-AND p.year = LEAST(t.year, (SELECT y FROM max_perim_year))
+AND p.year = least(t.year, (SELECT y FROM max_perim_year))

--- a/datalake/models/exposed/observatory/incentive_quarter.sql
+++ b/datalake/models/exposed/observatory/incentive_quarter.sql
@@ -20,13 +20,13 @@
 
 WITH
 {% if is_incremental() %}
-lookback AS (
-  SELECT max(year * 4 + quarter) - 1 AS min_yq FROM {{ this }}
-),
+  lookback AS (
+    SELECT max(year * 4 + quarter) - 1 AS min_yq FROM {{ this }}
+  ),
 {% endif %}
 
 max_perim_year AS (
-  SELECT MAX(year) AS y FROM {{ ref('perimeters_agg') }}
+  SELECT max(year) AS y FROM {{ ref('perimeters_agg') }}
 ),
 
 territory AS (
@@ -42,8 +42,8 @@ territory AS (
       no_oi                AS no_incentive
     FROM {{ ref('territory_quarter_' ~ model_type ~ '_both') }}
     {% if is_incremental() %}
-  WHERE year * 4 + quarter >= (SELECT min_yq FROM lookback)
-  {% endif %}
+      WHERE year * 4 + quarter >= (SELECT min_yq FROM lookback)
+    {% endif %}
     {% if not loop.last %}UNION ALL{% endif %}
   {% endfor %}
 )
@@ -61,4 +61,4 @@ SELECT
 FROM territory AS t
 LEFT JOIN {{ ref('perimeters_agg') }}
   AS p ON t.code = p.code AND t.type = p.type
-AND p.year = LEAST(t.year, (SELECT y FROM max_perim_year))
+AND p.year = least(t.year, (SELECT y FROM max_perim_year))

--- a/datalake/models/exposed/observatory/incentive_semester.sql
+++ b/datalake/models/exposed/observatory/incentive_semester.sql
@@ -20,13 +20,13 @@
 
 WITH
 {% if is_incremental() %}
-lookback AS (
-  SELECT max(year * 2 + semester) - 1 AS min_ys FROM {{ this }}
-),
+  lookback AS (
+    SELECT max(year * 2 + semester) - 1 AS min_ys FROM {{ this }}
+  ),
 {% endif %}
 
 max_perim_year AS (
-  SELECT MAX(year) AS y FROM {{ ref('perimeters_agg') }}
+  SELECT max(year) AS y FROM {{ ref('perimeters_agg') }}
 ),
 
 territory AS (
@@ -42,8 +42,8 @@ territory AS (
       no_oi                AS no_incentive
     FROM {{ ref('territory_semester_' ~ model_type ~ '_both') }}
     {% if is_incremental() %}
-  WHERE year * 2 + semester >= (SELECT min_ys FROM lookback)
-  {% endif %}
+      WHERE year * 2 + semester >= (SELECT min_ys FROM lookback)
+    {% endif %}
     {% if not loop.last %}UNION ALL{% endif %}
   {% endfor %}
 )
@@ -61,4 +61,4 @@ SELECT
 FROM territory AS t
 LEFT JOIN {{ ref('perimeters_agg') }}
   AS p ON t.code = p.code AND t.type = p.type
-AND p.year = LEAST(t.year, (SELECT y FROM max_perim_year))
+AND p.year = least(t.year, (SELECT y FROM max_perim_year))

--- a/datalake/models/exposed/observatory/incentive_year.sql
+++ b/datalake/models/exposed/observatory/incentive_year.sql
@@ -20,13 +20,13 @@
 
 WITH
 {% if is_incremental() %}
-lookback AS (
-  SELECT max(year) - 1 AS min_year FROM {{ this }}
-),
+  lookback AS (
+    SELECT max(year) - 1 AS min_year FROM {{ this }}
+  ),
 {% endif %}
 
 max_perim_year AS (
-  SELECT MAX(year) AS y FROM {{ ref('perimeters_agg') }}
+  SELECT max(year) AS y FROM {{ ref('perimeters_agg') }}
 ),
 
 territory AS (
@@ -41,8 +41,8 @@ territory AS (
       no_oi                AS no_incentive
     FROM {{ ref('territory_year_' ~ model_type ~ '_both') }}
     {% if is_incremental() %}
-  WHERE year >= (SELECT min_year FROM lookback)
-  {% endif %}
+      WHERE year >= (SELECT min_year FROM lookback)
+    {% endif %}
     {% if not loop.last %}UNION ALL{% endif %}
   {% endfor %}
 )
@@ -59,4 +59,4 @@ SELECT
 FROM territory AS t
 LEFT JOIN {{ ref('perimeters_agg') }}
   AS p ON t.code = p.code AND t.type = p.type
-AND p.year = LEAST(t.year, (SELECT y FROM max_perim_year))
+AND p.year = least(t.year, (SELECT y FROM max_perim_year))

--- a/datalake/models/exposed/observatory/occupation_month.sql
+++ b/datalake/models/exposed/observatory/occupation_month.sql
@@ -20,13 +20,13 @@
 
 WITH
 {% if is_incremental() %}
-lookback AS (
-  SELECT max(year * 100 + month) - 1 AS min_ym FROM {{ this }}
-),
+  lookback AS (
+    SELECT max(year * 100 + month) - 1 AS min_ym FROM {{ this }}
+  ),
 {% endif %}
 
 max_perim_year AS (
-  SELECT MAX(year) AS y FROM {{ ref('perimeters_agg') }}
+  SELECT max(year) AS y FROM {{ ref('perimeters_agg') }}
 ),
 
 territory AS (
@@ -43,8 +43,8 @@ territory AS (
       passenger_seats
     FROM {{ ref('territory_month_' ~ model_type ~ '_both') }}
     {% if is_incremental() %}
-  WHERE year * 100 + month >= (SELECT min_ym FROM lookback)
-  {% endif %}
+      WHERE year * 100 + month >= (SELECT min_ym FROM lookback)
+    {% endif %}
     {% if not loop.last %}UNION ALL{% endif %}
   {% endfor %}
 )
@@ -58,13 +58,13 @@ SELECT
   t.journeys,
   t.trips,
   t.has_incentive,
-  ROUND(
-    (t.carpools + t.passenger_seats)::numeric / NULLIF(t.carpools, 0), 2
+  round(
+    (t.carpools + t.passenger_seats)::numeric / nullif(t.carpools, 0), 2
   )                             AS occupation_rate,
-  ST_ASGEOJSON(p.geom, 6)::json AS geom
+  st_asgeojson(p.geom, 6)::json AS geom
 FROM territory AS t
 LEFT JOIN {{ ref('perimeters_agg') }} AS p
   ON
     t.code = p.code AND t.type = p.type
-    AND p.year = LEAST(t.year, (SELECT y FROM max_perim_year))
+    AND p.year = least(t.year, (SELECT y FROM max_perim_year))
 WHERE t.carpools > 0

--- a/datalake/models/exposed/observatory/occupation_quarter.sql
+++ b/datalake/models/exposed/observatory/occupation_quarter.sql
@@ -20,13 +20,13 @@
 
 WITH
 {% if is_incremental() %}
-lookback AS (
-  SELECT max(year * 4 + quarter) - 1 AS min_yq FROM {{ this }}
-),
+  lookback AS (
+    SELECT max(year * 4 + quarter) - 1 AS min_yq FROM {{ this }}
+  ),
 {% endif %}
 
 max_perim_year AS (
-  SELECT MAX(year) AS y FROM {{ ref('perimeters_agg') }}
+  SELECT max(year) AS y FROM {{ ref('perimeters_agg') }}
 ),
 
 territory AS (
@@ -43,8 +43,8 @@ territory AS (
       passenger_seats
     FROM {{ ref('territory_quarter_' ~ model_type ~ '_both') }}
     {% if is_incremental() %}
-  WHERE year * 4 + quarter >= (SELECT min_yq FROM lookback)
-  {% endif %}
+      WHERE year * 4 + quarter >= (SELECT min_yq FROM lookback)
+    {% endif %}
     {% if not loop.last %}UNION ALL{% endif %}
   {% endfor %}
 )
@@ -58,13 +58,13 @@ SELECT
   t.journeys,
   t.trips,
   t.has_incentive,
-  ROUND(
-    (t.carpools + t.passenger_seats)::numeric / NULLIF(t.carpools, 0), 2
+  round(
+    (t.carpools + t.passenger_seats)::numeric / nullif(t.carpools, 0), 2
   )                             AS occupation_rate,
-  ST_ASGEOJSON(p.geom, 6)::json AS geom
+  st_asgeojson(p.geom, 6)::json AS geom
 FROM territory AS t
 LEFT JOIN {{ ref('perimeters_agg') }} AS p
   ON
     t.code = p.code AND t.type = p.type
-    AND p.year = LEAST(t.year, (SELECT y FROM max_perim_year))
+    AND p.year = least(t.year, (SELECT y FROM max_perim_year))
 WHERE t.carpools > 0

--- a/datalake/models/exposed/observatory/occupation_semester.sql
+++ b/datalake/models/exposed/observatory/occupation_semester.sql
@@ -20,13 +20,13 @@
 
 WITH
 {% if is_incremental() %}
-lookback AS (
-  SELECT max(year * 2 + semester) - 1 AS min_ys FROM {{ this }}
-),
+  lookback AS (
+    SELECT max(year * 2 + semester) - 1 AS min_ys FROM {{ this }}
+  ),
 {% endif %}
 
 max_perim_year AS (
-  SELECT MAX(year) AS y FROM {{ ref('perimeters_agg') }}
+  SELECT max(year) AS y FROM {{ ref('perimeters_agg') }}
 ),
 
 territory AS (
@@ -43,8 +43,8 @@ territory AS (
       passenger_seats
     FROM {{ ref('territory_semester_' ~ model_type ~ '_both') }}
     {% if is_incremental() %}
-  WHERE year * 2 + semester >= (SELECT min_ys FROM lookback)
-  {% endif %}
+      WHERE year * 2 + semester >= (SELECT min_ys FROM lookback)
+    {% endif %}
     {% if not loop.last %}UNION ALL{% endif %}
   {% endfor %}
 )
@@ -58,13 +58,13 @@ SELECT
   t.journeys,
   t.trips,
   t.has_incentive,
-  ROUND(
-    (t.carpools + t.passenger_seats)::numeric / NULLIF(t.carpools, 0), 2
+  round(
+    (t.carpools + t.passenger_seats)::numeric / nullif(t.carpools, 0), 2
   )                             AS occupation_rate,
-  ST_ASGEOJSON(p.geom, 6)::json AS geom
+  st_asgeojson(p.geom, 6)::json AS geom
 FROM territory AS t
 LEFT JOIN {{ ref('perimeters_agg') }} AS p
   ON
     t.code = p.code AND t.type = p.type
-    AND p.year = LEAST(t.year, (SELECT y FROM max_perim_year))
+    AND p.year = least(t.year, (SELECT y FROM max_perim_year))
 WHERE t.carpools > 0

--- a/datalake/models/exposed/observatory/occupation_year.sql
+++ b/datalake/models/exposed/observatory/occupation_year.sql
@@ -20,13 +20,13 @@
 
 WITH
 {% if is_incremental() %}
-lookback AS (
-  SELECT max(year) - 1 AS min_year FROM {{ this }}
-),
+  lookback AS (
+    SELECT max(year) - 1 AS min_year FROM {{ this }}
+  ),
 {% endif %}
 
 max_perim_year AS (
-  SELECT MAX(year) AS y FROM {{ ref('perimeters_agg') }}
+  SELECT max(year) AS y FROM {{ ref('perimeters_agg') }}
 ),
 
 territory AS (
@@ -42,8 +42,8 @@ territory AS (
       passenger_seats
     FROM {{ ref('territory_year_' ~ model_type ~ '_both') }}
     {% if is_incremental() %}
-  WHERE year >= (SELECT min_year FROM lookback)
-  {% endif %}
+      WHERE year >= (SELECT min_year FROM lookback)
+    {% endif %}
     {% if not loop.last %}UNION ALL{% endif %}
   {% endfor %}
 )
@@ -56,13 +56,13 @@ SELECT
   t.journeys,
   t.trips,
   t.has_incentive,
-  ROUND(
-    (t.carpools + t.passenger_seats)::numeric / NULLIF(t.carpools, 0), 2
+  round(
+    (t.carpools + t.passenger_seats)::numeric / nullif(t.carpools, 0), 2
   )                             AS occupation_rate,
-  ST_ASGEOJSON(p.geom, 6)::json AS geom
+  st_asgeojson(p.geom, 6)::json AS geom
 FROM territory AS t
 LEFT JOIN {{ ref('perimeters_agg') }} AS p
   ON
     t.code = p.code AND t.type = p.type
-    AND p.year = LEAST(t.year, (SELECT y FROM max_perim_year))
+    AND p.year = least(t.year, (SELECT y FROM max_perim_year))
 WHERE t.carpools > 0

--- a/datalake/models/exposed/observatory/od_month.sql
+++ b/datalake/models/exposed/observatory/od_month.sql
@@ -20,13 +20,13 @@
 
 WITH
 {% if is_incremental() %}
-lookback AS (
-  SELECT max(year * 100 + month) - 1 AS min_ym FROM {{ this }}
-),
+  lookback AS (
+    SELECT max(year * 100 + month) - 1 AS min_ym FROM {{ this }}
+  ),
 {% endif %}
 
 max_perim_year AS (
-  SELECT MAX(year) AS y FROM {{ ref('perimeters_agg') }}
+  SELECT max(year) AS y FROM {{ ref('perimeters_agg') }}
 ),
 
 od AS (
@@ -43,8 +43,8 @@ od AS (
       duration
     FROM {{ ref('od_month_' ~ model_type) }}
     {% if is_incremental() %}
-  WHERE year * 100 + month >= (SELECT min_ym FROM lookback)
-  {% endif %}
+      WHERE year * 100 + month >= (SELECT min_ym FROM lookback)
+    {% endif %}
     {% if not loop.last %}UNION ALL{% endif %}
   {% endfor %}
 )
@@ -59,17 +59,17 @@ SELECT
   p2.libelle                     AS l_territory_2,
   od.journeys,
   od.passengers,
-  ROUND(od.distance / 1000.0, 2) AS distance,
-  ROUND(od.duration / 60.0, 2)   AS duration,
-  ST_X(p1.centroid)              AS lng_1,
-  ST_Y(p1.centroid)              AS lat_1,
-  ST_X(p2.centroid)              AS lng_2,
-  ST_Y(p2.centroid)              AS lat_2
+  round(od.distance / 1000.0, 2) AS distance,
+  round(od.duration / 60.0, 2)   AS duration,
+  st_x(p1.centroid)              AS lng_1,
+  st_y(p1.centroid)              AS lat_1,
+  st_x(p2.centroid)              AS lng_2,
+  st_y(p2.centroid)              AS lat_2
 FROM od
 LEFT JOIN {{ ref('perimeters_agg') }} AS p1
   ON
     od.territory_1 = p1.code AND od.type = p1.type
-    AND p1.year = LEAST(od.year, (SELECT y FROM max_perim_year))
+    AND p1.year = least(od.year, (SELECT y FROM max_perim_year))
 LEFT JOIN {{ ref('perimeters_agg') }}
   AS p2 ON od.territory_2 = p2.code AND od.type = p2.type
-AND p2.year = LEAST(od.year, (SELECT y FROM max_perim_year))
+AND p2.year = least(od.year, (SELECT y FROM max_perim_year))

--- a/datalake/models/exposed/observatory/od_quarter.sql
+++ b/datalake/models/exposed/observatory/od_quarter.sql
@@ -20,13 +20,13 @@
 
 WITH
 {% if is_incremental() %}
-lookback AS (
-  SELECT max(year * 4 + quarter) - 1 AS min_yq FROM {{ this }}
-),
+  lookback AS (
+    SELECT max(year * 4 + quarter) - 1 AS min_yq FROM {{ this }}
+  ),
 {% endif %}
 
 max_perim_year AS (
-  SELECT MAX(year) AS y FROM {{ ref('perimeters_agg') }}
+  SELECT max(year) AS y FROM {{ ref('perimeters_agg') }}
 ),
 
 od AS (
@@ -43,8 +43,8 @@ od AS (
       duration
     FROM {{ ref('od_quarter_' ~ model_type) }}
     {% if is_incremental() %}
-  WHERE year * 4 + quarter >= (SELECT min_yq FROM lookback)
-  {% endif %}
+      WHERE year * 4 + quarter >= (SELECT min_yq FROM lookback)
+    {% endif %}
     {% if not loop.last %}UNION ALL{% endif %}
   {% endfor %}
 )
@@ -59,17 +59,17 @@ SELECT
   p2.libelle                     AS l_territory_2,
   od.journeys,
   od.passengers,
-  ROUND(od.distance / 1000.0, 2) AS distance,
-  ROUND(od.duration / 60.0, 2)   AS duration,
-  ST_X(p1.centroid)              AS lng_1,
-  ST_Y(p1.centroid)              AS lat_1,
-  ST_X(p2.centroid)              AS lng_2,
-  ST_Y(p2.centroid)              AS lat_2
+  round(od.distance / 1000.0, 2) AS distance,
+  round(od.duration / 60.0, 2)   AS duration,
+  st_x(p1.centroid)              AS lng_1,
+  st_y(p1.centroid)              AS lat_1,
+  st_x(p2.centroid)              AS lng_2,
+  st_y(p2.centroid)              AS lat_2
 FROM od
 LEFT JOIN {{ ref('perimeters_agg') }} AS p1
   ON
     od.territory_1 = p1.code AND od.type = p1.type
-    AND p1.year = LEAST(od.year, (SELECT y FROM max_perim_year))
+    AND p1.year = least(od.year, (SELECT y FROM max_perim_year))
 LEFT JOIN {{ ref('perimeters_agg') }}
   AS p2 ON od.territory_2 = p2.code AND od.type = p2.type
-AND p2.year = LEAST(od.year, (SELECT y FROM max_perim_year))
+AND p2.year = least(od.year, (SELECT y FROM max_perim_year))

--- a/datalake/models/exposed/observatory/od_semester.sql
+++ b/datalake/models/exposed/observatory/od_semester.sql
@@ -20,13 +20,13 @@
 
 WITH
 {% if is_incremental() %}
-lookback AS (
-  SELECT max(year * 2 + semester) - 1 AS min_ys FROM {{ this }}
-),
+  lookback AS (
+    SELECT max(year * 2 + semester) - 1 AS min_ys FROM {{ this }}
+  ),
 {% endif %}
 
 max_perim_year AS (
-  SELECT MAX(year) AS y FROM {{ ref('perimeters_agg') }}
+  SELECT max(year) AS y FROM {{ ref('perimeters_agg') }}
 ),
 
 od AS (
@@ -43,8 +43,8 @@ od AS (
       duration
     FROM {{ ref('od_semester_' ~ model_type) }}
     {% if is_incremental() %}
-  WHERE year * 2 + semester >= (SELECT min_ys FROM lookback)
-  {% endif %}
+      WHERE year * 2 + semester >= (SELECT min_ys FROM lookback)
+    {% endif %}
     {% if not loop.last %}UNION ALL{% endif %}
   {% endfor %}
 )
@@ -59,17 +59,17 @@ SELECT
   p2.libelle                     AS l_territory_2,
   od.journeys,
   od.passengers,
-  ROUND(od.distance / 1000.0, 2) AS distance,
-  ROUND(od.duration / 60.0, 2)   AS duration,
-  ST_X(p1.centroid)              AS lng_1,
-  ST_Y(p1.centroid)              AS lat_1,
-  ST_X(p2.centroid)              AS lng_2,
-  ST_Y(p2.centroid)              AS lat_2
+  round(od.distance / 1000.0, 2) AS distance,
+  round(od.duration / 60.0, 2)   AS duration,
+  st_x(p1.centroid)              AS lng_1,
+  st_y(p1.centroid)              AS lat_1,
+  st_x(p2.centroid)              AS lng_2,
+  st_y(p2.centroid)              AS lat_2
 FROM od
 LEFT JOIN {{ ref('perimeters_agg') }} AS p1
   ON
     od.territory_1 = p1.code AND od.type = p1.type
-    AND p1.year = LEAST(od.year, (SELECT y FROM max_perim_year))
+    AND p1.year = least(od.year, (SELECT y FROM max_perim_year))
 LEFT JOIN {{ ref('perimeters_agg') }}
   AS p2 ON od.territory_2 = p2.code AND od.type = p2.type
-AND p2.year = LEAST(od.year, (SELECT y FROM max_perim_year))
+AND p2.year = least(od.year, (SELECT y FROM max_perim_year))

--- a/datalake/models/exposed/observatory/od_year.sql
+++ b/datalake/models/exposed/observatory/od_year.sql
@@ -20,13 +20,13 @@
 
 WITH
 {% if is_incremental() %}
-lookback AS (
-  SELECT max(year) - 1 AS min_year FROM {{ this }}
-),
+  lookback AS (
+    SELECT max(year) - 1 AS min_year FROM {{ this }}
+  ),
 {% endif %}
 
 max_perim_year AS (
-  SELECT MAX(year) AS y FROM {{ ref('perimeters_agg') }}
+  SELECT max(year) AS y FROM {{ ref('perimeters_agg') }}
 ),
 
 od AS (
@@ -42,8 +42,8 @@ od AS (
       duration
     FROM {{ ref('od_year_' ~ model_type) }}
     {% if is_incremental() %}
-  WHERE year >= (SELECT min_year FROM lookback)
-  {% endif %}
+      WHERE year >= (SELECT min_year FROM lookback)
+    {% endif %}
     {% if not loop.last %}UNION ALL{% endif %}
   {% endfor %}
 )
@@ -57,17 +57,17 @@ SELECT
   p2.libelle                     AS l_territory_2,
   od.journeys,
   od.passengers,
-  ROUND(od.distance / 1000.0, 2) AS distance,
-  ROUND(od.duration / 60.0, 2)   AS duration,
-  ST_X(p1.centroid)              AS lng_1,
-  ST_Y(p1.centroid)              AS lat_1,
-  ST_X(p2.centroid)              AS lng_2,
-  ST_Y(p2.centroid)              AS lat_2
+  round(od.distance / 1000.0, 2) AS distance,
+  round(od.duration / 60.0, 2)   AS duration,
+  st_x(p1.centroid)              AS lng_1,
+  st_y(p1.centroid)              AS lat_1,
+  st_x(p2.centroid)              AS lng_2,
+  st_y(p2.centroid)              AS lat_2
 FROM od
 LEFT JOIN {{ ref('perimeters_agg') }} AS p1
   ON
     od.territory_1 = p1.code AND od.type = p1.type
-    AND p1.year = LEAST(od.year, (SELECT y FROM max_perim_year))
+    AND p1.year = least(od.year, (SELECT y FROM max_perim_year))
 LEFT JOIN {{ ref('perimeters_agg') }}
   AS p2 ON od.territory_2 = p2.code AND od.type = p2.type
-AND p2.year = LEAST(od.year, (SELECT y FROM max_perim_year))
+AND p2.year = least(od.year, (SELECT y FROM max_perim_year))

--- a/datalake/models/exposed/observatory/users_month.sql
+++ b/datalake/models/exposed/observatory/users_month.sql
@@ -20,13 +20,13 @@
 
 WITH
 {% if is_incremental() %}
-lookback AS (
-  SELECT max(year * 100 + month) - 1 AS min_ym FROM {{ this }}
-),
+  lookback AS (
+    SELECT max(year * 100 + month) - 1 AS min_ym FROM {{ this }}
+  ),
 {% endif %}
 
 max_perim_year AS (
-  SELECT MAX(year) AS y FROM {{ ref('perimeters_agg') }}
+  SELECT max(year) AS y FROM {{ ref('perimeters_agg') }}
 ),
 
 territory AS (
@@ -42,8 +42,8 @@ territory AS (
       new_passengers
     FROM {{ ref('territory_month_' ~ model_type ~ '_both') }}
     {% if is_incremental() %}
-  WHERE year * 100 + month >= (SELECT min_ym FROM lookback)
-  {% endif %}
+      WHERE year * 100 + month >= (SELECT min_ym FROM lookback)
+    {% endif %}
     {% if not loop.last %}UNION ALL{% endif %}
   {% endfor %}
 )
@@ -61,4 +61,4 @@ SELECT
 FROM territory AS t
 LEFT JOIN {{ ref('perimeters_agg') }}
   AS p ON t.code = p.code AND t.type = p.type
-AND p.year = LEAST(t.year, (SELECT y FROM max_perim_year))
+AND p.year = least(t.year, (SELECT y FROM max_perim_year))

--- a/datalake/models/exposed/observatory/users_quarter.sql
+++ b/datalake/models/exposed/observatory/users_quarter.sql
@@ -20,13 +20,13 @@
 
 WITH
 {% if is_incremental() %}
-lookback AS (
-  SELECT max(year * 4 + quarter) - 1 AS min_yq FROM {{ this }}
-),
+  lookback AS (
+    SELECT max(year * 4 + quarter) - 1 AS min_yq FROM {{ this }}
+  ),
 {% endif %}
 
 max_perim_year AS (
-  SELECT MAX(year) AS y FROM {{ ref('perimeters_agg') }}
+  SELECT max(year) AS y FROM {{ ref('perimeters_agg') }}
 ),
 
 territory AS (
@@ -42,8 +42,8 @@ territory AS (
       new_passengers
     FROM {{ ref('territory_quarter_' ~ model_type ~ '_both') }}
     {% if is_incremental() %}
-  WHERE year * 4 + quarter >= (SELECT min_yq FROM lookback)
-  {% endif %}
+      WHERE year * 4 + quarter >= (SELECT min_yq FROM lookback)
+    {% endif %}
     {% if not loop.last %}UNION ALL{% endif %}
   {% endfor %}
 )
@@ -61,4 +61,4 @@ SELECT
 FROM territory AS t
 LEFT JOIN {{ ref('perimeters_agg') }}
   AS p ON t.code = p.code AND t.type = p.type
-AND p.year = LEAST(t.year, (SELECT y FROM max_perim_year))
+AND p.year = least(t.year, (SELECT y FROM max_perim_year))

--- a/datalake/models/exposed/observatory/users_semester.sql
+++ b/datalake/models/exposed/observatory/users_semester.sql
@@ -20,13 +20,13 @@
 
 WITH
 {% if is_incremental() %}
-lookback AS (
-  SELECT max(year * 2 + semester) - 1 AS min_ys FROM {{ this }}
-),
+  lookback AS (
+    SELECT max(year * 2 + semester) - 1 AS min_ys FROM {{ this }}
+  ),
 {% endif %}
 
 max_perim_year AS (
-  SELECT MAX(year) AS y FROM {{ ref('perimeters_agg') }}
+  SELECT max(year) AS y FROM {{ ref('perimeters_agg') }}
 ),
 
 territory AS (
@@ -42,8 +42,8 @@ territory AS (
       new_passengers
     FROM {{ ref('territory_semester_' ~ model_type ~ '_both') }}
     {% if is_incremental() %}
-  WHERE year * 2 + semester >= (SELECT min_ys FROM lookback)
-  {% endif %}
+      WHERE year * 2 + semester >= (SELECT min_ys FROM lookback)
+    {% endif %}
     {% if not loop.last %}UNION ALL{% endif %}
   {% endfor %}
 )
@@ -61,4 +61,4 @@ SELECT
 FROM territory AS t
 LEFT JOIN {{ ref('perimeters_agg') }}
   AS p ON t.code = p.code AND t.type = p.type
-AND p.year = LEAST(t.year, (SELECT y FROM max_perim_year))
+AND p.year = least(t.year, (SELECT y FROM max_perim_year))

--- a/datalake/models/exposed/observatory/users_year.sql
+++ b/datalake/models/exposed/observatory/users_year.sql
@@ -20,13 +20,13 @@
 
 WITH
 {% if is_incremental() %}
-lookback AS (
-  SELECT max(year) - 1 AS min_year FROM {{ this }}
-),
+  lookback AS (
+    SELECT max(year) - 1 AS min_year FROM {{ this }}
+  ),
 {% endif %}
 
 max_perim_year AS (
-  SELECT MAX(year) AS y FROM {{ ref('perimeters_agg') }}
+  SELECT max(year) AS y FROM {{ ref('perimeters_agg') }}
 ),
 
 territory AS (
@@ -41,8 +41,8 @@ territory AS (
       new_passengers
     FROM {{ ref('territory_year_' ~ model_type ~ '_both') }}
     {% if is_incremental() %}
-  WHERE year >= (SELECT min_year FROM lookback)
-  {% endif %}
+      WHERE year >= (SELECT min_year FROM lookback)
+    {% endif %}
     {% if not loop.last %}UNION ALL{% endif %}
   {% endfor %}
 )
@@ -59,4 +59,4 @@ SELECT
 FROM territory AS t
 LEFT JOIN {{ ref('perimeters_agg') }}
   AS p ON t.code = p.code AND t.type = p.type
-AND p.year = LEAST(t.year, (SELECT y FROM max_perim_year))
+AND p.year = least(t.year, (SELECT y FROM max_perim_year))

--- a/datalake/models/trusted/carpools_geo_correction.sql
+++ b/datalake/models/trusted/carpools_geo_correction.sql
@@ -40,8 +40,24 @@ perimeters_retablissement AS (
   )
 ),
 
+-- com_evolution est borné par la source insee_mvt_com_2025 : son année max
+-- sert à rabattre les trajets géocodés une année plus récente (ex. 2026) sur
+-- les dernières évolutions connues, sinon ils ne seraient jamais corrigés.
 max_evolution_year AS (
   SELECT MAX(year) AS y FROM {{ ref('com_evolution') }}
+),
+
+-- une seule cible par (old_com, année) : un old_com peut cumuler plusieurs
+-- mouvements la même année (recodage + fusion), ce qui dédoublerait les
+-- carpool_id en sortie et violerait l'index unique. On en garde un seul.
+com_recodage AS (
+  SELECT DISTINCT ON (old_com, year)
+    old_com,
+    new_com,
+    year
+  FROM {{ ref('com_evolution') }}
+  WHERE mod IN (31, 32, 33, 41, 50)
+  ORDER BY old_com, year, mod, new_com
 ),
 
 -- carpools dont au moins un bout est dans une commune rétablie (mod=21)
@@ -61,10 +77,9 @@ affected_fusion AS (
   SELECT DISTINCT sc._id
   FROM source_carpools AS sc
   CROSS JOIN max_evolution_year AS mey
-  INNER JOIN {{ ref('com_evolution') }} AS ce
+  INNER JOIN com_recodage AS ce
     ON
       (sc.start_geo_code = ce.old_com OR sc.end_geo_code = ce.old_com)
-      AND ce.mod IN (31, 32, 33, 41, 50)
       AND ce.year = LEAST(EXTRACT(YEAR FROM sc.geo_updated_at)::int, mey.y)
 ),
 
@@ -90,13 +105,11 @@ LEFT JOIN perimeters_retablissement AS pe
   ON
     ST_INTERSECTS(sc.end_position, pe.geom)
     AND pe.year = LEAST(EXTRACT(YEAR FROM sc.geo_updated_at)::int, mey.y)
-LEFT JOIN {{ ref('com_evolution') }} AS cs
+LEFT JOIN com_recodage AS cs
   ON
     sc.start_geo_code = cs.old_com
-    AND cs.mod IN (31, 32, 33, 41, 50)
     AND cs.year = LEAST(EXTRACT(YEAR FROM sc.geo_updated_at)::int, mey.y)
-LEFT JOIN {{ ref('com_evolution') }} AS ce
+LEFT JOIN com_recodage AS ce
   ON
     sc.end_geo_code = ce.old_com
-    AND ce.mod IN (31, 32, 33, 41, 50)
     AND ce.year = LEAST(EXTRACT(YEAR FROM sc.geo_updated_at)::int, mey.y)

--- a/datalake/models/trusted/carpools_geo_correction.sql
+++ b/datalake/models/trusted/carpools_geo_correction.sql
@@ -72,7 +72,8 @@ affected_retablissement AS (
       AND ce.year = LEAST(EXTRACT(YEAR FROM sc.geo_updated_at)::int, mey.y)
 ),
 
--- carpools dont au moins un bout est dans une commune fusionnée ou recodée (mod=31,32,33,41,50)
+-- carpools dont au moins un bout est dans une commune fusionnée ou recodée
+-- (mod=31,32,33,41,50)
 affected_fusion AS (
   SELECT DISTINCT sc._id
   FROM source_carpools AS sc

--- a/datalake/models/trusted/carpools_geo_correction.sql
+++ b/datalake/models/trusted/carpools_geo_correction.sql
@@ -40,26 +40,32 @@ perimeters_retablissement AS (
   )
 ),
 
+max_evolution_year AS (
+  SELECT MAX(year) AS y FROM {{ ref('com_evolution') }}
+),
+
 -- carpools dont au moins un bout est dans une commune rétablie (mod=21)
 affected_retablissement AS (
   SELECT DISTINCT sc._id
   FROM source_carpools AS sc
+  CROSS JOIN max_evolution_year AS mey
   INNER JOIN {{ ref('com_evolution') }} AS ce
     ON
       (sc.start_geo_code = ce.old_com OR sc.end_geo_code = ce.old_com)
       AND ce.mod = 21
-      AND ce.year = EXTRACT(YEAR FROM sc.geo_updated_at)::int
+      AND ce.year = LEAST(EXTRACT(YEAR FROM sc.geo_updated_at)::int, mey.y)
 ),
 
--- carpools dont au moins un bout est dans une commune fusionnée (mod=32)
+-- carpools dont au moins un bout est dans une commune fusionnée ou recodée (mod=31,32,33,41,50)
 affected_fusion AS (
   SELECT DISTINCT sc._id
   FROM source_carpools AS sc
+  CROSS JOIN max_evolution_year AS mey
   INNER JOIN {{ ref('com_evolution') }} AS ce
     ON
       (sc.start_geo_code = ce.old_com OR sc.end_geo_code = ce.old_com)
-      AND ce.mod = 32
-      AND ce.year = EXTRACT(YEAR FROM sc.geo_updated_at)::int
+      AND ce.mod IN (31, 32, 33, 41, 50)
+      AND ce.year = LEAST(EXTRACT(YEAR FROM sc.geo_updated_at)::int, mey.y)
 ),
 
 affected AS (
@@ -74,22 +80,23 @@ SELECT
   COALESCE(ps.com, cs.new_com, sc.start_geo_code) AS start_geo_code,
   COALESCE(pe.com, ce.new_com, sc.end_geo_code)   AS end_geo_code
 FROM source_carpools AS sc
+CROSS JOIN max_evolution_year AS mey
 INNER JOIN affected AS a ON sc._id = a._id
 LEFT JOIN perimeters_retablissement AS ps
   ON
     ST_INTERSECTS(sc.start_position, ps.geom)
-    AND ps.year = EXTRACT(YEAR FROM sc.geo_updated_at)::int
+    AND ps.year = LEAST(EXTRACT(YEAR FROM sc.geo_updated_at)::int, mey.y)
 LEFT JOIN perimeters_retablissement AS pe
   ON
     ST_INTERSECTS(sc.end_position, pe.geom)
-    AND pe.year = EXTRACT(YEAR FROM sc.geo_updated_at)::int
+    AND pe.year = LEAST(EXTRACT(YEAR FROM sc.geo_updated_at)::int, mey.y)
 LEFT JOIN {{ ref('com_evolution') }} AS cs
   ON
     sc.start_geo_code = cs.old_com
-    AND cs.mod = 32
-    AND cs.year = EXTRACT(YEAR FROM sc.geo_updated_at)::int
+    AND cs.mod IN (31, 32, 33, 41, 50)
+    AND cs.year = LEAST(EXTRACT(YEAR FROM sc.geo_updated_at)::int, mey.y)
 LEFT JOIN {{ ref('com_evolution') }} AS ce
   ON
     sc.end_geo_code = ce.old_com
-    AND ce.mod = 32
-    AND ce.year = EXTRACT(YEAR FROM sc.geo_updated_at)::int
+    AND ce.mod IN (31, 32, 33, 41, 50)
+    AND ce.year = LEAST(EXTRACT(YEAR FROM sc.geo_updated_at)::int, mey.y)


### PR DESCRIPTION
## Description

Corrige la normalisation géographique des trajets pour 2026, fiabilise le modèle
`datalake/models/trusted/carpools_geo_correction.sql`, et accélère drastiquement le job CI de
lint sqlfluff du datalake.

### Problème

`com_evolution` est borné par la source `insee_mvt_com_2025` (données jusqu'en 2025). Les
trajets géocodés en 2026 cherchaient une correspondance sur `ce.year = 2026`, qui n'existe
pas : **aucune correction n'était appliquée**.

En parallèle, le job CI « (datalake) sqlfluff lint » lintait les ~495 modèles via le templater
dbt sérialisé (`processes = 1`), soit **~1 h**. Bien que `continue-on-error`, le job devait se
terminer avant de pouvoir merger la PR.

### Ce qui change

**Correction géographique (`carpools_geo_correction.sql`)**

- **Rabattement d'année** : nouveau CTE `max_evolution_year` (`MAX(year)`) et remplacement de
  `EXTRACT(YEAR FROM geo_updated_at)` par `LEAST(EXTRACT(...), max_year)`. Les trajets d'une
  année plus récente que la dernière évolution connue sont rabattus sur celle-ci. Aucun impact
  sur les années passées (`LEAST(2024, 2025) = 2024`), correction idempotente (la jointure se
  fait sur `old_com`).
- **Périmètre des mouvements élargi** : `mod = 32` → `mod IN (31, 32, 33, 41, 50)` (fusion
  simple, commune nouvelle, fusion-association, changement de code département / chef-lieu).
- **Déduplication anti fan-out** (durcissement) : nouveau CTE `com_recodage`
  (`DISTINCT ON (old_com, year)`). Un `old_com` peut cumuler plusieurs mouvements la même
  année (recodage + fusion) ; sans déduplication les jointures finales dédoubleraient les
  `carpool_id` en sortie et violeraient l'index unique du modèle. La sélection est
  déterministe (`ORDER BY old_com, year, mod, new_com`). Le filtre `mod` est désormais
  centralisé dans ce CTE.
- **Documentation** : commentaires expliquant le couplage à la source `insee_mvt_com_2025` et
  le rationnel du rabattement d'année.

**Optimisation CI (`.github/workflows/quality-datalake.yml`)**

- Le job `sqlfluff lint` ne lint plus que les fichiers `.sql` **modifiés dans la PR** (diff de
  la base de fusion vs branche cible), au lieu de la totalité de `models/` + `analyses/`. Durée
  ramenée de ~1 h à quelques minutes ; le merge n'est plus bloqué par l'attente.
- `fetch-depth: 0` ajouté au checkout pour permettre le calcul du merge-base.
- **Garde anti-injection GitHub Actions** : le nom de branche de base passe par `env: BASE_REF`
  et la liste de fichiers par `env: CHANGED_FILES` (jamais interpolés directement dans `run:`) ;
  les noms de fichiers sont filtrés par une allowlist stricte
  (`grep -E '^[A-Za-z0-9_./-]+\.sql$'`) avant d'atteindre `$GITHUB_OUTPUT`.
- Correction d'une violation `LT05` (ligne > 80 colonnes) sur un commentaire du modèle, révélée
  par le nouveau lint ciblé.

### Hors-scope

- Renommage du CTE `affected_fusion` (couvre désormais aussi le recodage) — laissé tel quel,
  cosmétique.
- Jointures géométriques `perimeters_retablissement` (rétablissement, mod=21) — comportement
  pré-existant, non modifié.
- L'étape « Tune postgres for lint connection bursts » est conservée par prudence (grosses PR) ;
  supprimable plus tard, le risque de saturation disparaissant avec le lint ciblé.

## Sécurité

**Verdict : PASS** (non-bloquant).

- **Injection GitHub Actions maîtrisée** : aucune valeur dérivée du contenu de la PR (nom de
  branche, noms de fichiers) n'est interpolée dans un bloc `run:` ; tout passe par `env:` et les
  noms de fichiers sont validés par allowlist avant `$GITHUB_OUTPUT`. Pas d'escalade de
  permissions (pas de bloc `permissions:` élargi), pas de fuite de secrets.
- **SQL** : aucune injection — usage exclusif des macros dbt `{{ ref(...) }}`, pas de
  concaténation ni d'input utilisateur. Aucune donnée personnelle manipulée (niveau code commune
  INSEE, non-PII). Intégrité préservée : la déduplication `DISTINCT ON` garantit l'unicité de
  `carpool_id` (respect de l'index unique).

## CGU

**Verdict : PASS** (bloquant — franchi).

Changement purement analytique (pipeline de normalisation géographique) et infrastructure CI.
Aucune règle CGU applicable : pas de mutation de statut de trajet (CGU-1), pas de
rétention/anonymisation de donnée personnelle (CGU-2), pas d'exposition de PII (CGU-3).

## Release

Aucune release / aucun déploiement attendu : PR **data-only** (`datalake/` + `.github/`). Le
scope `datalake` est non-déployant et le filtre de fichiers (gate 1) ne voit aucun code
applicatif. Comportement correct et voulu.
