### PR TITLE
ci(quality): limite les tests api aux changements api/shared

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -139,6 +139,8 @@ jobs:
   # ###########################################################################################
 
   partners-audit:
+    needs: [changes]
+    if: ${{ needs.changes.outputs.partners == 'true' }}
     name: (partners) audit
     runs-on: ubuntu-latest
     steps:
@@ -157,6 +159,8 @@ jobs:
         working-directory: app-partners
 
   partners-lint:
+    needs: [changes]
+    if: ${{ needs.changes.outputs.partners == 'true' }}
     name: (partners) lint
     runs-on: ubuntu-latest
     steps:
@@ -179,7 +183,8 @@ jobs:
         run: npm run lint
 
   partners-smoke:
-    needs: [partners-lint, partners-audit]
+    needs: [changes, partners-lint, partners-audit]
+    if: ${{ needs.changes.outputs.partners == 'true' }}
     name: (partners) smoke tests
     runs-on: ubuntu-latest
     environment: production
@@ -211,6 +216,8 @@ jobs:
   # ###########################################################################################
 
   observatory-audit:
+    needs: [changes]
+    if: ${{ needs.changes.outputs.observatory == 'true' }}
     name: (observatory) audit
     runs-on: ubuntu-latest
     steps:
@@ -229,6 +236,8 @@ jobs:
         working-directory: app-observatory
 
   observatory-lint:
+    needs: [changes]
+    if: ${{ needs.changes.outputs.observatory == 'true' }}
     name: (observatory) lint
     runs-on: ubuntu-latest
     steps:
@@ -251,7 +260,8 @@ jobs:
         run: npm run lint
 
   observatory-smoke:
-    needs: [observatory-lint, observatory-audit]
+    needs: [changes, observatory-lint, observatory-audit]
+    if: ${{ needs.changes.outputs.observatory == 'true' }}
     name: (observatory) smoke tests
     runs-on: ubuntu-latest
     environment: production
@@ -317,6 +327,8 @@ jobs:
     outputs:
       app: ${{ steps.filter.outputs.app }}
       api: ${{ steps.filter.outputs.api }}
+      partners: ${{ steps.filter.outputs.partners }}
+      observatory: ${{ steps.filter.outputs.observatory }}
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -335,6 +347,10 @@ jobs:
             api:
               - 'api/**'
               - 'shared/**'
+            partners:
+              - 'app-partners/**'
+            observatory:
+              - 'app-observatory/**'
 
   release:
     name: (chore) release

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -22,6 +22,8 @@ jobs:
   # ###########################################################################################
 
   api-lint:
+    needs: [changes]
+    if: ${{ needs.changes.outputs.api == 'true' }}
     name: (api) Lint
     runs-on: ubuntu-latest
     steps:
@@ -45,7 +47,8 @@ jobs:
         run: deno lint
 
   api-unit:
-    needs: [api-lint]
+    needs: [changes, api-lint]
+    if: ${{ needs.changes.outputs.api == 'true' }}
     name: (api) unit tests
     runs-on: ubuntu-latest
     steps:
@@ -73,7 +76,8 @@ jobs:
           APP_REDIS_URL: redis://
 
   api-integration:
-    needs: [api-unit]
+    needs: [changes, api-unit]
+    if: ${{ needs.changes.outputs.api == 'true' }}
     name: (api) integration tests
     runs-on: ubuntu-latest
     steps:
@@ -104,7 +108,8 @@ jobs:
           PRO_CONNECT_CLIENT_SECRET: ${{ secrets.PRO_CONNECT_CLIENT_SECRET }}
 
   api-e2e:
-    needs: [api-unit]
+    needs: [changes, api-unit]
+    if: ${{ needs.changes.outputs.api == 'true' }}
     name: (api) e2e tests
     runs-on: ubuntu-latest
     steps:
@@ -311,6 +316,7 @@ jobs:
       pull-requests: read
     outputs:
       app: ${{ steps.filter.outputs.app }}
+      api: ${{ steps.filter.outputs.api }}
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -326,13 +332,23 @@ jobs:
               - 'app-partners/**'
               - 'app-observatory/**'
               - 'shared/**'
+            api:
+              - 'api/**'
+              - 'shared/**'
 
   release:
     name: (chore) release
     runs-on: ubuntu-latest
     # Only release when the app stack (api / front-ends) changed. Data-only
     # merges (dbt / sqlmesh / datalake / cms) must not cut an app version.
-    if: github.ref == 'refs/heads/main' && needs.changes.outputs.app == 'true'
+    # `always()` + no-failure so an app change that skips the api-scoped jobs
+    # (e.g. partners-only) still releases; a real failure in any need blocks it.
+    if: >-
+      ${{ always()
+      && github.ref == 'refs/heads/main'
+      && needs.changes.outputs.app == 'true'
+      && !contains(needs.*.result, 'failure')
+      && !contains(needs.*.result, 'cancelled') }}
     needs:
       - changes
       - api-lint


### PR DESCRIPTION
## Objectif

Éviter que les jobs de qualité d'une app (api, partners, observatory) ne se
lancent sur un changement sans rapport — typiquement un patch **datalake**.

## Changement

Filtres de chemins par app dans le job `changes`, puis conditionnement des jobs :

| Filtre | Chemins | Jobs conditionnés |
| --- | --- | --- |
| `api` | `api/**`, `shared/**` | `api-lint`, `api-unit`, `api-integration`, `api-e2e` |
| `partners` | `app-partners/**` | `partners-audit`, `partners-lint`, `partners-smoke` |
| `observatory` | `app-observatory/**` | `observatory-audit`, `observatory-lint`, `observatory-smoke` |

Les fronts ne consomment pas `shared` (vérifié) — d'où filtres au seul dossier.
`shared/**` reste rattaché à `api` (seul consommateur).

## Dépendances respectées

Le seul job dépendant est `release`. Il passe en :

```yaml
if: >-
  ${{ always()
  && github.ref == 'refs/heads/main'
  && needs.changes.outputs.app == 'true'
  && !contains(needs.*.result, 'failure')
  && !contains(needs.*.result, 'cancelled') }}
```

Sans `always()`, un job requis *sauté* aurait sauté `release` — cassant le
déploiement d'un changement app dont les autres jobs sont filtrés (ex. partners
seul). La garde `!contains(... 'failure')` conserve le blocage sur échec réel.

| Événement | `api`/`partners`/`obs` | `app` | jobs app | release |
| --- | --- | --- | --- | --- |
| datalake seul (PR ou main) | tous false | false | sautés | sauté |
| api → main | api | true | api exécutés | release (bloquée si échec) |
| partners seul → main | partners | true | partners exécutés | **release OK** |
| shared seul → main | api | true | api exécutés | release après succès api |

## Image datalake toujours construite

`deploy-datalake.yml` est un workflow séparé (`push: main`,
`paths: datalake/** | docker/datalake/**`), sans dépendance vers `quality.yml`.
Inchangé.

## À noter

Si un de ces jobs est un *required check* en protection de branche, un job
**sauté** satisfait le check (GitHub le compte comme passé) — pas de blocage de
merge sur une PR datalake.
