### PR TITLE
refactor(datalake): renomme le préfixe des schémas de zone dbt_ en zone_

### DIFF
--- a/datalake/README.md
+++ b/datalake/README.md
@@ -23,7 +23,7 @@ Remplace les projet legacy `sqlmesh/` et `dbt/`. Ingère les données brutes de 
            │  (DuckDB → PG)    │  (DuckDB → PG)         │  (requests → PG)
            ▼                   ▼                        ▼
 ┌─────────────────────────────────────────────────────────────────────────┐
-│  ZONE RAW  (dbt_raw)                                                    │
+│  ZONE RAW  (zone_raw)                                                   │
 │  Tables sources, pas de transformation, données telles quelles          │
 │  carpool_v1/v2 · cee · company · fraudcheck · anomaly · territory ·     │
 │  operator · policy · communes · EPCIs · depts · régions · campagnes     │
@@ -31,7 +31,7 @@ Remplace les projet legacy `sqlmesh/` et `dbt/`. Ingère les données brutes de 
                                 │  dbt run --select trusted.*
                                 ▼
 ┌─────────────────────────────────────────────────────────────────────────┐
-│  ZONE TRUSTED  (dbt_trusted)  — 8 modèles                               │
+│  ZONE TRUSTED  (zone_trusted)  — 8 modèles                              │
 │  Nettoyage, enrichissement géographique, dédoublonnage                  │
 │                                                                         │
 │  ┌─────────────────────────────────────────────────────────────────┐    │
@@ -46,7 +46,7 @@ Remplace les projet legacy `sqlmesh/` et `dbt/`. Ingère les données brutes de 
                                 │  dbt run --select aggregated.*
                                 ▼
 ┌─────────────────────────────────────────────────────────────────────────┐
-│  ZONE AGGREGATED  (dbt_aggregated)  — 469 modèles générés par macros    │
+│  ZONE AGGREGATED  (zone_aggregated)  — 469 modèles générés par macros   │
 │                                                                         │
 │  Grains temporels : day · month · quarter · semester · year             │
 │  Périmètres géo   : arr · com · plm · epci · aom · dep · reg · pays     │
@@ -107,7 +107,7 @@ Remplace les projet legacy `sqlmesh/` et `dbt/`. Ingère les données brutes de 
                                 │  dbt run --select exposed.*
                                 ▼
 ┌─────────────────────────────────────────────────────────────────────────┐
-│  ZONE EXPOSED  (dbt_exposed)  — 22 modèles                              │
+│  ZONE EXPOSED  (zone_exposed)  — 22 modèles                             │
 │                                                                         │
 │  Observatory · 20 modèles  (4 grains : mois/trimestre/semestre/année)   │
 │  ┌────────────────────────────────────────────────────────────────┐     │
@@ -233,7 +233,7 @@ Séquence à exécuter **une seule fois** pour peupler le datalake from scratch.
 just pipeline-raw
 ```
 
-Charge via DuckDB les données IGN 2025 (GPKG), CEREMA AOMs et mouvements INSEE depuis S3 ou URL publiques vers `dbt_raw`. Chunk size : 10 000 lignes. Inclut géométries complètes, simplifiées et centroïdes pour les communes, EPCIs, départements et régions. Charge aussi les campagnes et aires de covoiturage depuis data.gouv.fr.
+Charge via DuckDB les données IGN 2025 (GPKG), CEREMA AOMs et mouvements INSEE depuis S3 ou URL publiques vers `zone_raw`. Chunk size : 10 000 lignes. Inclut géométries complètes, simplifiées et centroïdes pour les communes, EPCIs, départements et régions. Charge aussi les campagnes et aires de covoiturage depuis data.gouv.fr.
 
 ### Étape 2 — Zone trusted géographique
 
@@ -241,7 +241,7 @@ Charge via DuckDB les données IGN 2025 (GPKG), CEREMA AOMs et mouvements INSEE 
 just pipeline-trusted-geo
 ```
 
-Construit la hiérarchie géographique dans `dbt_trusted` (`perimeters`, `perimeters_agg`, `com_evolution`). Base pour tous les JOINs géographiques des carpools.
+Construit la hiérarchie géographique dans `zone_trusted` (`perimeters`, `perimeters_agg`, `com_evolution`). Base pour tous les JOINs géographiques des carpools.
 
 ### Étape 3 — Backfill des carpools
 

--- a/datalake/dbt_project.yml
+++ b/datalake/dbt_project.yml
@@ -43,15 +43,15 @@ models:
   covoiturage:
     +dbt-osmosis: "_{model}.yml"
     raw:
-      +schema: "dbt_raw"
+      +schema: "zone_raw"
     trusted:
