### PR TITLE
fix(auth): renvoie 401 au lieu de 500 pour un token Dex invalide

### DIFF
--- a/api/src/pdc/proxy/middlewares/accessTokenMiddleware.ts
+++ b/api/src/pdc/proxy/middlewares/accessTokenMiddleware.ts
@@ -1,74 +1,42 @@
 import { KernelInterface, UnauthorizedException } from "@/ilos/common/index.ts";
-import { logger } from "@/lib/logger/index.ts";
-import { get } from "@/lib/object/index.ts";
 import { getPermissions } from "@/pdc/services/auth/config/permissions.ts";
 import { DexOIDCProvider } from "@/pdc/services/auth/providers/DexOIDCProvider.ts";
 import { NextFunction, Request as ExpressRequest, Response } from "dep:express";
 
 function getTokenFromRequest(req: ExpressRequest): string {
-  const authHeader = get(req, "headers.authorization", "");
-  if (!authHeader) {
+  const match = String(req.headers.authorization ?? "").match(/^Bearer\s+(.+)$/i);
+  if (!match) {
     throw new UnauthorizedException("No token provided");
   }
-  const token = String(authHeader).replace("Bearer ", "");
-  if (!token.length) {
-    throw new UnauthorizedException("Empty token provided");
-  }
-  return token;
+  return match[1];
 }
 
 /**
- * Returns an Express middleware that checks the token using DexOIDCProvider.
- * Accepts either a KernelInterface or a DexOIDCProvider instance as argument.
- */
-export function dexAccessTokenMiddleware(kernel: KernelInterface) {
-  return async (req: ExpressRequest, _res: Response, next: NextFunction): Promise<void> => {
-    try {
-      const token = getTokenFromRequest(req);
-      const dexProvider = kernel.get(DexOIDCProvider);
-
-      const data = await dexProvider.verifyToken(token);
-
-      req.stateless = {};
-
-      req.stateless.user = {
-        operator_id: data.operator_id,
-        role: data.role,
-        email: data.token_id,
-        permissions: getPermissions(data.role),
-      };
-
-      next();
-    } catch (e) {
-      // skip the unsupported algorithm message falling back to legacy token middleware
-      // to avoid bloating the logs.
-      if (Error.isError(e) && !e.message.includes("value for a JSON Web Key Set")) {
-        logger.warn(`[dexMiddleware] ${e.message}`);
-      }
-
-      next(e);
-    }
-  };
-}
-
-/**
- * Check the token using DexOIDCProvider and
- * fallback to legacy serverTokenMiddleware if it fails.
+ * Verify the Bearer access token issued by Dex and attach the authenticated
+ * user to the request.
+ *
+ * Any failure is forwarded to the error handler: a request whose token cannot
+ * be verified is rejected (401), never allowed to continue as anonymous.
+ * Token validation semantics (401 vs 500) live in DexOIDCProvider.verifyToken.
  */
 export function accessTokenMiddleware(kernel: KernelInterface) {
   return async (req: ExpressRequest, _res: Response, next: NextFunction): Promise<void> => {
-    dexAccessTokenMiddleware(kernel)(req, _res, async (err: Error | null) => {
-      if (typeof err === "undefined" || err === null) {
-        // If no error, continue to the next middleware
-        return next();
-      }
+    try {
+      const token = getTokenFromRequest(req);
+      const data = await kernel.get(DexOIDCProvider).verifyToken(token);
 
-      if (Error.isError(err)) return next(err);
-      if (typeof err === "string") {
-        return next(new Error(err));
-      }
+      req.stateless = {
+        user: {
+          operator_id: data.operator_id,
+          role: data.role,
+          email: data.token_id,
+          permissions: getPermissions(data.role),
+        },
+      };
 
       next();
-    });
+    } catch (err) {
+      next(err);
+    }
   };
 }

--- a/api/src/pdc/proxy/middlewares/accessTokenMiddleware.unit.spec.ts
+++ b/api/src/pdc/proxy/middlewares/accessTokenMiddleware.unit.spec.ts
@@ -1,0 +1,89 @@
+import { assert, assertEquals, assertInstanceOf, assertStrictEquals } from "dep:assert";
+import { describe, it } from "dep:testing-bdd";
+import { KernelInterface, UnauthorizedException } from "@/ilos/common/index.ts";
+import { NextFunction, Request as ExpressRequest, Response } from "dep:express";
+import { accessTokenMiddleware } from "./accessTokenMiddleware.ts";
+
+type VerifyFn = (token: string) => Promise<unknown>;
+type StatelessReq = ExpressRequest & {
+  stateless?: { user?: { operator_id: number; role: string; email: string; permissions: unknown[] } };
+};
+
+// Minimal kernel stub: kernel.get(DexOIDCProvider) returns an object exposing verifyToken.
+function makeKernel(verifyToken: VerifyFn): KernelInterface {
+  return { get: () => ({ verifyToken }) } as unknown as KernelInterface;
+}
+
+function makeReq(authorization?: string): StatelessReq {
+  return { headers: authorization ? { authorization } : {} } as unknown as StatelessReq;
+}
+
+// Run the middleware and capture what was passed to next().
+async function run(kernel: KernelInterface, req: StatelessReq) {
+  const sentinel = Symbol("not-called");
+  let nextArg: unknown = sentinel;
+  const next: NextFunction = (e?: unknown) => {
+    nextArg = e;
+  };
+  await accessTokenMiddleware(kernel)(req, {} as unknown as Response, next);
+  return nextArg === sentinel ? sentinel : nextArg;
+}
+
+describe("accessTokenMiddleware", () => {
+  it("rejects with 401 when no Authorization header is present", async () => {
+    const kernel = makeKernel(() => Promise.reject(new Error("verifyToken must not run")));
+    const err = await run(kernel, makeReq());
+    assertInstanceOf(err, UnauthorizedException);
+    assertEquals(err.httpCode, 401);
+  });
+
+  it("rejects with 401 when the Bearer token is empty", async () => {
+    const kernel = makeKernel(() => Promise.reject(new Error("verifyToken must not run")));
+    const err = await run(kernel, makeReq("Bearer "));
+    assertInstanceOf(err, UnauthorizedException);
+  });
+
+  it("populates the stateless user on a valid token and continues", async () => {
+    const req = makeReq("Bearer good");
+    const kernel = makeKernel(() =>
+      Promise.resolve({ operator_id: 7, role: "operator.admin", token_id: "ops@example.fr" })
+    );
+    const err = await run(kernel, req);
+    assertEquals(err, undefined); // next() called with no error
+    const user = req.stateless?.user;
+    assertEquals(user?.operator_id, 7);
+    assertEquals(user?.role, "operator.admin");
+    assertEquals(user?.email, "ops@example.fr");
+    assert(Array.isArray(user?.permissions) && user.permissions.length > 0);
+  });
+
+  it("forwards the auth error and never populates a user when verification fails", async () => {
+    const req = makeReq("Bearer bad");
+    const boom = new UnauthorizedException("nope");
+    const kernel = makeKernel(() => Promise.reject(boom));
+    const err = await run(kernel, req);
+    assertStrictEquals(err, boom);
+    // SECURITY: a verification failure must never silently downgrade to an anonymous request.
+    assertEquals(req.stateless, undefined);
+  });
+
+  it("never swallows an unexpected error into an anonymous request", async () => {
+    const req = makeReq("Bearer weird");
+    const kernel = makeKernel(() => Promise.reject(new TypeError("infra down")));
+    const err = await run(kernel, req);
+    assertInstanceOf(err, TypeError);
+    assertEquals(req.stateless, undefined);
+  });
+
+  it("forwards even a non-Error rejection instead of continuing anonymously", async () => {
+    // Regression guard: the old wrapper had an `else next()` branch that dropped
+    // any rejection that was neither an Error nor a string, letting the request
+    // through as anonymous.
+    const req = makeReq("Bearer weird");
+    const weird = { code: "NOT_AN_ERROR" };
+    const kernel = makeKernel(() => Promise.reject(weird));
+    const err = await run(kernel, req);
+    assertStrictEquals(err, weird);
+    assertEquals(req.stateless, undefined);
+  });
+});

--- a/api/src/pdc/services/auth/providers/DexOIDCProvider.ts
+++ b/api/src/pdc/services/auth/providers/DexOIDCProvider.ts
@@ -1,8 +1,42 @@
 import { ConfigInterfaceResolver, InitHookInterface, provider, UnauthorizedException } from "@/ilos/common/index.ts";
 import { logger } from "@/lib/logger/index.ts";
 import { encodeBase64 } from "dep:encoding";
-import { createRemoteJWKSet, jwtVerify } from "dep:jose";
-import { JWTExpired } from "https://deno.land/x/jose@v5.6.3/util/errors.ts";
+import { createRemoteJWKSet, errors, jwtVerify } from "dep:jose";
+
+const { JOSEError, JWKSTimeout } = errors;
+
+/**
+ * Translate a token-verification failure into the right HTTP semantics:
+ * - a JWKS timeout means OUR auth backend (Dex) is unreachable → keep it as-is
+ *   so it surfaces as a 500 (server error, retryable);
+ * - any other jose error means the client's token cannot be trusted → 401;
+ * - anything else (non-jose) is left untouched.
+ */
+export function toVerificationError(err: unknown): unknown {
+  if (err instanceof JWKSTimeout) {
+    return err;
+  }
+  if (err instanceof JOSEError) {
+    return new UnauthorizedException(err.message);
+  }
+  return err;
+}
+
+/**
+ * Parse the Dex token subject, expected as "<role>:<operator_id>"
+ * (e.g. "operator.admin:1", "registry.admin:0").
+ *
+ * A validly-signed token whose subject does not match this shape cannot be
+ * trusted to identify an operator → reject as 401 rather than silently
+ * producing an operator_id of NaN.
+ */
+export function parseTokenSubject(name: string | undefined): { role: string; operator_id: number } {
+  const [role, operatorId, ...rest] = (name ?? "").split(":");
+  if (!role || rest.length > 0 || !/^\d+$/.test(operatorId ?? "")) {
+    throw new UnauthorizedException("Malformed token subject");
+  }
+  return { role, operator_id: Number(operatorId) };
+}
 
 @provider()
 export class DexOIDCProvider implements InitHookInterface {
@@ -32,19 +66,21 @@ export class DexOIDCProvider implements InitHookInterface {
         audience: clientId,
       });
 
-      const [role, operator_id] = (payload.name || "").split(":");
+      const { role, operator_id } = parseTokenSubject(payload.name);
 
       return {
-        operator_id: parseInt(operator_id),
+        operator_id,
         role,
         token_id: payload.email,
       };
     } catch (err: unknown) {
-      if (err instanceof JWTExpired) {
-        throw new UnauthorizedException(err.message);
+      // Surface why verification failed (signature, issuer, expiry, ...) for
+      // support without leaking it to the client, then translate the error.
+      if (err instanceof JOSEError && !(err instanceof JWKSTimeout)) {
+        logger.warn(`[DexOIDCProvider:verifyToken] ${err.code} ${err.message}`);
       }
 
-      throw err;
+      throw toVerificationError(err);
     }
   }
 

