### PR TITLE
feat(policy): ajoute la campagne d'incitation ECOV x IDFM

### DIFF
--- a/api/src/pdc/services/policy/engine/helpers/cooldown.ts
+++ b/api/src/pdc/services/policy/engine/helpers/cooldown.ts
@@ -1,0 +1,54 @@
+import { MetadataLifetime, StatefulContextInterface, StatelessContextInterface } from "../../interfaces/index.ts";
+
+/**
+ * Non-splitting ("non-tronçonnage") cooldown.
+ *
+ * Registers a metadata storing the epoch (ms) of the last incentivized pickup
+ * for a given driver/passenger pair. `applyCooldown` then excludes any pickup
+ * happening less than `minMinutes` after the previous one, to prevent a driver
+ * from splitting a single ride into several short segments.
+ *
+ * The metadata uses a Month lifetime on purpose: `MetadataStore.store` only
+ * persists metadata whose lifetime is greater than Day, so a Day-scoped value
+ * would be lost between the finalize 6-hour windows. Month survives the windows
+ * (reset only across a month boundary — an accepted edge case).
+ */
+
+const COOLDOWN_NAME = "cooldown_last_pickup";
+
+export function registerCooldown(ctx: StatelessContextInterface, uuid: string): void {
+  const { driver_identity_key, passenger_identity_key } = ctx.carpool;
+  if (!driver_identity_key || !passenger_identity_key) {
+    return;
+  }
+
+  ctx.meta.register({
+    uuid,
+    name: COOLDOWN_NAME,
+    // "|" separator: identity keys are hex fingerprints, but a non-alphabet
+    // separator removes any theoretical scope collision between pairs.
+    scope: `${driver_identity_key}|${passenger_identity_key}`,
+    lifetime: MetadataLifetime.Month,
+  });
+}
+
+export function applyCooldown(
+  ctx: StatefulContextInterface,
+  uuid: string,
+  minMinutes: number,
+): void {
+  // The pair was not registered (missing identity key): nothing to enforce.
+  if (!ctx.meta.getRaw(uuid)) {
+    return;
+  }
+
+  const previous = ctx.meta.get(uuid); // epoch ms of the last pickup, 0 if none
+  const current = ctx.meta.datetime.getTime();
+
+  // Always record the latest pickup so the cooldown chains from it.
+  ctx.meta.set(uuid, current);
+
+  if (previous > 0 && current - previous < minMinutes * 60_000) {
+    ctx.incentive.set(0);
+  }
+}

--- a/api/src/pdc/services/policy/engine/helpers/cooldown.unit.spec.ts
+++ b/api/src/pdc/services/policy/engine/helpers/cooldown.unit.spec.ts
@@ -1,0 +1,66 @@
+import { it } from "dep:testing-bdd";
+
+import { StatefulContextInterface, StatelessContextInterface } from "../../interfaces/index.ts";
+import { process } from "../tests/macro.ts";
+import { applyCooldown, registerCooldown } from "./cooldown.ts";
+
+const COOLDOWN_UUID = "0f0c3e4a-0000-0000-0000-000000000001";
+const DRIVER = "driver-key";
+const PASSENGER = "passenger-key";
+
+// Minimal handler that flat-incentivizes every eligible carpool and applies a
+// 60-minute non-splitting cooldown per driver/passenger pair.
+const handler = {
+  id: "cooldown_test",
+  limits: [],
+  max_amount: 0,
+  async load() {},
+  processStateless(ctx: StatelessContextInterface) {
+    registerCooldown(ctx, COOLDOWN_UUID);
+    ctx.incentive.set(100);
+  },
+  processStateful(ctx: StatefulContextInterface) {
+    applyCooldown(ctx, COOLDOWN_UUID, 60);
+  },
+  params() {
+    return { tz: "Europe/Paris", slices: [], operators: [], allTimeOperators: [], limits: {}, extras: {} };
+  },
+};
+
+// same day, same pair, minutes apart
+function carpoolAt(minutes: number, passenger = PASSENGER) {
+  return {
+    datetime: new Date(new Date("2025-06-16T08:00:00Z").getTime() + minutes * 60_000),
+    driver_identity_key: DRIVER,
+    passenger_identity_key: passenger,
+  };
+}
+
+it("excludes a second pickup of the same pair within 60 minutes", async () => {
+  await process(
+    { handler, carpool: [carpoolAt(0), carpoolAt(30)] },
+    { incentive: [100, 0] },
+  );
+});
+
+it("keeps a pickup exactly 60 minutes after the previous one", async () => {
+  await process(
+    { handler, carpool: [carpoolAt(0), carpoolAt(60)] },
+    { incentive: [100, 100] },
+  );
+});
+
+it("chains the cooldown from the latest pickup (0, 30, 90)", async () => {
+  // t0 kept, t30 excluded (<60 from t0), t90 kept (>=60 from t30)
+  await process(
+    { handler, carpool: [carpoolAt(0), carpoolAt(30), carpoolAt(90)] },
+    { incentive: [100, 0, 100] },
+  );
+});
+
+it("does not affect a different passenger", async () => {
+  await process(
+    { handler, carpool: [carpoolAt(0), carpoolAt(30, "other-passenger")] },
+    { incentive: [100, 100] },
+  );
+});

