### PR TITLE
fix(dbt): exécute tous les modèles legacy en single-thread (SET max_parallel_workers_per_gather = 0)

### DIFF
--- a/dbt/dbt_project.yml
+++ b/dbt/dbt_project.yml
@@ -36,12 +36,12 @@ flags:
 models:
   covoiturage:
     +dbt-osmosis: "_{model}.yml"
+    # désactive les workers parallèles : évite la saturation du /dev/shm Postgres
+    +pre-hook: "SET max_parallel_workers_per_gather = 0"
     analytics:
       +schema: "analytics"
     observatoire:
       +schema: "observatoire_stats"
-      # désactive les workers parallèles : évite la saturation du /dev/shm Postgres
-      +pre-hook: "SET max_parallel_workers_per_gather = 0"
     geo:
       +schema: "geo_stats"
     dashboard:


### PR DESCRIPTION
## Contexte

Le fix `/dev/shm` de #3249 ne couvrait que les modèles `observatoire`. Le crash touche aussi le `dashboard` (et potentiellement les autres modèles lourds). On généralise le correctif à **tous les modèles dbt legacy**.

## Cause (rappel)

Les agrégats lourds déclenchent des workers parallèles Postgres, chacun réservant 256–512 Mo de mémoire partagée dans le `/dev/shm` du serveur. Avec `threads: 4`, plusieurs modèles concurrents saturent le `/dev/shm` (base managée, shm non ajustable côté client) → `could not resize shared memory segment ... No space left on device`.

## Correctif

- Remonte le `pre-hook` `SET max_parallel_workers_per_gather = 0` du niveau `observatoire` au niveau `covoiturage` dans `dbt_project.yml` : il cascade désormais sur **tous** les modèles legacy (analytics, observatoire, dashboard, geo, fraud, export, campaigns_analytics, metrics, metabase).
- Suppression de la ligne spécifique `observatoire` devenue redondante (les hooks dbt s'additionnent entre niveaux, elle tournerait deux fois).
- Chaque requête tourne en single-thread (zéro worker parallèle → zéro allocation `/dev/shm`). `threads: 4` est conservé : la concurrence entre modèles reste utile et la consommation shm reste bornée.

## Périmètre / release

Data-only (`dbt/`) → ne déclenche pas de release applicative (attendu). L'image dbt legacy se déploie via `deploy-dbt.yml` à la fusion sur `main`.