--- a/api/src/pdc/services/auth/providers/DexOIDCProvider.unit.spec.ts
+++ b/api/src/pdc/services/auth/providers/DexOIDCProvider.unit.spec.ts
@@ -1,0 +1,74 @@
+import { assertEquals, assertInstanceOf, assertStrictEquals, assertThrows } from "dep:assert";
+import { describe, it } from "dep:testing-bdd";
+import { UnauthorizedException } from "@/ilos/common/index.ts";
+import { errors } from "dep:jose";
+import { parseTokenSubject, toVerificationError } from "./DexOIDCProvider.ts";
+
+const {
+  JWKSNoMatchingKey,
+  JWKSTimeout,
+  JWSSignatureVerificationFailed,
+  JWTClaimValidationFailed,
+  JWTExpired,
+  JWTInvalid,
+} = errors;
+
+describe("DexOIDCProvider.toVerificationError", () => {
+  // Any token the client sends that we cannot positively verify is an auth
+  // problem (401), never a server error (500).
+  const tokenFailures = {
+    "an expired token": new JWTExpired("token expired", {}),
+    "a malformed token": new JWTInvalid("invalid"),
+    "a bad signature": new JWSSignatureVerificationFailed(),
+    "a failed claim (issuer/audience)": new JWTClaimValidationFailed("bad iss", {}),
+    "an unknown signing key": new JWKSNoMatchingKey(),
+  };
+
+  for (const [label, error] of Object.entries(tokenFailures)) {
+    it(`maps ${label} to a 401 UnauthorizedException`, () => {
+      const out = toVerificationError(error);
+      assertInstanceOf(out, UnauthorizedException);
+      assertEquals(out.httpCode, 401);
+    });
+  }
+
+  it("keeps a JWKS timeout untouched so it surfaces as a 500 (our infra is down)", () => {
+    const original = new JWKSTimeout();
+    assertStrictEquals(toVerificationError(original), original);
+  });
+
+  it("rethrows non-jose errors untouched", () => {
+    const original = new TypeError("fetch failed");
+    assertStrictEquals(toVerificationError(original), original);
+  });
+});
+
+describe("DexOIDCProvider.parseTokenSubject", () => {
+  it("parses a well-formed operator subject", () => {
+    assertEquals(parseTokenSubject("operator.admin:1"), { role: "operator.admin", operator_id: 1 });
+  });
+
+  it("parses the legacy application role", () => {
+    assertEquals(parseTokenSubject("application:42"), { role: "application", operator_id: 42 });
+  });
+
+  it("accepts operator_id 0 (e.g. registry.admin:0)", () => {
+    assertEquals(parseTokenSubject("registry.admin:0"), { role: "registry.admin", operator_id: 0 });
+  });
+
+  const malformed = {
+    "undefined": undefined,
+    "empty": "",
+    "missing operator_id": "operator.admin",
+    "trailing colon / empty operator_id": "operator.admin:",
+    "non-numeric operator_id": "operator.admin:abc",
+    "leading colon / empty role": ":1",
+    "extra segments": "operator.admin:1:2",
+  };
+
+  for (const [label, name] of Object.entries(malformed)) {
+    it(`rejects a ${label} subject with 401`, () => {
+      assertThrows(() => parseTokenSubject(name), UnauthorizedException);
+    });
+  }
+});