-      +schema: "dbt_trusted"
+      +schema: "zone_trusted"
       +dbt-osmosis: "yml/_{model}.yml"
     aggregated:
-      +schema: "dbt_aggregated"
+      +schema: "zone_aggregated"
       +dbt-osmosis: "yml/_{model}.yml"
     exposed:
-      +schema: "dbt_exposed"
+      +schema: "zone_exposed"
       +dbt-osmosis: "yml/_{model}.yml"
 
   ## see docs: https://docs.elementary-data.com/
@@ -62,7 +62,7 @@ seeds:
     +dbt-osmosis: "_{model}.yml"
     trusted:
       aom_region:
-        +schema: "dbt_trusted"
+        +schema: "zone_trusted"
         +tags: ["trusted", "geo", "aom_region"]
         +column_types:
           aom: varchar

--- a/datalake/justfile
+++ b/datalake/justfile
@@ -72,8 +72,8 @@ backfill-batch model period start end *args:
 
 # Pipeline 1: Seed raw data from S3 to raw_zone (yearly)
 pipeline-raw *args:
-  just seed raw/seed_perimeters.json dbt_raw --folder seeds {{ if args =~ "--full-refresh" { "--overwrite" } else { "" } }}
-  just seed raw/seed_datagouv.json dbt_raw {{ if args =~ "--full-refresh" { "--overwrite" } else { "" } }}
+  just seed raw/seed_perimeters.json zone_raw --folder seeds {{ if args =~ "--full-refresh" { "--overwrite" } else { "" } }}
+  just seed raw/seed_datagouv.json zone_raw {{ if args =~ "--full-refresh" { "--overwrite" } else { "" } }}
 
 # Pipeline 2: trusted geo (yearly)
 pipeline-trusted-geo *args:

--- a/datalake/models/sources/raw.yml
+++ b/datalake/models/sources/raw.yml
@@ -1,7 +1,7 @@
 version: 2
 sources:
   - name: raw
-    schema: dbt_raw
+    schema: zone_raw
     tables:
       - name: insee_mvt_com_2025
         columns:


### PR DESCRIPTION
## Résumé

La base du datalake est désormais séparée : on peut simplifier et clarifier le nommage des schémas de zone dbt. Le préfixe `dbt_` devient `zone_`, ce qui distingue explicitement les zones dbt des autres schémas de la base (sources métier, `elementary`, `dlk_export`).

| Avant | Après |
| --- | --- |
| `dbt_raw` | `zone_raw` |
| `dbt_trusted` | `zone_trusted` |
| `dbt_aggregated` | `zone_aggregated` |
| `dbt_exposed` | `zone_exposed` |

## Modifications

- **`datalake/dbt_project.yml`** — configs `+schema` des zones `raw` / `trusted` / `aggregated` / `exposed` (source de vérité) + seed `aom_region`.
- **`datalake/models/sources/raw.yml`** — `schema` de la source `raw` (la zone raw est écrite puis relue comme source).
- **`datalake/justfile`** — cibles de seed du pipeline `pipeline-raw`.
- **`datalake/README.md`** — schémas de zone dans les diagrammes ASCII (largeur préservée) et les descriptions.

En prod, `profiles.yml` fixe `schema: ""` et le macro `generate_schema_name.sql` retombe alors sur la valeur `+schema` de chaque modèle : ces configs **sont** donc les noms de schéma réels en prod.

## Hors périmètre

- Schéma `elementary`, schémas sources amont (`carpool_v1`, `cee`, …) et `dlk_export` (export FDW côté RPC, #3240) : ce ne sont pas des zones dbt, non touchés.
- **Pas de migration `ALTER SCHEMA`** : les anciens schémas `dbt_*` seront supprimés et recréés (`zone_*`) dans la nouvelle base.
- Consommateurs en aval de `dbt_exposed.*` / `dbt_aggregated.*` (Metabase, Grafana) : à repointer côté outils, hors dépôt.

## Contrôles

### CGU

**Verdict : PASS.** Renommage de schéma uniquement ; aucune logique applicative, aucun traitement de données personnelles, aucune mutation de statut. Règles CGU-1 (immuabilité 48 h), CGU-2 (rétention), CGU-3 (minimisation PII) : PASS.

### Sécurité

**Verdict : PASS.** Aucune requête ni entrée utilisateur modifiée (littéraux de config statiques), aucun secret, aucune dépendance, aucun log/API modifié. Renommage complet et cohérent sur les 4 fichiers (aucune référence résiduelle à `dbt_*`).

## Release

Changement **data-only** (`datalake/`) : ne déclenche volontairement **aucune version** ni déploiement applicatif (gate 1 : aucun fichier `api/**`, `app-*`, `shared/**` ; type `refactor` + scope `datalake` non releasant).