--- a/api/src/pdc/services/policy/engine/helpers/index.ts
+++ b/api/src/pdc/services/policy/engine/helpers/index.ts
@@ -1,5 +1,7 @@
 export { atDate } from "./atDate.ts";
+export { applyCooldown, registerCooldown } from "./cooldown.ts";
 export { ensureFreeRide } from "./ensureFreeRide.ts";
+export { frenchPublicHolidays, isPublicHoliday } from "./isPublicHoliday.ts";
 export { getOperatorsAt, type TimestampedOperators } from "./getOperatorsAt.ts";
 export { isAdultOrThrow } from "./isAdultOrThrow.ts";
 export { isAfter } from "./isAfter.ts";
@@ -21,6 +23,7 @@ export {
   watchForPersonMaxTripByMonth,
 } from "./limits.ts";
 export { onDistanceRange, onDistanceRangeOrThrow } from "./onDistanceRange.ts";
+export { onHourRange } from "./onHourRange.ts";
 export { onWeekday } from "./onWeekday.ts";
 export { perKm, perSeat } from "./per.ts";
 export { endsAt, startsAndEndsAt, startsAt } from "./position.ts";

--- a/api/src/pdc/services/policy/engine/helpers/isPublicHoliday.ts
+++ b/api/src/pdc/services/policy/engine/helpers/isPublicHoliday.ts
@@ -1,0 +1,63 @@
+import { StatelessContextInterface } from "../../interfaces/index.ts";
+import { defaultTimezone } from "@/config/time.ts";
+import { toTzString } from "@/pdc/helpers/dates.helper.ts";
+
+interface IsPublicHolidayParams {
+  tz?: string;
+}
+
+// French public holidays (jours fériés légaux) for the ECOV x IDFM campaign
+// window. Includes the Easter-based days (lundi de Pâques, Ascension, lundi de
+// Pentecôte). Lundi de Pentecôte stays listed here as it is an official
+// holiday; the "journée de solidarité" carve-out is a campaign-level decision
+// handled in the policy, not here.
+export const frenchPublicHolidays: readonly string[] = [
+  // 2025 — Pâques 20/04
+  "2025-01-01", // Jour de l'an
+  "2025-04-21", // Lundi de Pâques
+  "2025-05-01", // Fête du travail
+  "2025-05-08", // Victoire 1945
+  "2025-05-29", // Ascension
+  "2025-06-09", // Lundi de Pentecôte
+  "2025-07-14", // Fête nationale
+  "2025-08-15", // Assomption
+  "2025-11-01", // Toussaint
+  "2025-11-11", // Armistice 1918
+  "2025-12-25", // Noël
+  // 2026 — Pâques 05/04
+  "2026-01-01",
+  "2026-04-06",
+  "2026-05-01",
+  "2026-05-08",
+  "2026-05-14", // Ascension
+  "2026-05-25", // Lundi de Pentecôte
+  "2026-07-14",
+  "2026-08-15",
+  "2026-11-01",
+  "2026-11-11",
+  "2026-12-25",
+  // 2027 — Pâques 28/03
+  "2027-01-01",
+  "2027-03-29",
+  "2027-05-01",
+  "2027-05-06", // Ascension
+  "2027-05-08",
+  "2027-05-17", // Lundi de Pentecôte
+  "2027-07-14",
+  "2027-08-15",
+  "2027-11-01",
+  "2027-11-11",
+  "2027-12-25",
+];
+
+/**
+ * Returns true when the carpool departure day is a French public holiday,
+ * resolved in the given timezone (Europe/Paris by default).
+ */
+export function isPublicHoliday(
+  ctx: StatelessContextInterface,
+  params: IsPublicHolidayParams = {},
+): boolean {
+  const day = toTzString(ctx.carpool.datetime, params.tz ?? defaultTimezone, "yyyy-MM-dd");
+  return frenchPublicHolidays.includes(day);
+}

