### PR TITLE
feat(export): ajoute les vues FDW d'export vers le datalake

### DIFF
--- a/api/src/db/migrations/20260703000000-datalake-fdw-export.sql
+++ b/api/src/db/migrations/20260703000000-datalake-fdw-export.sql
@@ -1,34 +1,6 @@
 -- =====================================================================
---  dlk_export.sql — côté API (covoiturage_production) du FDW datalake
+--  côté API (covoiturage_production) du FDW datalake
 -- =====================================================================
---  CONTEXTE (pour reprise dans une autre session)
---  ---------------------------------------------------------------------
---  Projet : covoiturage-gouv-fr/infra (OpenTofu/Scaleway + Flux/kustomize).
---  Le datalake (dbt, repo covoiturage-gouv-fr/mono, dossier `datalake/`)
---  vit dans une base SÉPARÉE `datalake_production` et lit les tables de
---  l'API (`covoiturage_production`) via un foreign data wrapper (postgres_fdw).
---
---  Architecture FDW, deux schémas symétriques :
---    - covoiturage_production.dlk_export  -> LES VUES (ce script)
---    - datalake_production.dlk_import     -> LES FOREIGN TABLES (autre script)
---    Noms plats identiques des deux côtés (`<schema>_<table>`) =>
---    `IMPORT FOREIGN SCHEMA dlk_export ... INTO dlk_import` crée les 14 d'un coup.
---
---  Tickets/PR liés :
---    - #20  spike + mise en place FDW (extension postgres_fdw confirmée dispo)
---    - #34  création de la base datalake_production (OpenTofu)
---    - #36  (PR) user OpenTofu `datalake_fdw` (lecture seule) + secret
---             `pg_password_datalake_fdw_production` (Scaleway Secret Manager)
---    - #35  rotation du mot de passe (le USER MAPPING devra être mis à jour)
---
---  PRÉREQUIS D'EXÉCUTION
---    - Connexion : vnmqdctpgsro @ covoiturage_production (user applicatif).
---    - L'utilisateur `datalake_fdw` existe déjà (OpenTofu PR #36 + `tofu apply`),
---      sinon les GRANT échouent.
---    - vnm doit avoir SELECT sur les schémas sources (carpool_v2, policy, cee,
---      operator, territory, fraudcheck, company, anomaly, carpool) — sinon un
---      CREATE VIEW lèvera une erreur de droit sur la table concernée.
---
 --  CHOIX DE CONCEPTION
 --    - Vues "security definer" (défaut) : elles tournent avec les droits de leur
 --      propriétaire (vnm). `datalake_fdw` n'a AUCUN accès aux schémas applicatifs,
@@ -66,11 +38,6 @@
 --    - TODO (suivi, hors périmètre de cette migration) : acter la borne dans le
 --      registre RGPD / AIPD et, si un TTL propre au datalake est décidé, ajouter un
 --      job de purge côté `datalake_production`.
---
---  ÉTAPE SUIVANTE (autre script, côté datalake_production) :
---    CREATE EXTENSION postgres_fdw; CREATE SERVER; CREATE USER MAPPING
---    (datalake -> datalake_fdw); IMPORT FOREIGN SCHEMA dlk_export INTO dlk_import;
---    puis refactor des sources dbt vers source('dlk_import', ...).
 -- =====================================================================
 
 CREATE SCHEMA IF NOT EXISTS dlk_export;
