### PR TITLE
feat(apdf): ajoute le delta déclaré vs calculé dans l'export APDF (IDFM)

### DIFF
--- a/GEN-643-plan.md
+++ b/GEN-643-plan.md
@@ -1,0 +1,170 @@
+# GEN-643 — APDF : intégration du delta déclaré vs calculé
+
+> Plan & audit d'impact / complexité. Branche : `worktree-GEN-643-apdf-delta`.
+> Ticket Notion : [APDF - Intégration delta déclaré vs calculé](https://app.notion.com/p/37c994bec93180559a8ed559d18d598d) (Priorité 🔥 High).
+
+## 1. Objectif (rappel du besoin)
+
+Les collectivités ne peuvent pas, avec le seul fichier APDF actuel (données **calculées** par covoit.beta), repérer les décalages avec les factures / chiffres **déclarés** par les opérateurs.
+
+Besoin : faire apparaître dans le fichier APDF, sur l'onglet de synthèse, la valorisation du **delta entre données calculées (RPC) et déclarées (opérateur)**.
+
+Draft de spec (ticket) :
+- ajouter dans le tableau des tranches des colonnes avec les données **déclarées** opérateur utiles aux collectivités : **montant incitation, volume de trajets incités, contribution passager** ;
+- **distinguer visuellement** calculé vs déclaré (code couleur) ;
+- ajouter une **synthèse du différentiel** (montant incité + volume trajets incités) entre covoit.beta et opérateur.
+
+> Le draft détaillé est fourni (`~/apdf.xlsx`, onglet **« Proposition évolution »**) : c'est la sortie APDF de production avec un onglet maquette inséré. Maquette analysée ci-dessous (§2.6). Reste l'échange Vic/Jo/Éric/Thomas pour valider.
+
+### Maquette cible (onglet « Proposition évolution ») — voir §2.6 pour le détail
+Onglet Synthèse passe de **5 colonnes (A-E)** à **7 colonnes (A-G) groupées en 2 bandeaux**, + un **bloc Delta**.
+
+## 2. État des lieux technique (audit du code & des données)
+
+### 2.1 Chaîne d'export APDF
+- Commande CLI `apdf:export` → `commands/ExportCommand.ts:20`
+- → `actions/ExportAction.ts:33` (boucle campagne × opérateur, upload S3)
+- → `providers/excel/BuildExcel.ts:35` construit le classeur (2 onglets) :
+  - **« Synthèse par tranche »** → `providers/excel/SlicesWorksheetWriter.ts`
+  - **« Trajets »** → `providers/excel/TripsWorksheetWriter.ts`
+- Données : `providers/DataRepositoryProvider.ts`
+  - `getPolicyStats()` → bornes/labels des tranches (lignes du tableau de synthèse)
+  - `getPolicyCursor()` → lignes détaillées de l'onglet Trajets
+
+### 2.2 Mécanique clé de l'onglet Synthèse (déterminante pour le plan)
+**L'onglet « Synthèse par tranche » est piloté à 100 % par des formules Excel** (`SUMIFS`/`COUNTIFS`) qui pointent vers les colonnes de l'onglet **Trajets** — voir `SlicesWorksheetWriter.ts:269-322`. Références par lettre de colonne :
+- `M` = distance · `R` = rpc_incentive (calculé) · `S` = incentive_type · `T` = passenger_contribution
+
+`getPolicyStats()` ne fournit que la liste des tranches (start/end + label) ; **les valeurs affichées sont calculées vivantes par Excel** sur l'onglet Trajets.
+
+→ **Conséquence : pour ajouter une donnée à la synthèse, on ajoute d'abord une colonne à l'onglet Trajets, puis on l'agrège par `SUMIFS`/`COUNTIFS`.** C'est exactement le schéma de la PR #3206 (ajout de `passenger_contribution`, colonne T).
+
+### 2.3 Précédent direct : PR #3206 (`passenger_contribution`)
+Patron de référence complet (data pass-through SQL → normalize → cellule Excel) :
+- interface `APDFTripInterface` (+1 champ)
+- SQL `getPolicyCursor()` (+1 colonne)
+- `normalizeAPDFData.helper.ts` (conversion centimes→euros + null-safe)
+- `TripsWorksheetWriter.ts` (entête + largeur colonne)
+- `SlicesWorksheetWriter.ts` (entête + format € + `SUMIFS` + total + définition de champ)
+- test unitaire de normalisation
+
+### 2.4 ✅ La donnée « déclarée » EXISTE déjà (pas d'import à construire)
+C'est le point le plus important de l'audit. Le besoin laissait craindre une source de données inexistante. **Faux** : les incitations déclarées par les opérateurs sont stockées au niveau trajet dans :
+
+**`carpool_v2.operator_incentives`** — colonnes : `carpool_id`, `idx`, `siret`, `amount` (centimes).
+- Jointure : `operator_incentives.carpool_id = carpool_v2.carpools._id`
+- « contribution passager déclarée » = `carpool_v2.carpools.passenger_contribution` (déjà exporté).
+
+Donc le « déclaré » et le « calculé » sont déjà tous deux en base. **Aucun mécanisme d'import / formulaire / API à créer.** C'est ce qui rend le chantier raisonnable.
+
+### 2.5 Quelles incitations déclarées comparer ? → **résolu : appariement par SIREN du territoire**
+Volumétrie : la table `operator_incentives` est volumineuse (plusieurs dizaines de millions de lignes) → **un trajet porte souvent plusieurs incitations déclarées** de **financeurs différents** (région + département + AOM…). Le calculé RPC d'une campagne ne concerne qu'**un** financeur : le territoire qui porte la campagne. Sommer toutes les incitations sur-compterait.
+
+**Décision (consigne métier confirmée)** : le financeur = **le territoire qui définit la campagne**. Chaîne de résolution validée en base :
+
+```
+policy.policies.territory_id
+  → territory.territory_group.company_id
+    → company.companies.siren     (et .siret)
+```
+
+**Niveau d'appariement = SIREN (9 chiffres), pas le SIRET complet.** Vérifié sur données réelles :
+- Le SIRET « siège » du territoire **ne matche pas** : les opérateurs déclarent sous d'**autres établissements du même SIREN** (NIC différent). D'où l'appariement sur les 9 premiers chiffres.
+- Filtre SIRET complet → **0 match**. Filtre SIREN → match correct. Filtre « tous sirets » → sur-compte.
+
+Comparaison réalisée en base sur des campagnes témoins (montants non reproduits — **dépôt public**) : le filtre **SIRET complet → 0 correspondance**, le filtre **SIREN → delta cohérent et exploitable**, le filtre **« tous sirets » → sur-comptage** (capte d'autres financeurs).
+
+→ Le delta SIREN est plausible et exploitable ; c'est le bon périmètre. (Cohérent avec la logique `siret_is_aom` de la couche analytics existante.)
+
+**Cas limites à gérer/documenter** : territoire sans `company_id` (→ déclaré nul, documenté) ; délégation à un syndicat de SIREN différent (non apparié — à documenter) ; un même SIREN finançant plusieurs campagnes.
+
+### 2.6 Maquette cible détaillée (onglet « Proposition évolution »)
+
+**Onglet « Synthèse par tranche » — nouvelle structure.** Une ligne de bandeaux est insérée au-dessus des entêtes :
+
+| | Bandeau « **Données calculées par covoiturage.beta** » | | | Bandeau « **Données déclarées par les opérateurs** » | | |
+|---|---|---|---|---|---|---|
+| **A** Tranche | **B** Montant d'incitation | **C** Tous les trajets | **D** Trajets incités | **E** Montant d'incitation | **F** Trajets incités | **G** Contribution passagers |
+
+- B/C/D = calculé RPC (existant) : `SUMIFS(Trajets!R:R,…)`, `COUNTIFS(…)`, `COUNTIFS(Trajets!R:R,">0",…)`.
+- **E** = montant déclaré : `SUMIFS(Trajets!U:U,…)` (nouvelle colonne U, cf. §4).
+- **F** = trajets incités déclarés : `COUNTIFS(Trajets!U:U,">0",…)`.
+- **G** = contribution passagers (déplacée de E→G) : `SUMIFS(Trajets!T:T,…)`.
+- Deux tableaux : « période normale » puis « période booster », chacun avec ligne de total.
+
+**Bloc Delta (sous les tableaux) :**
+- Libellé « **Delta données covoiturage.beta / opérateurs** » sur 2 mesures : **Montant d'incitation** et **Trajets incités** (calculé − déclaré).
+- Note obligatoire : *« un écart de données peut exister du fait d'application de règles métier différentes entre l'opérateur et covoiturage.beta.gouv »*.
+- (Dans la maquette les cellules delta sont en `#NAME?` — placeholder ; à implémenter en formules sur les totaux B/E et D/F.)
+
+**Distinction calculé/déclaré (« code couleur » du ticket)** = les deux bandeaux d'entête fusionnés + remplissage de couleur distinct par bandeau (fills ExcelJS).
+
+> ⚠️ Dans la maquette, le tableau **booster** n'a PAS les colonnes déclarées E/F (seulement B/C/D/G). À confirmer : appliquer la même structure au booster (cohérence) ou la limiter au normal comme dessiné.
+
+## 3. Règle de calcul retenue
+
+- **Incitation déclarée (territoire)** = Σ `carpool_v2.operator_incentives.amount` du trajet **où `left(siret,9) = SIREN du territoire de la campagne`**.
+- **Incitation calculée (RPC)** = `policy.incentives.amount` (existant, colonne `R` de l'onglet Trajets).
+- **Trajets incités déclarés** = nb de trajets dont l'incitation déclarée (SIREN) > 0.
+- **Delta** = calculé RPC − déclaré territoire (montant et volume), par tranche + total.
+- **Contribution passager** : déjà exportée (déclarée par construction).
+
+## 4. Plan d'implémentation (sous réserve décision §3)
+
+Hypothèse de travail : on suit le patron PR #3206. Tout est dans `api/src/pdc/services/apdf/`.
+
+1. **SQL — résolution du SIREN territoire + montant déclaré**
+   - Résoudre une fois le SIREN du territoire de la campagne : `policy.policies.territory_id → territory.territory_group.company_id → company.companies.siren`. Le faire dans `ExportAction` (passé en param) ou en CTE de la requête.
+   - `DataRepositoryProvider.getPolicyCursor()` (`providers/DataRepositoryProvider.ts:162`) : ajouter
+     `LEFT JOIN LATERAL (SELECT sum(oi.amount) FROM carpool_v2.operator_incentives oi WHERE oi.carpool_id = cc._id AND left(oi.siret,9) = :territory_siren) decl(amount)` → `operator_declared_incentive`.
+   - Idem dans `getPolicyStats()` si on veut les valeurs côté serveur (sinon laisser les formules Excel agréger la nouvelle colonne Trajets).
+   - Vérifier l'index sur `carpool_v2.operator_incentives(carpool_id)` (jointure sur une table volumineuse).
+2. **Interface** — `interfaces/APDFTripInterface.ts` : `+ operator_declared_incentive: number | null`.
+3. **Normalisation** — `helpers/normalizeAPDFData.helper.ts` : conversion centimes→euros, null-safe (+ test unitaire dédié, cf. `normalizeAPDFData.unit.spec.ts`).
+4. **Onglet Trajets** — `providers/excel/TripsWorksheetWriter.ts` : nouvelle colonne **`U` = `operator_declared_incentive`** (montant déclaré SIREN, en euros), entête + largeur (patron col. T). C'est la source des `SUMIFS`/`COUNTIFS` du déclaré.
+5. **Onglet Synthèse** — `providers/excel/SlicesWorksheetWriter.ts`, refonte de `drawSliceTable` selon §2.6 :
+   - insérer la **ligne de bandeaux** fusionnés (`B:D` = « Données calculées… », `E:G` = « Données déclarées… ») avec **fills de couleur distincts** (le « code couleur ») ;
+   - colonnes : **B/C/D** calculé (existant), **E** = `SUMIFS(Trajets!U:U,…)`, **F** = `COUNTIFS(Trajets!U:U,">0",…)`, **G** = `SUMIFS(Trajets!T:T,…)` (contribution, déplacée de E→G) ;
+   - mettre à jour `numFmt €` (B & E & G), largeurs, et la **ligne de total** (somme B,E ; comptes C,D,F) ;
+   - **bloc Delta** : libellé + 2 formules (`total B − total E`, `total D − total F`) + la **note** sur les écarts de règles métier ;
+   - **définitions de champs** : ajouter l'entrée du montant déclaré (et préciser le périmètre SIREN territoire) ;
+   - reproduire pour les 2 tableaux (normale + booster, cf. question booster §2.6).
+   - ⚠️ l'insertion du bandeau décale toutes les lignes de +1 → recaler les références de la doc (`A20`, `G1`…) et les plages de total.
+6. **Tests** :
+   - unit normalize (nouveau champ) ;
+   - integration `DataRepositoryProvider.integration.spec.ts` (jointure operator_incentives) ;
+   - unit `SlicesWorksheetWriter` / `BuildExcel` (présence colonnes/formules).
+7. **Docs** :
+   - `api/specs` (publication bump.sh) + documentation publique des champs APDF ;
+   - `api/src/pdc/services/apdf/README.md` si présent.
+
+## 5. Audit d'impact
+
+| Zone | Impact |
+|---|---|
+| Schéma BDD | **Aucun** (lecture seule de tables existantes) |
+| SQL `getPolicyCursor` | +1 jointure latérale → coût requête à surveiller (table volumineuse ; index sur `operator_incentives.carpool_id` à vérifier) |
+| Format fichier APDF | **Changement visible client** : nouvelles colonnes + delta. Impacte les collectivités qui parsent le fichier → communication / changelog |
+| Onglet Synthèse | Réagencement colonnes (risque de régression sur formules/totaux/fusions) |
+| Autres exports (IDFM custom #3206) | Vérifier qu'un export spécifique ne casse pas avec le nouveau schéma de colonnes |
+| Perf export | Marginal par trajet ; valider sur grosse campagne |
+| Rétrocompat fichiers passés | Les anciens fichiers restent inchangés ; nouveaux mois seulement |
+
+## 6. Audit de complexité
+
+**Complexité technique : Moyenne (revue à la baisse).** Patron PR #3206 réutilisable, pas de nouvelle infra, données présentes, **mapping campagne→SIREN résolu et validé en base**.
+
+Postes de complexité, par ordre :
+1. **Réagencement de l'onglet Synthèse** — formules Excel par lettre de colonne + fusions/totaux codés en dur : sensible aux régressions, à tester sur fichier réel ouvert dans Excel/LibreOffice. C'est désormais le poste le plus délicat.
+2. **Appariement SIREN — cas limites** — territoire sans `company_id`, délégation à un SIREN tiers, SIREN finançant plusieurs campagnes : à documenter clairement dans l'onglet définitions pour éviter une mauvaise lecture du delta.
+3. **Performance SQL** — jointure latérale sur une table volumineuse ; vérifier l'index `operator_incentives(carpool_id)` et le coût du `left(siret,9)`.
+4. **Code couleur** — simple en soi (fills ExcelJS), mais multiplie les cellules à styler.
+
+**Effort estimé** : ~1–2 j de dev + tests, une fois le draft de spec détaillé (onglet 2) intégré. Plus de chemin critique « décision data » : le périmètre est tranché.
+
+## 7. Hors-scope / questions ouvertes
+- Indicateurs + alertes Metabase (évoqués dans le ticket parent GEN-441) → **hors scope** de ce fichier APDF.
+- Lecture du draft de spec détaillé (onglet 2 du Google Sheet) — à intégrer avant dev.
+- Validation du périmètre SIREN avec Vic/Jo/Éric/Thomas (confirmer que l'appariement par SIREN du territoire répond bien au besoin des collectivités).
+- Confort de lecture : faut-il aussi exposer le déclaré **ligne à ligne** dans l'onglet Trajets, ou seulement agrégé en synthèse ?
+- Détail par financeur des incitations `idx` multiples (somme SIREN retenue ; faut-il aussi montrer le « tous financeurs » à titre indicatif ?).

--- a/api/src/pdc/services/apdf/helpers/normalizeAPDFData.helper.ts
+++ b/api/src/pdc/services/apdf/helpers/normalizeAPDFData.helper.ts
@@ -55,6 +55,9 @@ export function normalize(src: APDFTripInterface, config: ExcelCampaignConfig): 
     // incentives in euros
     rpc_incentive: src.rpc_incentive / 100,
 
+    // declared operator incentive (territory funder) in euros
+    operator_declared_incentive: src.operator_declared_incentive == null ? null : src.operator_declared_incentive / 100,
+
     // passenger contribution in euros
     passenger_contribution: src.passenger_contribution == null ? null : src.passenger_contribution / 100,
   };

--- a/api/src/pdc/services/apdf/helpers/normalizeAPDFData.unit.spec.ts
+++ b/api/src/pdc/services/apdf/helpers/normalizeAPDFData.unit.spec.ts
@@ -25,6 +25,7 @@ describe("normalizeAPDFData", () => {
       operator_journey_id: "ojid",
       operator_trip_id: "otid",
       operator: "Operator",
+      operator_declared_incentive: 150,
       passenger_contribution: 180,
       passenger_operator_user_id: "passenger",
       rpc_incentive: 200,
@@ -45,5 +46,15 @@ describe("normalizeAPDFData", () => {
   it("keeps null passenger_contribution as null", () => {
     const result = normalize(fakeTrip({ passenger_contribution: null }), config);
     assertEquals(result.passenger_contribution, null);
+  });
+
+  it("converts operator_declared_incentive from cents to euros", () => {
+    const result = normalize(fakeTrip({ operator_declared_incentive: 150 }), config);
+    assertEquals(result.operator_declared_incentive, 1.5);
+  });
+
+  it("keeps null operator_declared_incentive as null", () => {
+    const result = normalize(fakeTrip({ operator_declared_incentive: null }), config);
+    assertEquals(result.operator_declared_incentive, null);
   });
 });

--- a/api/src/pdc/services/apdf/interfaces/APDFRepositoryProviderInterface.ts
+++ b/api/src/pdc/services/apdf/interfaces/APDFRepositoryProviderInterface.ts
@@ -13,6 +13,9 @@ export interface CampaignSearchParamsInterface {
   operator_id: number;
   start_date: Date;
   end_date: Date;
+  // SIREN (9 chiffres) du territoire financeur, quand la campagne expose le delta
+  // déclaré vs calculé (config extras.declared_incentives). Absent sinon.
+  declared_siren?: string | null;
 }
 
 export interface DataRepositoryInterface {

--- a/api/src/pdc/services/apdf/interfaces/APDFTripInterface.ts
+++ b/api/src/pdc/services/apdf/interfaces/APDFTripInterface.ts
@@ -11,6 +11,7 @@ export interface APDFTripInterface {
   operator_journey_id: string;
   operator_trip_id: string;
   operator: string;
+  operator_declared_incentive: number | null;
   passenger_contribution: number | null;
   passenger_operator_user_id: string;
   rpc_incentive: number;

--- a/api/src/pdc/services/apdf/providers/DataRepositoryProvider.integration.spec.ts
+++ b/api/src/pdc/services/apdf/providers/DataRepositoryProvider.integration.spec.ts
@@ -64,4 +64,15 @@ describe("DataRepositoryProvider", () => {
     }
     assertEquals(batches, []);
   });
+
+  // GEN-643 : valide que la jointure latérale du montant déclaré (appariement par
+  // SIREN sur carpool_v2.operator_incentives) est un SQL valide contre le schéma réel.
+  it("getPolicyCursor supports the declared-incentive lateral join (SIREN) without crashing", async () => {
+    await using cursor = await repository.getPolicyCursor({ ...params, declared_siren: "287500078" });
+    const batches: APDFTripInterface[][] = [];
+    for await (const rows of cursor.read(50)) {
+      batches.push(rows);
+    }
+    assertEquals(batches, []);
+  });
 });

--- a/api/src/pdc/services/apdf/providers/DataRepositoryProvider.ts
+++ b/api/src/pdc/services/apdf/providers/DataRepositoryProvider.ts
@@ -1,7 +1,7 @@
 import { provider } from "@/ilos/common/index.ts";
 import { Cursor, DenoPostgresConnection } from "@/ilos/connection-postgres/index.ts";
 import { set } from "@/lib/object/index.ts";
-import sql, { raw } from "@/lib/pg/sql.ts";
+import sql, { empty, raw } from "@/lib/pg/sql.ts";
 import { UnboundedSlices } from "../../policy/contracts/common/interfaces/Slices.ts";
 import { PolicyStatsInterface } from "../contracts/interfaces/PolicySliceStatInterface.ts";
 import {
@@ -160,7 +160,22 @@ export class DataRepositoryProvider implements DataRepositoryInterface {
    * List all carpools for CSV APDF export using a cursor
    */
   public async getPolicyCursor(params: CampaignSearchParamsInterface): Promise<Cursor<APDFTripInterface>> {
-    const { start_date, end_date, operator_id, campaign_id } = params;
+    const { start_date, end_date, operator_id, campaign_id, declared_siren } = params;
+
+    // Incitation déclarée par l'opérateur, rattachée au territoire financeur par le
+    // SIREN (9 chiffres) — cf. GEN-643. Uniquement quand la campagne l'expose.
+    const declaredSelect = declared_siren
+      ? sql`decl.amount as operator_declared_incentive,`
+      : sql`null::int as operator_declared_incentive,`;
+    const declaredJoin = declared_siren
+      ? sql`
+        left join lateral (
+          select sum(oi.amount) as amount
+          from carpool_v2.operator_incentives oi
+          where oi.carpool_id = cc._id
+            and left(oi.siret, 9) = ${declared_siren}
+        ) decl on true`
+      : empty;
 
     return this.pgConnection.cursor<APDFTripInterface>(sql`
       -- list in api/services/trip/src/providers/excel/TripsWorksheetWriter.ts
@@ -174,6 +189,7 @@ export class DataRepositoryProvider implements DataRepositoryInterface {
         cc.passenger_contribution,
 
         pi.amount as rpc_incentive,
+        ${declaredSelect}
 
         cc.start_datetime,
         cc.end_datetime,
@@ -198,6 +214,7 @@ export class DataRepositoryProvider implements DataRepositoryInterface {
       left join ${raw(this.geoPerimetersTable)} gps on cg.start_geo_code = gps.arr and gps.year = geo.get_latest_millesime_or(extract(year from cc.start_datetime)::smallint)
       left join ${raw(this.geoPerimetersTable)} gpe on cg.end_geo_code = gpe.arr and gpe.year = geo.get_latest_millesime_or(extract(year from cc.end_datetime)::smallint)
       left join ${raw(this.operatorsTable)} oo on oo._id = cc.operator_id
+      ${declaredJoin}
 
       where
             cc.start_datetime >= ${start_date}

--- a/api/src/pdc/services/apdf/providers/excel/BuildExcel.ts
+++ b/api/src/pdc/services/apdf/providers/excel/BuildExcel.ts
@@ -2,7 +2,6 @@ import { defaultTimezone } from "@/config/time.ts";
 import { KernelInterfaceResolver, provider } from "@/ilos/common/index.ts";
 import { logger } from "@/lib/logger/index.ts";
 import { APDFNameProvider } from "@/pdc/providers/storage/index.ts";
-import { APDFTripInterface } from "@/pdc/services/apdf/interfaces/APDFTripInterface.ts";
 import { ExcelCampaignConfig } from "@/pdc/services/apdf/interfaces/ExcelTypes.ts";
 import excel from "dep:excel";
 import { ResultInterface as Campaign } from "../../../policy/contracts/find.contract.ts";
@@ -38,11 +37,17 @@ export class BuildExcel {
     end_date: Date,
     operator_id: number,
   ): Promise<{ filename: string; filepath: string }> {
+    // Delta déclaré vs calculé (GEN-643) : activé par la config de campagne
+    // extras.declared_incentives.siren = SIREN du territoire financeur. Absent → export inchangé.
+    const declared_siren = (campaign.params?.extras as { declared_incentives?: { siren?: string } })
+      ?.declared_incentives?.siren ?? null;
+
     const params = {
       start_date,
       end_date,
       operator_id,
       campaign_id: campaign._id,
+      declared_siren,
     };
 
     // fetch aggregated and slice data
@@ -68,7 +73,7 @@ export class BuildExcel {
 
     // create the Workbook and add Worksheets
     const wbWriter: excel.stream.xlsx.WorkbookWriter = BuildExcel.initWorkbookWriter(filepath);
-    if (this.hasSliceTrips(slices)) await this.writeSlices(wbWriter, slices);
+    if (this.hasSliceTrips(slices)) await this.writeSlices(wbWriter, slices, Boolean(declared_siren));
     await this.writeTrips(wbWriter, params);
     await wbWriter.commit();
 
@@ -92,10 +97,14 @@ export class BuildExcel {
     }
   }
 
-  private async writeSlices(wkw: excel.stream.xlsx.WorkbookWriter, slices: SliceStatInterface[]): Promise<void> {
+  private async writeSlices(
+    wkw: excel.stream.xlsx.WorkbookWriter,
+    slices: SliceStatInterface[],
+    withDeclared: boolean,
+  ): Promise<void> {
     try {
       if (!slices.length) return;
-      await this.slicesWsWriter.call(wkw, slices);
+      await this.slicesWsWriter.call(wkw, slices, withDeclared);
     } catch (e) {
       logger.error("[apdf:buildExcel] Error while computing slices");
       if (e instanceof Error) {

--- a/api/src/pdc/services/apdf/providers/excel/BuildExcel.unit.spec.ts
+++ b/api/src/pdc/services/apdf/providers/excel/BuildExcel.unit.spec.ts
@@ -145,6 +145,7 @@ describe("BuildExcel", () => {
         operator_id: operator_id,
         start_date: start_date,
         end_date: end_date,
+        declared_siren: null,
       },
       wrapSlices(campaign.params.slices),
     );
@@ -154,6 +155,7 @@ describe("BuildExcel", () => {
       operator_id: operator_id,
       start_date: start_date,
       end_date: end_date,
+      declared_siren: null,
     });
 
     sinon.assert.calledOnceWithExactly(filenameStub!, {
@@ -215,6 +217,7 @@ describe("BuildExcel", () => {
         operator_id: operator_id,
         start_date: start_date,
         end_date: end_date,
+        declared_siren: null,
       },
       wrapSlices(campaign.params.slices),
     );
@@ -224,6 +227,7 @@ describe("BuildExcel", () => {
       operator_id: operator_id,
       start_date: start_date,
       end_date: end_date,
+      declared_siren: null,
     });
 
     sinon.assert.calledOnceWithExactly(filenameStub!, {
@@ -280,6 +284,7 @@ describe("BuildExcel", () => {
         operator_id: operator_id,
         start_date: start_date,
         end_date: end_date,
+        declared_siren: null,
       },
       wrapSlices(campaign.params.slices),
     );
@@ -289,6 +294,7 @@ describe("BuildExcel", () => {
       operator_id: operator_id,
       start_date: start_date,
       end_date: end_date,
+      declared_siren: null,
     });
 
     sinon.assert.calledOnceWithExactly(filenameStub!, {

--- a/api/src/pdc/services/apdf/providers/excel/SlicesWorksheetWriter.ts
+++ b/api/src/pdc/services/apdf/providers/excel/SlicesWorksheetWriter.ts
@@ -25,7 +25,15 @@ export class SlicesWorksheetWriter extends AbstractWorksheetWriter {
   async call(
     wbWriter: excel.stream.xlsx.WorkbookWriter,
     slices: SliceStatInterface[],
+    withDeclared = false,
   ): Promise<void> {
+    // GEN-643 : les campagnes exposant le delta déclaré vs calculé utilisent un
+    // layout dédié (bandeaux calculé/déclaré + bloc Delta). Le layout générique
+    // ci-dessous reste strictement inchangé pour toutes les autres collectivités.
+    if (withDeclared) {
+      return this.callDeclared(wbWriter, slices);
+    }
+
     const options: Partial<excel.AddWorksheetOptions> = {
       views: [{ showGridLines: false }],
     };
@@ -236,6 +244,209 @@ export class SlicesWorksheetWriter extends AbstractWorksheetWriter {
 
     ws.commit();
     /* eslint-enable prettier/prettier,max-len */
+  }
+
+  // ==================================================================================
+  // GEN-643 — Layout dédié « delta déclaré vs calculé » (campagnes avec
+  // extras.declared_incentives, ex. Covoit IDFM). Colonnes de l'onglet Trajets :
+  // M distance · R rpc_incentive (calculé) · S incentive_type · T passenger_contribution
+  // · U operator_declared_incentive (déclaré).
+  // ==================================================================================
+
+  private readonly BAND_CALCULATED = "Données calculées par covoiturage.beta";
+  private readonly BAND_DECLARED = "Données déclarées par les opérateurs";
+  private readonly DELTA_NOTE =
+    "un écart de données peut exister du fait d'application de règles métier différentes entre l'opérateur et covoiturage.beta.gouv";
+  private readonly CALC_FILL = "FFDDEBF7"; // bleu clair
+  private readonly DECL_FILL = "FFFCE4D6"; // orange clair
+
+  private async callDeclared(
+    wbWriter: excel.stream.xlsx.WorkbookWriter,
+    slices: SliceStatInterface[],
+  ): Promise<void> {
+    const options: Partial<excel.AddWorksheetOptions> = { views: [{ showGridLines: false }] };
+    const ws: excel.Worksheet = this.initWorkSheet(wbWriter, this.WORKSHEET_NAME, undefined, options);
+
+    // Column styling A..G (B/E/G en euros)
+    const font = { name: "Arial", size: 12 };
+    ws.getColumn("A").width = 26;
+    ws.getColumn("A").font = font;
+    for (const col of ["B", "C", "D", "E", "F", "G"]) {
+      ws.getColumn(col).width = 20;
+      ws.getColumn(col).font = font;
+    }
+    for (const col of ["B", "E", "G"]) {
+      ws.getColumn(col).numFmt = "# ##0.00€";
+    }
+
+    // Le déclaré (E/F + bandeau) n'est exposé que sur la période normale. Le booster
+    // ne porte que les colonnes calculées (B/C/D) + la contribution passagers (G).
+    const normaleTotal = this.drawDeclaredSliceTable(ws, slices, 'Tranche "période normale"', "normale", true);
+    this.drawDeclaredSliceTable(ws, slices, 'Tranche "période booster"', "booster", false);
+
+    this.drawDeltaBlock(ws, normaleTotal);
+    this.drawDeclaredDocumentation(ws);
+
+    ws.commit();
+  }
+
+  /**
+   * Dessine un tableau de tranches à 7 colonnes (A tranche ; B/C/D calculé ;
+   * E/F/G déclaré) surmonté d'une ligne de bandeaux colorés. Renvoie le numéro
+   * de la ligne de total (pour les références du bloc Delta).
+   */
+  private drawDeclaredSliceTable(
+    ws: excel.Worksheet,
+    slices: SliceStatInterface[],
+    trancheLabel: string,
+    mode: "normale" | "booster",
+    withDeclaredColumns: boolean,
+  ): number {
+    if (ws.lastRow) this.pad(ws, 2);
+
+    // Ligne de bandeaux (code couleur). Le bandeau « déclaré » (E:G) n'apparaît que
+    // sur la période normale.
+    const bandeau = ws.addRow([]);
+    const bRow = bandeau.number;
+    ws.mergeCells(`B${bRow}:D${bRow}`);
+    ws.getCell(`B${bRow}`).value = this.BAND_CALCULATED;
+    for (const col of ["B", "C", "D"]) this.fillCell(ws, `${col}${bRow}`, this.CALC_FILL);
+    ws.getCell(`B${bRow}`).font = { name: "Arial", size: 11, bold: true };
+    ws.getCell(`B${bRow}`).alignment = { horizontal: "center", vertical: "middle" };
+    if (withDeclaredColumns) {
+      ws.mergeCells(`E${bRow}:G${bRow}`);
+      ws.getCell(`E${bRow}`).value = this.BAND_DECLARED;
+      for (const col of ["E", "F", "G"]) this.fillCell(ws, `${col}${bRow}`, this.DECL_FILL);
+      ws.getCell(`E${bRow}`).font = { name: "Arial", size: 11, bold: true };
+      ws.getCell(`E${bRow}`).alignment = { horizontal: "center", vertical: "middle" };
+    }
+
+    // En-têtes (le booster masque les colonnes déclarées E/F)
+    const headers = ws.addRow(
+      withDeclaredColumns
+        ? [trancheLabel, "Montant d'incitation", "Tous les trajets", "Trajets incités", "Montant d'incitation",
+          "Trajets incités", "Contribution passagers"]
+        : [trancheLabel, "Montant d'incitation", "Tous les trajets", "Trajets incités", null, null,
+          "Contribution passagers"],
+    );
+    headers.font = { name: "Arial", size: 12, bold: true };
+    headers.height = 24;
+    headers.eachCell((c, colNumber) => {
+      c.alignment = colNumber > 1 ? { vertical: "middle", horizontal: "right" } : { vertical: "middle" };
+      c.border = { bottom: { style: "thin" } };
+    });
+
+    // Données
+    for (const s of slices) {
+      const { start, end } = s.slice;
+      const mode_criteria = `Trajets!S:S,"${mode}"`;
+      const slice_criteria = `Trajets!M:M,">=${start}"${end ? `,Trajets!M:M,"<${end}"` : ""}`;
+      const calc = [
+        this.formatSliceLabel(s.slice),
+        { date1904: false, formula: `SUMIFS(Trajets!R:R,${mode_criteria},${slice_criteria})` },
+        { date1904: false, formula: `COUNTIFS(${mode_criteria},${slice_criteria})` },
+        { date1904: false, formula: `COUNTIFS(Trajets!R:R,">0",${mode_criteria},${slice_criteria})` },
+      ];
+      const contribution = { date1904: false, formula: `SUMIFS(Trajets!T:T,${mode_criteria},${slice_criteria})` };
+      const r = ws.addRow(
+        withDeclaredColumns
+          ? [
+            ...calc,
+            { date1904: false, formula: `SUMIFS(Trajets!U:U,${mode_criteria},${slice_criteria})` },
+            { date1904: false, formula: `COUNTIFS(Trajets!U:U,">0",${mode_criteria},${slice_criteria})` },
+            contribution,
+          ]
+          : [...calc, null, null, contribution],
+      );
+      r.height = 20;
+      r.alignment = { vertical: "middle" };
+    }
+
+    // Ligne de total (somme des colonnes présentes uniquement)
+    const first = headers.number + 1;
+    const last = headers.number + slices.length;
+    const totalRow = last + 1;
+    const border: Partial<excel.Borders> = { top: { style: "thin" } };
+    const totalCols = withDeclaredColumns ? ["B", "C", "D", "E", "F", "G"] : ["B", "C", "D", "G"];
+    for (const col of ["A", "B", "C", "D", "E", "F", "G"]) {
+      const cell = ws.getCell(`${col}${totalRow}`);
+      if (slices.length > 0 && totalCols.includes(col)) {
+        cell.value = { date1904: false, formula: `SUM(${col}${first}:${col}${last})` };
+      }
+      cell.border = border;
+    }
+    return totalRow;
+  }
+
+  /**
+   * Bloc « Delta » = calculé − déclaré (montant et volume de trajets incités).
+   * Comparaison sur la seule période normale, seule à porter le déclaré.
+   */
+  private drawDeltaBlock(ws: excel.Worksheet, normaleTotal: number): void {
+    this.pad(ws, 2);
+    const label = ws.addRow(["Delta données covoiturage.beta / opérateurs"]);
+    ws.mergeCells(`A${label.number}:G${label.number}`);
+    ws.getCell(`A${label.number}`).font = { name: "Arial", size: 12, bold: true };
+    ws.getCell(`A${label.number}`).border = { bottom: { style: "thin" } };
+
+    const amount = ws.addRow([
+      "Montant d'incitation",
+      { date1904: false, formula: `B${normaleTotal}-E${normaleTotal}` },
+    ]);
+    ws.getCell(`B${amount.number}`).numFmt = "# ##0.00€";
+
+    ws.addRow([
+      "Trajets incités",
+      { date1904: false, formula: `D${normaleTotal}-F${normaleTotal}` },
+    ]);
+
+    this.pad(ws, 1);
+    const note = ws.addRow([this.DELTA_NOTE]);
+    ws.mergeCells(`A${note.number}:G${note.number}`);
+    ws.getCell(`A${note.number}`).font = { name: "Arial", size: 10, italic: true };
+    ws.getCell(`A${note.number}`).alignment = { wrapText: true, vertical: "top" };
+  }
+
+  /** Définitions des champs (dont le déclaré + périmètre SIREN) placées sous les tableaux. */
+  private drawDeclaredDocumentation(ws: excel.Worksheet): void {
+    const defs: [string, string][] = [
+      ["rpc_journey_id", "Identifiant du trajet pour le RPC"],
+      ["operator_journey_id", "Identifiant du trajet envoyé par l'opérateur"],
+      ["start_datetime", "Date et heure de début du trajet"],
+      ["distance", "Distance du trajet en mètres"],
+      ["operator", "Nom de l'opérateur"],
+      ["rpc_incentive", "Montant d'incitation calculé par le RPC en euros"],
+      ["incentive_type", "Type d'incitation (normale ou booster)"],
+      ["passenger_contribution", "Contribution financière du passager en euros"],
+      [
+        "operator_declared_incentive",
+        "Montant d'incitation déclaré par l'opérateur pour le territoire financeur de la campagne, " +
+        "apparié par le SIREN (9 chiffres) de ce territoire, en euros. " +
+        "Un trajet peut être financé par plusieurs entités : seul le montant déclaré pour ce territoire est repris.",
+      ],
+    ];
+
+    this.pad(ws, 2);
+    const head = ws.addRow(["DEFINITIONS DES CHAMPS"]);
+    ws.mergeCells(`A${head.number}:G${head.number}`);
+    ws.getCell(`A${head.number}`).font = { name: "Arial", size: 12, bold: true };
+    ws.getCell(`A${head.number}`).alignment = { horizontal: "center", vertical: "middle" };
+    ws.getCell(`A${head.number}`).border = { bottom: { style: "thin" } };
+
+    for (const [key, description] of defs) {
+      const r = ws.addRow([key]);
+      ws.mergeCells(`B${r.number}:G${r.number}`);
+      ws.getCell(`B${r.number}`).value = description;
+      ws.getCell(`B${r.number}`).alignment = { wrapText: true, vertical: "top" };
+    }
+  }
+
+  private fillCell(ws: excel.Worksheet, address: string, argb: string): void {
+    ws.getCell(address).fill = {
+      type: "pattern",
+      pattern: "solid",
+      fgColor: { argb },
+    };
   }
 
   private drawSliceTable(

--- a/api/src/pdc/services/apdf/providers/excel/SlicesWorksheetWriter.unit.spec.ts
+++ b/api/src/pdc/services/apdf/providers/excel/SlicesWorksheetWriter.unit.spec.ts
@@ -1,0 +1,65 @@
+import { assertEquals, assertStringIncludes } from "dep:assert";
+import { describe, it } from "dep:testing-bdd";
+import excel from "dep:excel";
+import { SliceStatInterface } from "../../contracts/interfaces/PolicySliceStatInterface.ts";
+import { SlicesWorksheetWriter } from "./SlicesWorksheetWriter.ts";
+
+describe("SlicesWorksheetWriter — layout déclaré (GEN-643)", () => {
+  const slices: SliceStatInterface[] = [
+    { count: 10, subsidized: 8, sum: 1000, slice: { start: 0, end: 2000 } },
+    { count: 5, subsidized: 4, sum: 500, slice: { start: 2000, end: null } },
+  ];
+
+  // Génère la feuille en écrivant un vrai classeur puis en le relisant.
+  async function render(withDeclared: boolean): Promise<excel.Worksheet> {
+    const path = await Deno.makeTempFile({ suffix: ".xlsx" });
+    const wbWriter = new excel.stream.xlsx.WorkbookWriter({ filename: path, useStyles: true });
+    await new SlicesWorksheetWriter().call(wbWriter, slices, withDeclared);
+    await wbWriter.commit();
+
+    const wb = new excel.Workbook();
+    await wb.xlsx.readFile(path);
+    await Deno.remove(path);
+    return wb.getWorksheet("Synthèse par tranche")!;
+  }
+
+  it("affiche les bandeaux calculé / déclaré", async () => {
+    const ws = await render(true);
+    assertStringIncludes(String(ws.getCell("B1").value), "calculées par covoiturage.beta");
+    assertStringIncludes(String(ws.getCell("E1").value), "déclarées par les opérateurs");
+  });
+
+  it("agrège le déclaré depuis la colonne U de l'onglet Trajets", async () => {
+    const ws = await render(true);
+    // ligne bandeau=1, en-têtes=2, 1re tranche=3
+    assertStringIncludes(ws.getCell("B3").formula, "SUMIFS(Trajets!R:R"); // calculé (existant)
+    assertStringIncludes(ws.getCell("E3").formula, "SUMIFS(Trajets!U:U"); // montant déclaré
+    assertStringIncludes(ws.getCell("F3").formula, 'COUNTIFS(Trajets!U:U,">0"'); // trajets incités déclarés
+    assertStringIncludes(ws.getCell("G3").formula, "SUMIFS(Trajets!T:T"); // contribution passagers (E→G)
+  });
+
+  it("calcule le delta = calculé − déclaré sur la période normale (montant et trajets incités)", async () => {
+    const ws = await render(true);
+    // total normale=ligne5 (layout déterministe : 2 tranches). Le delta ne porte que sur la normale.
+    assertStringIncludes(String(ws.getCell("A15").value), "Delta");
+    assertEquals(ws.getCell("B16").formula, "B5-E5"); // delta montant
+    assertEquals(ws.getCell("B17").formula, "D5-F5"); // delta trajets incités
+  });
+
+  it("masque le déclaré (E/F) sur le tableau booster mais garde la contribution (G)", async () => {
+    const ws = await render(true);
+    // booster : bandeau=8, en-têtes=9, 1re tranche=10
+    assertEquals(ws.getCell("E9").value, null); // pas d'en-tête montant déclaré
+    assertEquals(ws.getCell("F9").value, null); // pas d'en-tête trajets déclarés
+    assertStringIncludes(String(ws.getCell("G9").value), "Contribution passagers");
+    assertEquals(ws.getCell("E10").value, null); // pas de formule déclarée sur le booster
+    assertStringIncludes(ws.getCell("G10").formula, "SUMIFS(Trajets!T:T"); // contribution conservée
+  });
+
+  it("laisse le layout générique inchangé quand le déclaré est absent (pas de colonne U/G déclaré)", async () => {
+    const ws = await render(false);
+    // en-têtes en ligne 1, 1re tranche en ligne 2, colonne E = contribution passagers
+    assertStringIncludes(ws.getCell("E2").formula, "SUMIFS(Trajets!T:T");
+    assertEquals(ws.getCell("F2").value, null); // pas de colonne déclarée F
+  });
+});

--- a/api/src/pdc/services/apdf/providers/excel/TripsWorksheetWriter.ts
+++ b/api/src/pdc/services/apdf/providers/excel/TripsWorksheetWriter.ts
@@ -12,7 +12,7 @@ export class TripsWorksheetWriter extends AbstractWorksheetWriter {
   public readonly CURSOR_BATCH_SIZE = 100;
   public readonly WORKSHEET_NAME = "Trajets";
   // TODO improve listing of columns
-  public readonly WORKSHEET_COLUMN_HEADERS: Partial<excel.Column>[] = [
+  public readonly BASE_COLUMN_KEYS: string[] = [
     "rpc_journey_id",
     "operator_journey_id",
     "operator_trip_id",
@@ -33,17 +33,23 @@ export class TripsWorksheetWriter extends AbstractWorksheetWriter {
     "rpc_incentive",
     "incentive_type",
     "passenger_contribution",
-  ].map((header) => ({ header, key: header }));
+  ];
 
   async call(
     cursor: Cursor<APDFTripInterface>,
     config: ExcelCampaignConfig,
     workbookWriter: excel.stream.xlsx.WorkbookWriter,
   ): Promise<void> {
+    // La colonne du déclaré (U) n'est ajoutée que pour les campagnes exposant le
+    // delta déclaré vs calculé (config extras.declared_incentives) — cf. GEN-643.
+    const columnKeys = config.extras?.declared_incentives
+      ? [...this.BASE_COLUMN_KEYS, "operator_declared_incentive"]
+      : this.BASE_COLUMN_KEYS;
+
     const worksheet: excel.Worksheet = this.initWorkSheet(
       workbookWriter,
       this.WORKSHEET_NAME,
-      this.WORKSHEET_COLUMN_HEADERS,
+      columnKeys.map((header) => ({ header, key: header })),
     );
 
     // style columns and apply optimised width
@@ -69,6 +75,7 @@ export class TripsWorksheetWriter extends AbstractWorksheetWriter {
       R: { width: 12, font },
       S: { width: 12, font },
       T: { width: 12, font },
+      ...(config.extras?.declared_incentives ? { U: { width: 12, font } } : {}),
     };
 
     Object.entries(columns).forEach(([key, value]) => {

--- a/api/src/pdc/services/policy/engine/policies/20251201_Covoit_IDFM_2026.ts
+++ b/api/src/pdc/services/policy/engine/policies/20251201_Covoit_IDFM_2026.ts
@@ -169,7 +169,11 @@ export const CovoitIDFM2026: PolicyHandlerStaticInterface = class extends Abstra
       operators: getOperatorsAt(this.operators),
       allTimeOperators: Array.from(new Set(this.operators.flatMap((entry) => entry.operators))),
       limits: { glob: this.max_amount },
-      extras: {},
+      // GEN-643 — expose dans l'export APDF le delta entre incitation calculée (RPC)
+      // et déclarée par l'opérateur, appariée au SIREN du territoire financeur (IdFM).
+      extras: {
+        declared_incentives: { siren: "287500078" },
+      },
     };
   }
 };


### PR DESCRIPTION
## Résumé

Intègre dans le fichier APDF, **pour la seule campagne Covoit IDFM**, la valorisation **déclarée** par l'opérateur en regard de l'incitation **calculée** par le RPC, ainsi que le **delta** entre les deux. Objectif métier (GEN-643) : permettre à la collectivité de repérer les écarts entre les chiffres du RPC et ses factures / déclarations opérateur.

Le chantier a été volontairement **restreint à IDFM** : cela lève les questions métier ouvertes du cadrage et réduit le périmètre technique à un fichier unique, sans risque de régression sur les exports des autres collectivités.

## Ce qui change

- **Source du déclaré** : `carpool_v2.operator_incentives.amount` (déjà en base, aucun import à construire), apparié au territoire financeur par le **SIREN (9 chiffres)** du territoire de la campagne (`policy.policies → territory.territory_group → company.companies`). Le SIRET complet ne matche pas (les opérateurs déclarent sous d'autres établissements du même SIREN).
- **Activation par configuration** : `extras.declared_incentives.siren` dans le handler de campagne (`20251201_Covoit_IDFM_2026.ts`). Toute campagne sans ce réglage conserve **exactement** le layout actuel (chemin de rendu générique inchangé).
- **Onglet Trajets** : nouvelle colonne conditionnelle `operator_declared_incentive` (colonne `U`).
- **Onglet Synthèse** : layout dédié — bandeaux « calculé » / « déclaré » (code couleur), colonnes `E` (montant déclaré), `F` (trajets incités déclarés), `G` (contribution passagers), et **bloc Delta** (calculé − déclaré, montant + trajets incités) avec note sur les écarts de règles métier.
- **Booster** : le déclaré (E/F) est masqué sur le tableau booster (conforme à la maquette) ; le delta ne porte que sur la période normale.

## Validation sur données de production

Delta calculé vs déclaré vérifié sur un mois récent pour la campagne Covoit IDFM : appariement par SIREN cohérent (volumes de trajets incités calculés et déclarés quasi identiques), delta positif et exploitable. _Chiffres non reproduits ici — dépôt public._

Les deux enveloppes IdFM (Covoit IDFM et ECOV) sont portées par des **opérateurs distincts** → aucun recouvrement malgré le SIREN financeur partagé ; une seule ligne déclarée par trajet sous le SIREN du territoire.

## Tests

- **Unitaires** : normalisation du montant déclaré (centimes → euros, null-safe) ; layout Synthèse déclaré vérifié en **générant un vrai `.xlsx` puis en le relisant** (bandeaux, formules `SUMIFS(U)` / `COUNTIFS(U>0)` / `SUMIFS(T)`, bloc Delta, masquage booster, layout générique préservé).
- **Intégration** : ouverture du curseur avec la jointure latérale déclarée (validité SQL contre le schéma réel).

## Sécurité — PASS

Aucune vulnérabilité. Le SIREN est **bindé en paramètre** (placeholders `$n`), jamais concaténé ; `raw()` n'est utilisé que sur des noms de tables internes. Aucune nouvelle PII ni secret exposé (le SIREN d'IdFM est une donnée publique du répertoire SIRENE ; `siret` utilisé au prédicat mais **non** exporté). Gestion d'erreur et contrôle d'accès inchangés.

_Remarque non bloquante_ : `declared_siren` n'est pas validé au format 9 chiffres (valeur de config interne, bindée — risque purement fonctionnel, pas de sécurité).

## CGU — PASS

Lecture seule sur des tables existantes, aucune mutation de statut, aucune extension de rétention. Le montant déclaré est une donnée financière **agrégée**, de même maille que `rpc_incentive` / `passenger_contribution` déjà exportés — pas de nouvelle catégorie de donnée personnelle. `siret` volontairement non exposé (bonne minimisation). Finalité (réconciliation financière) inchangée.

## Hors-scope / suivi

- Documentation publique du champ (doc.covoiturage.beta.gouv.fr) — à faire ultérieurement.
- Perf du prédicat `left(siret,9)` sur `operator_incentives` (table volumineuse) : validé sur un mois en prod ; à confirmer côté perf (jointure activée uniquement pour les campagnes configurées).
- Détail « tous financeurs » / ligne à ligne : hors scope (choix d'affichage).

## Release

Touche `api/**` (gate fichiers) + `feat(apdf)` (scope non-data) → **coupe une version mineure et déploie l'API**. Les fichiers avec delta seront produits au prochain run `apdf:export` après déploiement.