--- a/api/src/pdc/services/policy/engine/helpers/isPublicHoliday.unit.spec.ts
+++ b/api/src/pdc/services/policy/engine/helpers/isPublicHoliday.unit.spec.ts
@@ -1,0 +1,36 @@
+import { assertEquals } from "dep:assert";
+import { it } from "dep:testing-bdd";
+
+import { StatelessContext } from "../entities/Context.ts";
+import { generateCarpool } from "../tests/helpers.ts";
+import { isPublicHoliday } from "./isPublicHoliday.ts";
+
+function setup(datetime: Date) {
+  return StatelessContext.fromCarpool(1, generateCarpool({ datetime }));
+}
+
+it("should return true on a fixed-date holiday (14 juillet)", async () => {
+  const ctx = setup(new Date("2025-07-14T09:00:00Z"));
+  assertEquals(isPublicHoliday(ctx), true);
+});
+
+it("should return true on an Easter-based holiday (Ascension 2025)", async () => {
+  const ctx = setup(new Date("2025-05-29T09:00:00Z"));
+  assertEquals(isPublicHoliday(ctx), true);
+});
+
+it("should return true on lundi de Pentecôte (still an official holiday)", async () => {
+  const ctx = setup(new Date("2026-05-25T09:00:00Z"));
+  assertEquals(isPublicHoliday(ctx), true);
+});
+
+it("should return false on a normal working day", async () => {
+  const ctx = setup(new Date("2025-07-15T09:00:00Z"));
+  assertEquals(isPublicHoliday(ctx), false);
+});
+
+it("should use the Paris timezone to resolve the day", async () => {
+  // 22:30 UTC on 13/07 -> 00:30 Paris on 14/07 (holiday)
+  const ctx = setup(new Date("2025-07-13T22:30:00Z"));
+  assertEquals(isPublicHoliday(ctx), true);
+});

--- a/api/src/pdc/services/policy/engine/helpers/onHourRange.ts
+++ b/api/src/pdc/services/policy/engine/helpers/onHourRange.ts
@@ -1,0 +1,28 @@
+import { StatelessContextInterface, StatelessRuleHelper } from "../../interfaces/index.ts";
+import { defaultTimezone } from "@/config/time.ts";
+import { toTzString } from "@/pdc/helpers/dates.helper.ts";
+
+interface OnHourRangeParams {
+  // hours of the day as decimals in the [0, 24] range
+  start: number;
+  end: number;
+  tz?: string;
+}
+
+/**
+ * Returns true when the carpool departure time-of-day falls within
+ * [start, end) in the given timezone (Europe/Paris by default).
+ * Minutes are taken into account (e.g. 03:30 => 3.5).
+ */
+export const onHourRange: StatelessRuleHelper<OnHourRangeParams> = (
+  ctx: StatelessContextInterface,
+  params: OnHourRangeParams,
+): boolean => {
+  // Extract the wall-clock time in the target timezone, independent of the
+  // runtime timezone (formatInTimeZone under the hood).
+  const [hh, mm] = toTzString(ctx.carpool.datetime, params.tz ?? defaultTimezone, "HH:mm")
+    .split(":")
+    .map(Number);
+  const hours = hh + mm / 60;
+  return hours >= params.start && hours < params.end;
+};

--- a/api/src/pdc/services/policy/engine/helpers/onHourRange.unit.spec.ts
+++ b/api/src/pdc/services/policy/engine/helpers/onHourRange.unit.spec.ts
@@ -1,0 +1,41 @@
+import { assertEquals } from "dep:assert";
+import { it } from "dep:testing-bdd";
+
+import { StatelessContext } from "../entities/Context.ts";
+import { generateCarpool } from "../tests/helpers.ts";
+import { onHourRange } from "./onHourRange.ts";
+
+// Europe/Paris in June is UTC+2, so the UTC instant maps to +2h local time.
+function setup(datetime: Date) {
+  return StatelessContext.fromCarpool(1, generateCarpool({ datetime }));
+}
+
+it("should return true inside the range", async () => {
+  // 08:00 UTC -> 10:00 Paris
+  const ctx = setup(new Date("2025-06-16T08:00:00Z"));
+  assertEquals(onHourRange(ctx, { start: 4, end: 23 }), true);
+});
+
+it("should return true at the start bound (inclusive)", async () => {
+  // 02:00 UTC -> 04:00 Paris
+  const ctx = setup(new Date("2025-06-16T02:00:00Z"));
+  assertEquals(onHourRange(ctx, { start: 4, end: 23 }), true);
+});
+
+it("should return false before the start bound", async () => {
+  // 01:00 UTC -> 03:00 Paris
+  const ctx = setup(new Date("2025-06-16T01:00:00Z"));
+  assertEquals(onHourRange(ctx, { start: 4, end: 23 }), false);
+});
+
+it("should return false at the end bound (exclusive)", async () => {
+  // 21:00 UTC -> 23:00 Paris
+  const ctx = setup(new Date("2025-06-16T21:00:00Z"));
+  assertEquals(onHourRange(ctx, { start: 4, end: 23 }), false);
+});
+
+it("should respect minutes near the start bound", async () => {
+  // 01:30 UTC -> 03:30 Paris
+  const ctx = setup(new Date("2025-06-16T01:30:00Z"));
+  assertEquals(onHourRange(ctx, { start: 4, end: 23 }), false);
+});

