### PR TITLE
chore(datalake): actualise le README (schéma FDW dlk_import, seeds S3, sources data.gouv en direct)

### DIFF
--- a/datalake/README.md
+++ b/datalake/README.md
@@ -19,17 +19,21 @@ Remplace les projet legacy `sqlmesh/` et `dbt/`. Ingère les données brutes de 
 │  │  fraudcheck…)  │  │  depts, régions) │  │                       │    │
 │  └───────┬────────┘  └───────┬──────────┘  └──────────┬────────────┘    │
 └──────────┼───────────────────┼────────────────────────┼─────────────────┘
-           │  pipeline-raw     │  seed_perimeters.json  │  seed_datagouv.json
-           │  (DuckDB → PG)    │  (DuckDB → PG)         │  (requests → PG)
-           ▼                   ▼                        ▼
-┌─────────────────────────────────────────────────────────────────────────┐
-│  ZONE RAW  (zone_raw)                                                   │
-│  Tables sources, pas de transformation, données telles quelles          │
-│  carpool_v1/v2 · cee · company · fraudcheck · anomaly · territory ·     │
-│  operator · policy · communes · EPCIs · depts · régions · campagnes     │
-└───────────────────────────────┬─────────────────────────────────────────┘
-                                │  dbt run --select trusted.*
-                                ▼
+           │ postgres_fdw      │ seed_perimeters.json   │ seed_datagouv.json
+           │ (dlk_import)      │ (S3 → DuckDB → PG)     │ (fetch live → PG)
+           │                   └────────────┬───────────┘
+           │                                ▼
+           │             ┌────────────────────────────────────────────────┐
+           │             │  ZONE RAW  (zone_raw)                          │
+           │             │  Sources géo / open-data, telles quelles       │
+           │             │  communes · EPCIs · depts · régions ·          │
+           │             │  aires · campagnes · mouvements communes       │
+           │             └──────────────────┬─────────────────────────────┘
+           │  carpool_v1/v2 · cee ·         │ dbt run --select trusted.*
+           │  policy · fraudcheck ·         │
+           │  anomaly · operator ·          │
+           │  company · territory           │
+           ▼                                ▼
 ┌─────────────────────────────────────────────────────────────────────────┐
 │  ZONE TRUSTED  (zone_trusted)  — 8 modèles                              │
 │  Nettoyage, enrichissement géographique, dédoublonnage                  │
@@ -233,7 +237,7 @@ Séquence à exécuter **une seule fois** pour peupler le datalake from scratch.
 just pipeline-raw
 ```
 
-Charge via DuckDB les données IGN 2025 (GPKG), CEREMA AOMs et mouvements INSEE depuis S3 ou URL publiques vers `zone_raw`. Chunk size : 10 000 lignes. Inclut géométries complètes, simplifiées et centroïdes pour les communes, EPCIs, départements et régions. Charge aussi les campagnes et aires de covoiturage depuis data.gouv.fr.
+Charge via DuckDB les données IGN 2025 (GPKG), CEREMA AOMs et mouvements INSEE depuis `<bucket>/seeds/` vers `zone_raw`. Chunk size : 10 000 lignes. Inclut géométries complètes, simplifiées et centroïdes pour les communes, EPCIs, départements et régions. Charge aussi les campagnes et aires de covoiturage **récupérées en direct** depuis data.gouv.fr / transport.data.gouv.fr : `get_last_url` interroge l'API à chaque run et lit la dernière ressource publiée (pas de copie dans le bucket).
 
 ### Étape 2 — Zone trusted géographique
 


### PR DESCRIPTION
## Résumé

Actualise le `README.md` du datalake pour refléter la nouvelle architecture d'ingestion mise en place par les refactors récents : sources métier branchées sur le schéma FDW `dlk_import`, seeds géo lus depuis le dossier `seeds/` du bucket S3, et sources data.gouv récupérées en direct plutôt que copiées.

Changement **documentaire uniquement** (`datalake/README.md`).

## Modifications

- **Schéma ASCII de l'architecture des zones** : distingue désormais les deux chemins d'ingestion vers `zone_raw` :
  - sources métier (carpool v1/v2, cee, policy, fraudcheck, anomaly, operator, company, territory) via `postgres_fdw` (schéma `dlk_import`) ;
  - sources géo / open-data (communes, EPCIs, départements, régions, aires, campagnes, mouvements communes) via les seeds `seed_perimeters.json` (S3 → DuckDB → PG) et `seed_datagouv.json` (fetch live → PG).
- **Étape 1 `pipeline-raw`** : les données IGN 2025 / CEREMA / INSEE sont lues depuis `<bucket>/seeds/` (au lieu d'une URL/bucket en clair). Précise que les campagnes et aires de covoiturage sont **récupérées en direct** depuis data.gouv.fr / transport.data.gouv.fr : `get_last_url` interroge l'API à chaque run et lit la dernière ressource publiée (pas de copie dans le bucket).

## Contrôles

### CGU

**Verdict : PASS** — aucun constat. Aucune règle concernée (statut 48 h, rétention PII, minimisation/exposition PII) : pas de code, pas de migration, pas d'export. Le diff **améliore** même la confidentialité en remplaçant l'URL/bucket S3 en clair par un placeholder.

### Sécurité

**Verdict : PASS** — aucun constat. Diff exclusivement documentaire, aucun secret ni credential (bucket via placeholder `<bucket>/seeds/`), sources toutes en open-data.

## Release

Changement **data-only** (`datalake/`), type `chore` : ne déclenche volontairement **aucune version** ni déploiement applicatif (gate 1 : aucun fichier `api/**`, `app-*`, `shared/**` ; gate 2 : type `chore` + scope `datalake` non releasants).
