### PR TITLE
chore(datalake): lit les seeds geo depuis le dossier seeds/ du bucket

### DIFF
--- a/datalake/justfile
+++ b/datalake/justfile
@@ -72,7 +72,7 @@ backfill-batch model period start end *args:
 
 # Pipeline 1: Seed raw data from S3 to raw_zone (yearly)
 pipeline-raw *args:
-  just seed raw/seed_perimeters.json dbt_raw {{ if args =~ "--full-refresh" { "--overwrite" } else { "" } }}
+  just seed raw/seed_perimeters.json dbt_raw --folder seeds {{ if args =~ "--full-refresh" { "--overwrite" } else { "" } }}
   just seed raw/seed_datagouv.json dbt_raw {{ if args =~ "--full-refresh" { "--overwrite" } else { "" } }}
 
 # Pipeline 2: trusted geo (yearly)


### PR DESCRIPTION
## Résumé

Route le chargement des seeds geo du datalake vers le préfixe `seeds/` du bucket, en accompagnement de la migration des fichiers sources de `geo-datasets-archives` vers `datalake-production/seeds/`.

## Changement

`datalake/justfile`, recette `pipeline-raw` : ajout de `--folder seeds` sur l'appel `just seed raw/seed_perimeters.json`. Le helper `s3_path` construit alors la clé `seeds/{filename}.{ext}` au lieu de `{filename}.{ext}` à la racine.

Concerne les 5 fichiers sources déplacés :
- `ADE-COG_4-0_GPKG_WGS84G_FRA-ED2025-01-01.gpkg` (IGN AE)
- `ADE-COG-CARTO-PE_4-0_GPKG_WGS84G_FRA-ED2025-01-01.gpkg` (IGN CARTO/centroïdes)
- `cerema_aom_2025.csv`
- `insee_mvt_com_2025.csv`
- `old_perimeters.gpkg`

Le second seed de la pipeline (`raw/seed_datagouv.json` — campagnes, aires de covoiturage) n'est **pas** modifié : il lit des URLs publiques data.gouv, pas le bucket.

## Hors périmètre

- Les exports (`pipelines/cmd/export.py`) partagent encore la variable `S3_BUCKET` sans dossier dédié → à router vers `exports/` dans un second temps (ticket de suivi créé).
- La variable d'environnement `S3_BUCKET` (config runtime, non versionnée) doit pointer sur `datalake-production`.

## Release

PR **data-only** (`datalake/**`, scope `datalake`) → ne déclenche volontairement **aucune release** ni déploiement applicatif.

## Sécurité

Verdict : **PASS** — aucune finding. Ajout d'une chaîne littérale statique (`--folder seeds`) en argument CLI, sans entrée utilisateur, sans injection, sans secret, sans path traversal.

## CGU

Verdict : **PASS** (check bloquant) — aucune finding. Modification purement organisationnelle d'un chemin de lecture : aucun impact sur les statuts de trajets (CGU-1), la rétention (CGU-2) ou l'exposition de données personnelles (CGU-3).