--- a/api/src/pdc/services/policy/engine/policies/20250428_ECOV_IDFM.ts
+++ b/api/src/pdc/services/policy/engine/policies/20250428_ECOV_IDFM.ts
@@ -1,0 +1,188 @@
+import { RunnableSlices } from "../../interfaces/engine/PolicyInterface.ts";
+import {
+  OperatorsEnum,
+  PolicyHandlerInterface,
+  PolicyHandlerParamsInterface,
+  PolicyHandlerStaticInterface,
+  StatefulContextInterface,
+  StatelessContextInterface,
+} from "../../interfaces/index.ts";
+import { NotEligibleTargetException } from "../exceptions/NotEligibleTargetException.ts";
+import { atDate } from "../helpers/atDate.ts";
+import { applyCooldown, registerCooldown } from "../helpers/cooldown.ts";
+import { getOperatorsAt, TimestampedOperators } from "../helpers/getOperatorsAt.ts";
+import { isOperatorClassOrThrow } from "../helpers/isOperatorClassOrThrow.ts";
+import { isOperatorOrThrow } from "../helpers/isOperatorOrThrow.ts";
+import { isPublicHoliday } from "../helpers/isPublicHoliday.ts";
+import {
+  LimitTargetEnum,
+  watchForGlobalMaxAmount,
+  watchForMaxPassengersPerDriverPerDay,
+  watchForMaxPassengersPerTrip,
+  watchForPersonMaxAmountByMonth,
+} from "../helpers/limits.ts";
+import { onDistanceRange, onDistanceRangeOrThrow } from "../helpers/onDistanceRange.ts";
+import { onHourRange } from "../helpers/onHourRange.ts";
+import { onWeekday } from "../helpers/onWeekday.ts";
+import { perKm, perSeat } from "../helpers/per.ts";
+import { endsAt, startsAt } from "../helpers/position.ts";
+import { AbstractPolicyHandler } from "./AbstractPolicyHandler.ts";
+
+// Fiche descriptive : campagne d'incitation Île-de-France Mobilités x Ecov
+// (lignes de covoiturage Ecov IDFM). Validée AOM. Voir ticket RPC #347769.
+//
+// Éligibilité :
+//   • Opérateur Ecov, classe de preuve C, distance >= 2 km.
+//   • Départ ET arrivée sur le territoire d'Île-de-France Mobilités.
+//   • Service ouvert du lundi au vendredi de 4h à 23h (heure de départ),
+//     hors jours fériés — sauf la journée de solidarité (lundi de Pentecôte).
+//   • Non-tronçonnage : un même passager ne peut être pris en charge par le
+//     même conducteur moins de 60 minutes après le trajet précédent.
+//
+// Barème (identique à Covoit IDFM 2026) :
+//   • 2 € de 2 à 20 km, puis 0,10 €/km, plafonné à 3 € par trajet et passager.
+//
+// Plafonds :
+//   • 200 €/mois/conducteur, 6 trajets passager/jour/conducteur,
+//     3 trajets passager/trip (Ecov : 1 passager par journey => sièges = journeys).
+export const EcovIDFM2026: PolicyHandlerStaticInterface = class extends AbstractPolicyHandler
+  implements PolicyHandlerInterface {
+  static readonly id = "ecov_idfm_2026";
+
+  // Code INSEE de l'AOM Île-de-France Mobilités
+  protected readonly idfmAom = "287500078";
+
+  // Journée de solidarité (lundi de Pentecôte) : jour férié mais travaillé,
+  // donc le service reste ouvert et les trajets restent éligibles.
+  protected readonly journeeSolidarite = [
+    "2025-06-09",
+    "2026-05-25",
+    "2027-05-17",
+  ];
+
+  // À activer si la collectivité confirme l'exclusion des trajets Paris-Paris
+  // (absente de la fiche descriptive, en attente retour équipe).
+  protected readonly excludeParisParis = false;
+
+  constructor(public max_amount: number) {
+    super();
+    this.limits = [
+      // 200 € max / mois / conducteur
+      [
+        "0d5f2a1e-9a3c-4d0a-8b6e-1f2c3d4e5f60",
+        200_00,
+        watchForPersonMaxAmountByMonth,
+        LimitTargetEnum.Driver,
+      ],
+      // 6 trajets passager / jour / conducteur
+      [
+        "1e6f3b2f-0b4d-5e1b-9c7f-2a3b4c5d6e71",
+        6,
+        watchForMaxPassengersPerDriverPerDay,
+      ],
+      // 3 trajets passager / trip
+      [
+        "2f7a4c30-1c5e-6f2c-ad80-3b4c5d6e7f82",
+        3,
+        watchForMaxPassengersPerTrip,
+      ],
+      // Plafond global de la campagne
+      [
+        "3a8b5d41-2d6f-7a3d-be91-4c5d6e7f8093",
+        max_amount,
+        watchForGlobalMaxAmount,
+      ],
+    ];
+  }
+
+  protected operators: TimestampedOperators = [
+    {
+      date: new Date("2025-04-28T00:00:00+0200"),
+      operators: [
+        OperatorsEnum.ECOV,
+      ],
+    },
+  ];
+
+  // Identifiant de la métadonnée de non-tronçonnage
+  protected readonly cooldownUuid = "4b9c6e52-3e70-8b4e-cfa2-5d6e7f809104";
+  protected readonly cooldownMinutes = 60;
+
+  protected slices: RunnableSlices = [
+    {
+      start: 2_000,
+      end: 20_000,
+      fn: (ctx: StatelessContextInterface) => perSeat(ctx, 200),
+    },
+    {
+      start: 20_000,
+      fn: (ctx: StatelessContextInterface) => perSeat(ctx, perKm(ctx, { amount: 10, offset: 20_000, limit: 30_000 })),
+    },
+  ];
+
+  protected processExclusion(ctx: StatelessContextInterface) {
+    // Opérateur Ecov uniquement
+    isOperatorOrThrow(ctx, getOperatorsAt(this.operators, ctx.carpool.datetime));
+
+    // Distance minimum 2 km
+    onDistanceRangeOrThrow(ctx, { min: 2_000 });
+
+    // Départ ET arrivée dans l'AOM Île-de-France Mobilités
+    if (!startsAt(ctx, { aom: [this.idfmAom] }) || !endsAt(ctx, { aom: [this.idfmAom] })) {
+      throw new NotEligibleTargetException();
+    }
+
+    // Exclusion Paris-Paris (désactivée par défaut, voir excludeParisParis)
+    if (this.excludeParisParis && startsAt(ctx, { com: ["75056"] }) && endsAt(ctx, { com: ["75056"] })) {
+      throw new NotEligibleTargetException();
+    }
+
+    // Ouverture : lundi au vendredi, 4h-23h, hors jours fériés (sauf solidarité)
+    const isHoliday = isPublicHoliday(ctx) && !atDate(ctx, { dates: this.journeeSolidarite });
+    if (
+      !onWeekday(ctx, { days: [1, 2, 3, 4, 5] }) ||
+      !onHourRange(ctx, { start: 4, end: 23 }) ||
+      isHoliday
+    ) {
+      throw new NotEligibleTargetException();
+    }
+
+    // Classe de preuve C
+    isOperatorClassOrThrow(ctx, ["C"]);
+  }
+
+  override processStateless(ctx: StatelessContextInterface): void {
+    this.processExclusion(ctx);
+    super.processStateless(ctx);
+
+    // Non-tronçonnage : mémorise le couple conducteur/passager
+    registerCooldown(ctx, this.cooldownUuid);
+
+    // Calcul de l'incitation par tranches (additif)
+    let amount = 0;
+    for (const { start, fn } of this.slices) {
+      if (onDistanceRange(ctx, { min: start })) {
+        amount += fn(ctx);
+      }
+    }
+
+    ctx.incentive.set(amount);
+  }
+
+  override processStateful(ctx: StatefulContextInterface): void {
+    // Applique le non-tronçonnage avant les limites cumulatives
+    applyCooldown(ctx, this.cooldownUuid, this.cooldownMinutes);
+    super.processStateful(ctx);
+  }
+
+  params(): PolicyHandlerParamsInterface {
+    return {
+      tz: "Europe/Paris",
+      slices: this.slices,
+      operators: getOperatorsAt(this.operators),
+      allTimeOperators: Array.from(new Set(this.operators.flatMap((entry) => entry.operators))),
+      limits: { glob: this.max_amount },
+      extras: {},
+    };
+  }
+};