### PR DESCRIPTION
## Contexte

Des requêtes vers l'API externe avec un token d'accès Dex invalide remontaient en
**500** dans les logs (ex. `GET /v3.1/journeys/1234 ... 500`). En cause :
`DexOIDCProvider.verifyToken` ne traduisait que `JWTExpired` en
`UnauthorizedException` ; toutes les autres erreurs jose (signature, émetteur /
audience, JWT malformé, clé de signature inconnue) étaient relancées brutes et
finissaient en **500** par défaut dans `errorHandlerMiddleware`. Résultat : un
problème d'authentification **client** polluait le canal des erreurs serveur
500 / Sentry, avec un mauvais code HTTP renvoyé à l'opérateur.

Le code portait aussi des résidus de l'ancien support des tokens « applications »
(non-JWT), notamment un wrapper de middleware à deux fonctions dont une branche
pouvait avaler l'erreur et laisser passer la requête en anonyme.

## Modifications

- **Classification correcte des erreurs de vérification** (`DexOIDCProvider.ts`) :
  - `JWKSTimeout` (backend Dex injoignable) → **500**, erreur serveur rejouable ;
  - toute autre erreur jose → **401**, token client non vérifiable.
  - Le détail jose (`code` + message) reste journalisé côté serveur pour le
    support, sans être renvoyé au client.