@@ -193,7 +160,6 @@ FROM cee.cee_applications;
 --  Droits pour datalake_fdw (lecture seule, user créé par OpenTofu PR #36)
 -- =====================================================================
 
-GRANT CONNECT ON DATABASE covoiturage_production TO datalake_fdw;
 GRANT USAGE   ON SCHEMA   dlk_export              TO datalake_fdw;
 GRANT SELECT  ON ALL TABLES IN SCHEMA dlk_export  TO datalake_fdw;
 

--- a/api/src/db/migrations/20260703000000-datalake-fdw-export.sql
+++ b/api/src/db/migrations/20260703000000-datalake-fdw-export.sql
@@ -1,0 +1,201 @@
+-- =====================================================================
+--  dlk_export.sql — côté API (covoiturage_production) du FDW datalake
+-- =====================================================================
+--  CONTEXTE (pour reprise dans une autre session)
+--  ---------------------------------------------------------------------
+--  Projet : covoiturage-gouv-fr/infra (OpenTofu/Scaleway + Flux/kustomize).
+--  Le datalake (dbt, repo covoiturage-gouv-fr/mono, dossier `datalake/`)
+--  vit dans une base SÉPARÉE `datalake_production` et lit les tables de
+--  l'API (`covoiturage_production`) via un foreign data wrapper (postgres_fdw).
+--
+--  Architecture FDW, deux schémas symétriques :
+--    - covoiturage_production.dlk_export  -> LES VUES (ce script)
+--    - datalake_production.dlk_import     -> LES FOREIGN TABLES (autre script)
+--    Noms plats identiques des deux côtés (`<schema>_<table>`) =>
+--    `IMPORT FOREIGN SCHEMA dlk_export ... INTO dlk_import` crée les 14 d'un coup.
+--
+--  Tickets/PR liés :
+--    - #20  spike + mise en place FDW (extension postgres_fdw confirmée dispo)
+--    - #34  création de la base datalake_production (OpenTofu)
+--    - #36  (PR) user OpenTofu `datalake_fdw` (lecture seule) + secret
+--             `pg_password_datalake_fdw_production` (Scaleway Secret Manager)
+--    - #35  rotation du mot de passe (le USER MAPPING devra être mis à jour)
+--
+--  PRÉREQUIS D'EXÉCUTION
+--    - Connexion : vnmqdctpgsro @ covoiturage_production (user applicatif).
+--    - L'utilisateur `datalake_fdw` existe déjà (OpenTofu PR #36 + `tofu apply`),
+--      sinon les GRANT échouent.
+--    - vnm doit avoir SELECT sur les schémas sources (carpool_v2, policy, cee,
+--      operator, territory, fraudcheck, company, anomaly, carpool) — sinon un
+--      CREATE VIEW lèvera une erreur de droit sur la table concernée.
+--
+--  CHOIX DE CONCEPTION
+--    - Vues "security definer" (défaut) : elles tournent avec les droits de leur
+--      propriétaire (vnm). `datalake_fdw` n'a AUCUN accès aux schémas applicatifs,
+--      seulement USAGE sur dlk_export + SELECT sur les vues.
+--    - Enums castés en `text` -> pas besoin de répliquer les types enum via le FDW.
+--    - Geometry conservée (start_position/end_position/geo) : utilisée par les
+--      exports (ST_X/ST_Y) -> postgis REQUIS aussi côté datalake_production.
+--    - PII minimisée : seules les colonnes réellement consommées par les modèles
+--      dbt sont exportées (marquées -- PII ci-dessous). Les colonnes PII inutilisées
+--      ont été retirées (licence_plate, carpool v1 identity_id, et cee last_name_trunc
+--      / phone_trunc / driving_license / identity_key). Restent : téléphones complets
+--      (entrée du hash driver_key/passenger_key dans trusted), identity_key et
+--      operator_user_id bruts (surfacés dans exposed/export/export_partners).
+--    - Projection = colonnes déclarées dans les sources dbt (`models/sources/*.yml`),
+--      filtrées sur usage réel. 14 tables : 12 pérennes + 2 temporaires.
+--
+--  RÉTENTION / RGPD (borne de conservation de la PII exportée)
+--  ---------------------------------------------------------------------
+--    - Pas de nouvelle collecte : ces vues sont une simple PROJECTION en lecture
+--      seule de tables API déjà soumises à la politique de rétention de
+--      `covoiturage_production`. Le FDW ne matérialise rien côté API.
+--    - Alignement source : `datalake_production` ne conserve PAS la PII au-delà de
+--      la source. Les modèles dbt sont reconstruits (full-refresh) depuis les vues ;
+--      une ligne purgée/anonymisée côté API disparaît du datalake au rebuild suivant.
+--      => la borne de rétention de la PII = celle de covoiturage_production, héritée.
+--    - Minimisation par hachage : les PII directes (téléphones, identity_key,
+--      operator_user_id) ne servent qu'à dériver `driver_key`/`passenger_key`
+--      (md5) dans la couche `trusted` ; la PII brute n'est PAS persistée au-delà
+--      de `trusted` (cf. datalake/models/trusted/carpools.sql).
+--    - Exception maîtrisée : `identity_key` + `operator_user_id` bruts ne surfacent
+--      que dans `exposed/export/export_partners`, export partenaire déjà couvert par
+--      les CGU/accords de partage de données opérateurs.
+--    - Accès : PII lisible uniquement par le rôle `datalake_fdw` (lecture seule) et
+--      le propriétaire des vues ; aucun accès direct aux schémas applicatifs.
+--    - TODO (suivi, hors périmètre de cette migration) : acter la borne dans le
+--      registre RGPD / AIPD et, si un TTL propre au datalake est décidé, ajouter un
+--      job de purge côté `datalake_production`.
+--
+--  ÉTAPE SUIVANTE (autre script, côté datalake_production) :
+--    CREATE EXTENSION postgres_fdw; CREATE SERVER; CREATE USER MAPPING
+--    (datalake -> datalake_fdw); IMPORT FOREIGN SCHEMA dlk_export INTO dlk_import;
+--    puis refactor des sources dbt vers source('dlk_import', ...).
+-- =====================================================================
+
+CREATE SCHEMA IF NOT EXISTS dlk_export;
+
+-- ============================ carpool_v2 (pérenne) ============================
+
+CREATE OR REPLACE VIEW dlk_export.carpool_v2_carpools AS
+SELECT
+  _id, created_at, updated_at, operator_id, operator_journey_id, operator_trip_id,
+  operator_class, start_datetime, start_position, end_datetime, end_position, distance,
+  driver_identity_key,           -- PII
+  driver_operator_user_id,       -- PII
+  driver_phone,                  -- PII
+  driver_phone_trunc,
+  driver_travelpass_name, driver_travelpass_user_id, driver_revenue,
+  passenger_identity_key,        -- PII
+  passenger_operator_user_id,    -- PII
+  passenger_phone,               -- PII
+  passenger_phone_trunc,
+  passenger_travelpass_name, passenger_travelpass_user_id, passenger_over_18,
+  passenger_seats, passenger_contribution, passenger_payments, uuid, legacy_id
+FROM carpool_v2.carpools;
+
+CREATE OR REPLACE VIEW dlk_export.carpool_v2_geo AS
+SELECT _id, carpool_id, updated_at, start_geo_code, end_geo_code, errors
+FROM carpool_v2.geo;
+
+CREATE OR REPLACE VIEW dlk_export.carpool_v2_status AS
+SELECT
+  _id, carpool_id, updated_at,
+  acquisition_status::text AS acquisition_status,
+  fraud_status::text       AS fraud_status,
+  anomaly_status::text     AS anomaly_status
+FROM carpool_v2.status;
+
+CREATE OR REPLACE VIEW dlk_export.carpool_v2_operator_incentives AS
+SELECT _id, carpool_id, idx, siret, amount
+FROM carpool_v2.operator_incentives;
+
+CREATE OR REPLACE VIEW dlk_export.carpool_v2_terms_violation_error_labels AS
+SELECT _id, created_at, carpool_id, labels
+FROM carpool_v2.terms_violation_error_labels;
+
+-- ============================ policy (pérenne) ============================
+
+CREATE OR REPLACE VIEW dlk_export.policy_incentives AS
+SELECT
+  _id, policy_id, status::text AS status, meta, carpool_id, amount, datetime,
+  result, state::text AS state, operator_id, operator_journey_id
+FROM policy.incentives;
+
+CREATE OR REPLACE VIEW dlk_export.policy_policies AS
+SELECT
+  _id, created_at, updated_at, deleted_at, territory_id, start_date, end_date,
+  name, description, unit::text AS unit, status::text AS status, handler,
+  incentive_sum, max_amount, tz, descriptive_sheet_url
+FROM policy.policies;
+
+-- ============================ operator (pérenne) ============================
+
+CREATE OR REPLACE VIEW dlk_export.operator_operators AS
+SELECT
+  _id, created_at, updated_at, deleted_at, name, legal_name, siret,
+  cgu_accepted_at, cgu_accepted_by, company, address, bank, contacts, uuid, support
+FROM operator.operators;
+
+-- ============================ territory (pérenne) ============================
+
+CREATE OR REPLACE VIEW dlk_export.territory_territory_group AS
+SELECT _id, company_id, created_at, updated_at, deleted_at, name, shortname, contacts, address
+FROM territory.territory_group;
+
+-- ============================ fraudcheck (pérenne) ============================
+
+CREATE OR REPLACE VIEW dlk_export.fraudcheck_labels AS
+SELECT _id, created_at, carpool_id, label
+FROM fraudcheck.labels;
+
+-- ============================ company (pérenne) ============================
+
+CREATE OR REPLACE VIEW dlk_export.company_companies AS
+SELECT
+  _id, siret, siren, nic, legal_name, company_naf_code, establishment_naf_code,
+  legal_nature_code, legal_nature_label, nonprofit_code, intra_vat,
+  geo,                           -- geometry (postgis requis côté datalake)
+  address, headquarter, updated_at,
+  address_street, address_postcode, address_cedex, address_city
+FROM company.companies;
+
+-- ============================ anomaly (pérenne) ============================
+
+CREATE OR REPLACE VIEW dlk_export.anomaly_labels AS
+SELECT
+  _id, created_at, carpool_id, label, conflicting_carpool_id,
+  conflicting_operator_journey_id, overlap_duration_ratio, operator_journey_id
+FROM anomaly.labels;
+
+-- ================= carpool v1 (TEMPORAIRE : suppr après consolidation trusted) =================
+
+CREATE OR REPLACE VIEW dlk_export.carpool_carpools AS
+SELECT
+  _id, created_at, acquisition_id, operator_id, trip_id, operator_trip_id, is_driver,
+  operator_class, datetime, duration, start_position, end_position, distance, seats,
+  operator_journey_id, cost, meta, status::text AS status,
+  start_territory_id, end_territory_id, start_geo_code, end_geo_code, payment
+FROM carpool.carpools;
+
+-- ================= cee (TEMPORAIRE : CEE déprécié) =================
+
+CREATE OR REPLACE VIEW dlk_export.cee_cee_applications AS
+SELECT
+  _id, created_at, updated_at, operator_id, journey_type::text AS journey_type,
+  is_specific,
+  datetime, carpool_id,
+  application_timestamp,
+  operator_journey_id
+FROM cee.cee_applications;
+
+-- =====================================================================
+--  Droits pour datalake_fdw (lecture seule, user créé par OpenTofu PR #36)
+-- =====================================================================
+
+GRANT CONNECT ON DATABASE covoiturage_production TO datalake_fdw;
+GRANT USAGE   ON SCHEMA   dlk_export              TO datalake_fdw;
+GRANT SELECT  ON ALL TABLES IN SCHEMA dlk_export  TO datalake_fdw;
+
+-- Auto-grant SELECT sur les futures vues créées par vnm dans dlk_export :
+ALTER DEFAULT PRIVILEGES IN SCHEMA dlk_export GRANT SELECT ON TABLES TO datalake_fdw;

--- a/datalake/profiles/profiles.yml
+++ b/datalake/profiles/profiles.yml
@@ -9,7 +9,7 @@ default:
       port: "{{ env_var('DBT_PORT') | int }}"
       dbname: "{{ env_var('DBT_DBNAME') }}" # or database instead of dbname
       schema: ""
-      threads: 4
+      threads: "{{ env_var('DBT_THREADS', 2) | int }}"
     dev:
       type: postgres
       host: "{{ env_var('DBT_HOST', 'localhost') }}"


### PR DESCRIPTION
## Résumé

Ajoute la migration API qui crée, côté API, le schéma `dlk_export` : 14 vues en lecture seule (12 pérennes + 2 temporaires) consommées par le datalake via un foreign data wrapper (`postgres_fdw`), plus les droits associés pour le rôle `datalake_fdw` (lecture seule).

## Contenu

- `api/src/db/migrations/20260703000000-datalake-fdw-export.sql`
  - `CREATE SCHEMA dlk_export` + 14 vues `CREATE OR REPLACE` sur `carpool_v2`, `policy`, `operator`, `territory`, `fraudcheck`, `company`, `anomaly`, `carpool` (v1, temporaire), `cee` (temporaire).
  - Enums castés en `text`, geometry conservée (postgis requis côté datalake).
  - `GRANT CONNECT/USAGE/SELECT` + `ALTER DEFAULT PRIVILEGES` pour `datalake_fdw` (lecture seule).
  - Bloc RÉTENTION/RGPD documentant la borne de conservation de la PII exportée.
- `datalake/profiles/profiles.yml` : `DBT_THREADS` paramétrable via variable d'environnement (défaut 2).

## Minimisation PII

La projection a été alignée sur l'usage réel des modèles dbt. 6 colonnes PII inutilisées ont été retirées des vues :

- `licence_plate` (carpool_v2)
- `identity_id` (carpool v1, temporaire)
- `last_name_trunc`, `phone_trunc`, `driving_license`, `identity_key` (cee, temporaire)

PII conservée car réellement consommée : téléphones complets, `identity_key` et `operator_user_id` (driver + passenger). Les PII directes ne servent qu'à dériver `driver_key`/`passenger_key` (md5) dans la couche `trusted` et ne sont pas persistées au-delà ; `identity_key` + `operator_user_id` bruts ne surfacent que dans `exposed/export/export_partners`.

## Rétention / RGPD

Les vues sont une projection en lecture seule de tables déjà soumises à la rétention de l'API : pas de nouvelle collecte, rien de matérialisé côté API. `datalake_production` hérite de cette borne (reconstruction full-refresh — une ligne purgée/anonymisée côté API disparaît au rebuild). PII lisible uniquement par le rôle lecture seule `datalake_fdw`.

Suivi (hors périmètre de cette migration) : acter la borne au registre RGPD/AIPD et arbitrer un éventuel job de purge côté `datalake_production`.

## Contrôles

- **CGU (`cgu-guard`, bloquant) : PASS.** Les constats précédents CGU-2 (rétention) et CGU-3 (minimisation) sont résolus. Résiduel `low` non bloquant : acter la borne au registre RGPD/AIPD (TODO en commentaire).
- **Sécurité (`check-security`, non bloquant) : PASS.** Moindre privilège des GRANT, vues SECURITY DEFINER isolant le rôle FDW, `ALTER DEFAULT PRIVILEGES` borné au schéma, aucun secret en dur, DDL statique idempotente. Suivi `low` : confirmer PostgreSQL ≥ 15 (sinon `REVOKE ALL ON SCHEMA public FROM PUBLIC`) et que `datalake_fdw` est `NOINHERIT` minimal (défini côté OpenTofu #36).