--- a/api/src/pdc/services/policy/engine/policies/20250428_ECOV_IDFM.unit.spec.ts
+++ b/api/src/pdc/services/policy/engine/policies/20250428_ECOV_IDFM.unit.spec.ts
@@ -1,0 +1,187 @@
+import { describe, it } from "dep:testing-bdd";
+import { v4 as uuidV4 } from "@/lib/uuid/index.ts";
+import { OperatorsEnum } from "../../interfaces/index.ts";
+import { makeProcessHelper } from "../tests/macro.ts";
+import { EcovIDFM2026 as Handler } from "./20250428_ECOV_IDFM.ts";
+
+const defaultPosition = {
+  arr: "78646",
+  com: "78646",
+  aom: "287500078", // Île-de-France Mobilités
+  epci: "200056232",
+  dep: "78",
+  reg: "11",
+  country: "XXXXX",
+};
+const defaultLat = 48.72565703413325;
+const defaultLon = 2.261827843187402;
+
+// Monday 16/06/2025, 08:00 UTC = 10:00 Paris (summer, UTC+2): weekday, within
+// opening hours, not a holiday. Datetimes are UTC-explicit so the tests are
+// independent of the runtime timezone (CI runs in UTC).
+const defaultCarpool = {
+  _id: 1,
+  operator_trip_id: uuidV4(),
+  passenger_identity_key: uuidV4(),
+  driver_identity_key: uuidV4(),
+  operator_uuid: OperatorsEnum.ECOV,
+  operator_class: "C",
+  passenger_is_over_18: true,
+  passenger_has_travel_pass: true,
+  driver_has_travel_pass: true,
+  datetime: new Date("2025-06-16T08:00:00Z"),
+  seats: 1,
+  distance: 5_000,
+  operator_journey_id: uuidV4(),
+  operator_id: 1,
+  driver_revenue: 2_00,
+  passenger_contribution: 0,
+  start: { ...defaultPosition },
+  end: { ...defaultPosition },
+  start_lat: defaultLat,
+  start_lon: defaultLon,
+  end_lat: defaultLat,
+  end_lon: defaultLon,
+};
+
+const process = makeProcessHelper(defaultCarpool);
+
+describe("ECOV x IDFM - Exclusions", () => {
+  it("unsupported operator", async () =>
+    await process({
+      policy: { handler: Handler.id },
+      carpool: [{ operator_uuid: "not in list" }],
+    }, { incentive: [0] }));
+
+  it("distance below minimum (2 km)", async () =>
+    await process({
+      policy: { handler: Handler.id },
+      carpool: [{ distance: 1_000 }],
+    }, { incentive: [0] }));
+
+  it("trip outside AOM (start)", async () =>
+    await process({
+      policy: { handler: Handler.id },
+      carpool: [{ start: { ...defaultPosition, aom: "not_ok" } }],
+    }, { incentive: [0] }));
+
+  it("trip outside AOM (end)", async () =>
+    await process({
+      policy: { handler: Handler.id },
+      carpool: [{ end: { ...defaultPosition, aom: "not_ok" } }],
+    }, { incentive: [0] }));
+
+  it("operator class not eligible (only C)", async () =>
+    await process({
+      policy: { handler: Handler.id },
+      carpool: [{ operator_class: "B" }],
+    }, { incentive: [0] }));
+
+  it("trip before the campaign start (operator not active yet)", async () =>
+    await process({
+      policy: { handler: Handler.id },
+      carpool: [{ datetime: new Date("2025-01-06T09:00:00Z") }],
+    }, { incentive: [0] }));
+
+  it("trip on a weekend (Saturday)", async () =>
+    await process({
+      policy: { handler: Handler.id },
+      carpool: [{ datetime: new Date("2025-06-14T08:00:00Z") }],
+    }, { incentive: [0] }));
+
+  it("trip before opening hours (03:00)", async () =>
+    await process({
+      policy: { handler: Handler.id },
+      carpool: [{ datetime: new Date("2025-06-16T01:00:00Z") }],
+    }, { incentive: [0] }));
+
+  it("trip after closing hours (23:30)", async () =>
+    await process({
+      policy: { handler: Handler.id },
+      carpool: [{ datetime: new Date("2025-06-16T21:30:00Z") }],
+    }, { incentive: [0] }));
+
+  it("trip on a public holiday (14 juillet)", async () =>
+    await process({
+      policy: { handler: Handler.id },
+      carpool: [{ datetime: new Date("2025-07-14T08:00:00Z") }],
+    }, { incentive: [0] }));
+});
+
+describe("ECOV x IDFM - Journée de solidarité", () => {
+  it("stays eligible on lundi de Pentecôte (2025-06-09)", async () =>
+    await process({
+      policy: { handler: Handler.id },
+      carpool: [{ datetime: new Date("2025-06-09T08:00:00Z") }],
+    }, { incentive: [200] }));
+});
+
+describe("ECOV x IDFM - Incentives", () => {
+  it("first slice: flat 2€ from 2 to 20 km", async () =>
+    await process({
+      policy: { handler: Handler.id },
+      carpool: [
+        { passenger_identity_key: uuidV4(), distance: 2_000 },
+        { passenger_identity_key: uuidV4(), distance: 5_000 },
+        { passenger_identity_key: uuidV4(), distance: 20_000 },
+      ],
+    }, { incentive: [200, 200, 200] }));
+
+  it("second slice: +0.10€/km capped at 3€", async () =>
+    await process({
+      policy: { handler: Handler.id },
+      carpool: [
+        { passenger_identity_key: uuidV4(), distance: 25_000 },
+        { passenger_identity_key: uuidV4(), distance: 30_000 },
+        { passenger_identity_key: uuidV4(), distance: 80_000 },
+      ],
+    }, { incentive: [250, 300, 300] }));
+});
+
+describe("ECOV x IDFM - Limits", () => {
+  it("limits passengers per trip to 3", async () => {
+    const operator_trip_id = uuidV4();
+    await process({
+      policy: { handler: Handler.id },
+      carpool: [
+        { driver_identity_key: "1", operator_trip_id, passenger_identity_key: "emile" },
+        { driver_identity_key: "1", operator_trip_id, passenger_identity_key: "georgette" },
+        { driver_identity_key: "1", operator_trip_id, passenger_identity_key: "bob" },
+        { driver_identity_key: "1", operator_trip_id, passenger_identity_key: "alice" }, // exceeds
+      ],
+    }, { incentive: [200, 200, 200, 0] });
+  });
+
+  it("limits passengers per driver per day to 6", async () =>
+    await process({
+      policy: { handler: Handler.id },
+      carpool: [
+        { driver_identity_key: "d", operator_trip_id: uuidV4(), passenger_identity_key: "p1", seats: 2 },
+        { driver_identity_key: "d", operator_trip_id: uuidV4(), passenger_identity_key: "p2", seats: 2 },
+        { driver_identity_key: "d", operator_trip_id: uuidV4(), passenger_identity_key: "p3", seats: 2 },
+        { driver_identity_key: "d", operator_trip_id: uuidV4(), passenger_identity_key: "p4", seats: 2 }, // exceeds
+      ],
+    }, { incentive: [400, 400, 400, 0] }));
+
+  it("limits driver monthly earnings to 200 €", async () =>
+    await process({
+      policy: { handler: Handler.id },
+      carpool: [{ driver_identity_key: "driver_1" }],
+      meta: [
+        { key: "max_amount_restriction.0-driver_1.month.5-2025", value: 199_00 },
+        { key: "max_amount_restriction.global.campaign.global", value: 199_00 },
+      ],
+    }, { incentive: [1_00] }));
+});
+
+describe("ECOV x IDFM - Non-tronçonnage (60 min)", () => {
+  it("excludes a second pickup of the same pair within 60 minutes", async () =>
+    await process({
+      policy: { handler: Handler.id },
+      carpool: [
+        { driver_identity_key: "d", passenger_identity_key: "p", datetime: new Date("2025-06-16T08:00:00Z") },
+        { driver_identity_key: "d", passenger_identity_key: "p", datetime: new Date("2025-06-16T08:30:00Z") },
+        { driver_identity_key: "d", passenger_identity_key: "p", datetime: new Date("2025-06-16T10:00:00Z") },
+      ],
+    }, { incentive: [200, 0, 200] }));
+});

