### PR TITLE
fix(datalake): écrit les fichiers temporaires dans un répertoire inscriptible

### DIFF
--- a/datalake/pipelines/cmd/export_worker.py
+++ b/datalake/pipelines/cmd/export_worker.py
@@ -5,6 +5,7 @@ the export bucket -> report success/failure back to the API.
 """
 
 import os
+import tempfile
 import zipfile
 from datetime import datetime
 
@@ -48,14 +49,17 @@ def process_one(api, conn, s3, bucket) -> bool:
         params["end_at"] = _to_local_date(params["end_at"])
         inner = build_copy_sql(task["target"], params)
 
-        csv_path = f"./{uuid}.csv"
-        zip_path = f"./{uuid}.csv.zip"
-        stream_csv(conn, inner, csv_path)
-        with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as z:
-            z.write(csv_path, arcname=f"{uuid}.csv")
+        # temp files vont dans un répertoire inscriptible (TMPDIR, défaut /tmp) :
+        # le workdir de l'image est monté en lecture seule. Auto-nettoyé en sortie.
+        with tempfile.TemporaryDirectory(prefix="export-") as tmp:
+            csv_path = os.path.join(tmp, f"{uuid}.csv")
+            zip_path = os.path.join(tmp, f"{uuid}.csv.zip")
+            stream_csv(conn, inner, csv_path)
+            with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as z:
+                z.write(csv_path, arcname=f"{uuid}.csv")
 
-        s3_upload(bucket, f"{uuid}.csv.zip", zip_path, client=s3)
-        api.complete(uuid, os.path.getsize(zip_path))
+            s3_upload(bucket, f"{uuid}.csv.zip", zip_path, client=s3)
+            api.complete(uuid, os.path.getsize(zip_path))
         return True
     except Exception as e:  # any failure -> report to API, don't crash the loop
         # Full detail stays worker-side (logs); the API/user only sees a generic
@@ -63,10 +67,6 @@ def process_one(api, conn, s3, bucket) -> bool:
         print(f"❌ export {uuid} failed: {e!r}")
         api.fail(uuid, "export generation failed")
         return True
-    finally:
-        for p in (f"./{uuid}.csv", f"./{uuid}.csv.zip"):
-            if os.path.exists(p):
-                os.unlink(p)
 
 
 @app.command()

--- a/datalake/pipelines/helpers/duckdb.py
+++ b/datalake/pipelines/helpers/duckdb.py
@@ -3,9 +3,17 @@ import duckdb
 from pathlib import Path
 from typing import Optional
 
+# Fichier DuckDB = cache scratch S3→Postgres, doit vivre dans un répertoire
+# inscriptible (l'image monte /data en lecture seule) ; surchargeable par volume.
+DEFAULT_DUCKDB_PATH = "/tmp/datalake/db.duckdb"
+
+
+def _resolve_db_path(db_file: Optional[str] = None) -> str:
+    return db_file or os.getenv("DUCKDB_PATH", DEFAULT_DUCKDB_PATH)
+
 
 def duckdb_client(db_file: Optional[str] = None) -> duckdb.DuckDBPyConnection:
-    db_file = db_file or "./db/db.duckdb"
+    db_file = _resolve_db_path(db_file)
     Path(db_file).parent.mkdir(parents=True, exist_ok=True)
 
     conn = duckdb.connect(db_file)

--- a/datalake/tests/test_duckdb_helpers.py
+++ b/datalake/tests/test_duckdb_helpers.py
@@ -1,0 +1,17 @@
+from pipelines.helpers.duckdb import DEFAULT_DUCKDB_PATH, _resolve_db_path
+
+
+def test_resolve_db_path_prefers_explicit_arg(monkeypatch):
+    monkeypatch.setenv("DUCKDB_PATH", "/vol/cache.duckdb")
+    assert _resolve_db_path("/custom/x.duckdb") == "/custom/x.duckdb"
+
+
+def test_resolve_db_path_uses_env(monkeypatch):
+    monkeypatch.setenv("DUCKDB_PATH", "/vol/cache.duckdb")
+    assert _resolve_db_path() == "/vol/cache.duckdb"
+
+
+def test_resolve_db_path_defaults_to_writable_tmp(monkeypatch):
+    monkeypatch.delenv("DUCKDB_PATH", raising=False)
+    assert _resolve_db_path() == DEFAULT_DUCKDB_PATH
+    assert DEFAULT_DUCKDB_PATH.startswith("/tmp/")

--- a/datalake/tests/test_export_worker.py
+++ b/datalake/tests/test_export_worker.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from pipelines.cmd.export_worker import process_one
@@ -11,7 +12,13 @@ def test_process_one_empty_returns_false():
 
 @patch("pipelines.cmd.export_worker.stream_csv")
 def test_process_one_success_flow(stream_csv, tmp_path, monkeypatch):
+    # Le worker ne doit écrire aucun fichier temporaire dans le répertoire courant
+    # (régression : ./{uuid}.csv échouait sur le workdir en lecture seule du pod).
+    monkeypatch.chdir(tmp_path)
+    captured = {}
+
     def _fake_stream(conn, inner, csv_path):
+        captured["csv_path"] = csv_path
         with open(csv_path, "w") as f:
             f.write("journey_id\n1\n")
     stream_csv.side_effect = _fake_stream
@@ -21,12 +28,13 @@ def test_process_one_success_flow(stream_csv, tmp_path, monkeypatch):
                              "params": {"start_at": "2026-01-01T00:00:00+0100",
                                         "end_at": "2026-02-01T00:00:00+0100",
                                         "operator_id": [1], "geo_selector": None}}
-    conn = MagicMock()
     s3 = MagicMock()
-    monkeypatch.chdir(tmp_path)
-    ok = process_one(api, conn, s3, "export")
+    ok = process_one(api, MagicMock(), s3, "export")
     assert ok is True
-    stream_csv.assert_called_once()
+    # temp file lived outside cwd, and the tempdir was cleaned up on exit
+    assert Path(captured["csv_path"]).parent != tmp_path
+    assert not Path(captured["csv_path"]).exists()
+    assert list(tmp_path.iterdir()) == []
     s3.upload_file.assert_called_once()
     assert s3.upload_file.call_args[0][2] == "u1.csv.zip"
     api.complete.assert_called_once()
@@ -35,12 +43,12 @@ def test_process_one_success_flow(stream_csv, tmp_path, monkeypatch):
 
 @patch("pipelines.cmd.export_worker.stream_csv", side_effect=RuntimeError("boom"))
 def test_process_one_failure_calls_fail(stream_csv, tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
     api = MagicMock()
     api.claim.return_value = {"uuid": "u2", "target": "operator",
                              "params": {"start_at": "2026-01-01T00:00:00+0100",
                                         "end_at": "2026-02-01T00:00:00+0100",
                                         "operator_id": [1], "geo_selector": None}}
-    monkeypatch.chdir(tmp_path)
     assert process_one(api, MagicMock(), MagicMock(), "export") is True
     api.fail.assert_called_once()
     assert api.fail.call_args[0][0] == "u2"


### PR DESCRIPTION
## Contexte

Suite au déploiement de la migration des exports vers le datalake (#3253), le
lancement de `pipeline-raw` en cluster échoue :

```
PermissionError: [Errno 13] Permission denied: 'db'
```

Le workdir de l'image (`/data`) est monté en **lecture seule**. Or plusieurs
pipelines écrivent dans le **répertoire courant**, ce qui échoue en cluster.

## Corrections

- **DuckDB** (`seed`, `export`, `db_sync`) : le fichier scratch DuckDB passait de
  `./db/db.duckdb` (cwd, non inscriptible) à un chemin surchargeable par
  `DUCKDB_PATH`, défaut `/tmp/datalake/db.duckdb`. L'infra peut pointer
  `DUCKDB_PATH` vers un volume monté si l'on veut conserver le cache entre runs.

- **Export worker** (`export_worker.py`) : les fichiers temporaires CSV/zip
  passaient de `./{uuid}.csv` à un `tempfile.TemporaryDirectory` (respecte
  `TMPDIR`, auto-nettoyé). **C'est le correctif critique** : le worker à la
  demande fraîchement déployé plantait sur `open()` à chaque export, échec
  attrapé par le `except` global → chaque export était rapporté « failed » à
  l'API de façon silencieuse.

> Pour de gros exports, l'infra peut fixer `TMPDIR` sur un volume disque : `/tmp`
> est souvent en tmpfs (mémoire).

## Tests

- `test_duckdb_helpers.py` (nouveau) : résolution du chemin (arg explicite >
  `DUCKDB_PATH` > défaut `/tmp`).
- `test_export_worker.py` (durci) : les tests ne dépendent plus d'un cwd
  inscriptible ; ils vérifient que le fichier temporaire vit **hors du cwd** et
  que le répertoire courant reste vide.
- Suite datalake : 22 passed, 2 skipped.

## Release

Scope `datalake` → ne coupe pas de release applicative (attendu). Le correctif
est embarqué dans la prochaine image datalake (build `deploy-data`), ce dont le
Job de backfill et le CronJob worker ont besoin.
