### PR TITLE
fix(ci): ajoute needs: tag au job build de deploy-data (tag d'image vide)

### DIFF
--- a/.github/workflows/deploy-data.yml
+++ b/.github/workflows/deploy-data.yml
@@ -31,6 +31,7 @@ jobs:
         run: echo "value=$(date +'%F.%H%M')" >> $GITHUB_OUTPUT
   build:
     name: Build and Push DATA Docker Image
+    needs: tag
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
## Contexte

Le workflow **Deploy Notebooks (data)** (`deploy-data.yml`) échoue à la construction de l'image :

```
ERROR: failed to build: invalid tag "ghcr.io/covoiturage-gouv-fr/data:": invalid reference format
```

Le tag d'image est vide (rien après `data:`). Déclenché à chaque push sur `main` touchant `dbt/**` (ici la fusion de #3249).

## Cause

Le job `build` utilise `${{ needs.tag.outputs.value }}` mais **ne déclare pas `needs: tag`**. Sans cette dépendance :

- les jobs `tag` et `build` tournent en parallèle (d'où le job « Set deployment tag » qui réussit de son côté) ;
- le contexte `needs.tag.outputs.value` est vide au moment du build → tag invalide.

Régression introduite par un rollback antérieur du tagging d'image (`221748948`, `45a51e90d`).

## Correctif

Ajout de `needs: tag` sur le job `build`, alignant `deploy-data.yml` sur `deploy-dbt.yml` et `deploy-datalake.yml` qui ont déjà ce pattern.

## Périmètre / release

CI-only (`.github/**`) → ne déclenche pas de release applicative (attendu).