--- a/api/src/pdc/services/policy/engine/policies/index.ts
+++ b/api/src/pdc/services/policy/engine/policies/index.ts
@@ -55,6 +55,7 @@ import { MontluconCommunaute2026 } from "./20260101_Montlucon_2026.ts";
 import { Occitanie20262027 } from "./20260101_Occitanie.ts";
 import { PMGF2026 } from "./20260101_PMGF.ts";
 import { CCSPSL2026 } from "./20260301_CCSPSL_2026.ts";
+import { EcovIDFM2026 } from "./20250428_ECOV_IDFM.ts";
 
 export const policies: Map<string, PolicyHandlerStaticInterface> = new Map(
   [
@@ -67,6 +68,7 @@ export const policies: Map<string, PolicyHandlerStaticInterface> = new Map(
     Cannes2024,
     Cotentin2023,
     CovoitIDFM2026,
+    EcovIDFM2026,
     GrandChatellerault2024,
     GrandChatellerault2025,
     GrandChatellerault2026,


### PR DESCRIPTION
## Résumé

Ajoute la campagne d'incitation au covoiturage **Île-de-France Mobilités × Ecov** (ticket #347769), sur les lignes de covoiturage Ecov IDFM. Fiche descriptive validée par l'AOM.

Le handler `ecov_idfm_2026` est calqué sur `covoit_idfm_2026`, avec en plus les contraintes propres à cette campagne : horaires d'ouverture, jours fériés, et règle de non-tronçonnage.

## Ce qui change

### Nouveau handler de campagne
`api/src/pdc/services/policy/engine/policies/20250428_ECOV_IDFM.ts` (id `ecov_idfm_2026`, territoire 329) :

- **Éligibilité** : opérateur Ecov, classe de preuve C, distance ≥ 2 km, départ **et** arrivée dans l'AOM IDFM (`287500078`).
- **Ouverture** : lundi au vendredi, 4h–23h (heure de départ), hors jours fériés — **sauf la journée de solidarité** (lundi de Pentecôte), travaillée.
- **Non-tronçonnage** : un même passager ne peut être repris par le même conducteur moins de 60 minutes après le trajet précédent.
- **Barème** : 2 € de 2 à 20 km, puis 0,10 €/km, plafonné à 3 € par trajet et par passager (identique à Covoit IDFM 2026).
- **Plafonds** : 200 €/mois/conducteur, 6 trajets passager/jour/conducteur, 3 trajets passager/trip.
- **Budget** : 1 999 999 €. Période : 28/04/2025 → 20/12/2027.

Note : Ecov envoie 1 passager par journey (vérifié en base : `passenger_seats` = 1 sur 145 318 trajets), donc les compteurs par sièges expriment exactement les seuils exprimés en « trajets passager ».

### Nouveaux helpers réutilisables
- `onHourRange` — plage horaire de la journée, robuste au fuseau (`formatInTimeZone`).
- `isPublicHoliday` — jours fériés français 2025-2027.
- `cooldown` (`registerCooldown` / `applyCooldown`) — non-tronçonnage via métadonnée de durée `Month` (survit aux fenêtres de 6h du `finalize`), horodatage chaîné sur le dernier ramassage.

### Tests
Développement en TDD : 14 tests unitaires sur les helpers, 17 assertions sur le handler (exclusions, journée de solidarité, barème, plafonds, non-tronçonnage). Suite complète du moteur de policies : **328 tests verts, 0 régression**.

## Suite (hors code, opérationnel)

1. Insérer la campagne dans `policy.policies` (SQL prêt) **après déploiement** du handler.
2. Recalcul rétroactif : `campaign:apply` puis `campaign:finalize` depuis le 28/04/2025.
3. Notifier le chargé de déploiement.

## Point en attente

- **Exclusion Paris-Paris** (75056↔75056) : absente de la fiche, codée derrière le flag `excludeParisParis = false`. À confirmer avec la collectivité/l'équipe avant de l'activer.

## Limite connue

Le cooldown de non-tronçonnage se réinitialise au passage de mois (métadonnée `Month`) : un couple à cheval sur minuit du 1er du mois échappe à la règle. Cas limite accepté et documenté dans le code.

## CGU

Verdict : **PASS** pour le périmètre de la PR. Les fichiers de la campagne (handler + helpers) ne touchent à aucune donnée personnelle exposée/loggée/exportée et n'introduisent aucune mutation de statut de trajet. Les `*_identity_key` ne servent que de `scope` de métadonnée (identifiants déjà pseudonymisés, mécanisme existant).

## Sécurité

Verdict : **PASS** (non bloquant). Points vérifiés conformes : pas d'injection SQL, pas de fuite de données personnelles en log, epoch stocké en `bigint` sans débordement (< 2^53), robustesse timezone (`toTzString` indépendant du fuseau runtime), aucun secret, aucune nouvelle dépendance.

Constats mineurs :
- **Séparateur de scope du cooldown** (faible) — corrigé dans cette PR : passage de `-` à `|` pour lever toute collision théorique entre couples conducteur/passager.
- **Liste de jours fériés en dur jusqu'au 25/12/2027** (moyen) — accepté : la couverture englobe toute la durée de la campagne (fin le 20/12/2027, au-delà de laquelle le garde de dates de la policy rejette les trajets). Un calcul dynamique des jours mobiles (Pâques) serait sur-dimensionné pour une campagne unique.