- **Middleware fail-closed** (`accessTokenMiddleware.ts`) : suppression du wrapper
  legacy `accessTokenMiddleware`/`dexAccessTokenMiddleware` et de sa branche
  `else next()` qui pouvait laisser passer une requête en anonyme. Toute erreur de
  vérification est désormais transmise via `next(err)` — la requête est rejetée,
  jamais dégradée en anonyme.
- **Parsing plus strict** : en-tête `Bearer` (`^Bearer\s+(.+)$/i`) et validation du
  sujet du token `role:operator_id` — un sujet malformé est rejeté en **401** au
  lieu de produire un `operator_id` à `NaN` silencieux.
- Suppression du filtre de log fragile basé sur un message interne de jose.

## Tests

Ces fichiers n'avaient **aucune couverture** auparavant. Ajout de tests unitaires :
- `DexOIDCProvider.unit.spec.ts` — classification des erreurs (expiré / malformé /
  signature / claim / clé inconnue → 401 ; `JWKSTimeout` → 500 ; non-jose →
  inchangé) et parsing du sujet (formats valides dont `operator_id` à 0, et tous
  les cas malformés rejetés en 401).
- `accessTokenMiddleware.unit.spec.ts` — invariant de sécurité : un échec de
  vérification ne peuple jamais `req.stateless.user` ; garde de non-régression sur
  l'ancienne branche qui avalait les rejets non-`Error`.

`deno fmt`, `deno lint` et `deno test` passent sur les quatre fichiers (23 étapes).

## Sécurité

Verdict : **PASS**. La modification renforce la posture : passage en fail-closed
par défaut (suppression du vecteur de dégradation en anonyme), séparation claire
401 (client) / 500 (infra), validation stricte du sujet.

- Constat « divulgation d'information via le message d'erreur JWT » examiné et
  écarté : le message jose passé à `UnauthorizedException` devient `rpcError.data`,
  mais sur le chemin middleware → Express c'est `errorHandlerMiddleware` qui
  construit la réponse (à partir de `name`/`message` de l'exception, soit
  « Unauthorized Error »), sans sérialiser `rpcError`. Le détail jose n'est donc
  exposé qu'aux logs serveur, pas au client.
- Constats mineurs (longueur de `operator_id`, `\s` dans la regex Bearer) jugés
  négligeables (en-têtes HTTP normalisés, `operator_id` non utilisé dans un calcul
  sensible).

## CGU

Verdict : **PASS**. Aucune règle CGU applicable — code d'authentification et de
gestion d'erreurs uniquement ; aucune mutation de statut de trajet, de conservation
de données personnelles ni d'exposition de PII.

## Release

PR **app-stack** (`api/**`) destinée à déployer : type `fix` + scope non-data
(`auth`) → **release patch** attendue et déploiement de l'API.
