### PR TITLE
fix(dbt): désactive les workers parallèles sur les modèles observatoire

### DIFF
--- a/dbt/dbt_project.yml
+++ b/dbt/dbt_project.yml
@@ -40,6 +40,8 @@ models:
       +schema: "analytics"
     observatoire:
       +schema: "observatoire_stats"
+      # désactive les workers parallèles : évite la saturation du /dev/shm Postgres
+      +pre-hook: "SET max_parallel_workers_per_gather = 0"
     geo:
       +schema: "geo_stats"
     dashboard:


### PR DESCRIPTION
## Contexte

Le job dbt observatoire crashe sur le cluster :
`could not resize shared memory segment ... No space left on device` sur
`carpool_by_day`, `carpool_incentive_by_day`, `carpool_newcomer_by_day`.

## Cause

Ces agrégats lourds (`COUNT(DISTINCT)` + `GROUP BY`) déclenchent des workers
parallèles Postgres, chacun réservant 256–512 Mo de segment mémoire partagée
dans le `/dev/shm` du serveur. Avec `threads: 4` en prod, plusieurs modèles
tournent en parallèle et saturent le `/dev/shm` (base managée, shm non ajustable
côté client). Ce n'est pas un disque plein mais la mémoire partagée (RAM).

## Correctif

`pre-hook` `SET max_parallel_workers_per_gather = 0` sur les modèles
`observatoire` : supprime les workers parallèles → plus d'allocation `/dev/shm`.
Le `SET` est de portée session, il ne touche donc que ce pipeline (pas de
changement global sur la base). Coût : agrégation mono-thread (plus lente) mais
fiable — aujourd'hui elle échoue totalement.

## Périmètre / release

Data-only (`dbt/`) → ne déclenche **pas** de release applicative (attendu).
L'image dbt legacy est déployée via `deploy-dbt.yml` à la fusion sur `main`.
