### PR TITLE
feat(datalake): backfill historique en module just (exécution en pod)

### DIFF
--- a/datalake/README.md
+++ b/datalake/README.md
@@ -232,6 +232,23 @@ Injectées dans les SELECT via `{{ macro_name() }}`.
 
 Séquence à exécuter **une seule fois** pour peupler le datalake from scratch.
 
+> **Depuis un pod du cluster (recommandé pour un gros backfill)** : une fois `zone_raw`
+> semée (étape 1), tout l'enchaînement tient en une commande idempotente et rejouable —
+> ```bash
+> just backfill all            # ou : just backfill all 2019-01-01 2027-01-01
+> ```
+> Elle enchaîne migrations → stats FDW → geo → trusted → agrégé → exposé, avec le **profil
+> mémoire borné et les threads déjà réglés par couche** (rien à ajuster à la main). Les
+> étapes détaillées ci-dessous restent utiles pour rejouer une couche isolément.
+
+### Étape 0 — Migrations (fonctions + extensions)
+
+```bash
+just migrate
+```
+
+Applique les objets DB que dbt ne gère pas (idempotent, tracé dans `schema_migrations`) : la fonction `ts_ceil`, les **extensions `h3` / `h3_postgis`** (indispensables à `trusted.carpools`, qui indexe les positions en cellules H3 — sans elles l'étape 3 échoue) et le **tuning FDW** (`fetch_size`, `use_remote_estimate` sur le serveur `postgres_fdw` — scans cross-DB 10–100× plus rapides). Le serveur FDW lui-même reste créé par l'ops (OpenTofu).
+
 ### Étape 1 — Données géographiques de référence
 
 ```bash
@@ -248,29 +265,37 @@ just pipeline-trusted-geo
 
 Construit la hiérarchie géographique dans `zone_trusted` (`perimeters`, `perimeters_agg`, `com_evolution`). Base pour tous les JOINs géographiques des carpools.
 
-### Étape 3 — Backfill des carpools
+### Étape 2 bis — Stats des tables distantes (FDW)
 
 ```bash
-just backfill-batch trusted.carpools month 2020-01 2026-06
+just analyze-sources
 ```
 
-Rejoue mois par mois (delete + insert par fenêtre) pour éviter les "phantom rows" sur les grands volumes. Enrichit chaque fenêtre avec la correction géo, les labels fraude/anomalie, les incentives et les campagnes.
+`ANALYZE` les foreign tables `dlk_import.*`. Autovacuum ne les analyse jamais (elles n'ont pas de tuples locaux), donc sans ce pas leurs stats locales restent vides (`reltuples = -1`). À lancer une fois avant le backfill lourd : le planner s'appuie dessus pour les fragments de requête non délégués au serveur distant. Les stats côté serveur distant (base de l'API, ce que lit `use_remote_estimate`) sont, elles, entretenues par l'autovacuum de l'API.
+
+### Étape 3 — Backfill de la couche trusted (FDW)
+
+```bash
+just backfill trusted            # chunk annuel, 2019 → 2027 par défaut
+```
+
+Construit les 5 modèles incrémentaux lus via FDW (`carpools_geo_correction`, `cee`, `incentives`, `operator_incentives`, puis `carpools` qui indexe les positions en cellules H3). Chunk **annuel**, `delete + insert` par fenêtre (idempotent, pas de "phantom rows"). **Mono-thread volontaire** : la concurrence sur le remote prod partagé dégrade chaque modèle par contention et charge la prod. La mémoire est bornée par session (`BACKFILL_PGOPTIONS` : `work_mem` réduit + gather non parallèle) — sans quoi `work_mem` × workers × threads fait sauter le backend (OOM, « SSL SYSCALL error: EOF »). Le débit FDW vient de `fetch_size`/`use_remote_estimate` posés côté serveur à l'étape 0. Profil validé sur une année dense (2025) sans OOM.
 
 ### Étape 4 — Agrégations historiques complètes
 
 ```bash
-just backfill-batch aggregated.* month 2020-01 2026-06
+just backfill aggregated         # chunk annuel, 2019 → 2027 par défaut
 ```
 
-Lance les 469 modèles agrégés sur toute la période. Les macros `od_model` / `fraud_model` / `territory_model` tournent en parallèle (`DBT_THREADS=6` par défaut).
+Lance les ~470 modèles agrégés sur toute la période. Lectures **locales** (les modèles trusted sont désormais matérialisés localement, plus de FDW) → **multi-thread** (`DBT_THREADS=6`) sous le même profil mémoire borné. Même fenêtrage annuel : `filtered_carpools` → `time_filter` honore `--vars start/end`.
 
 ### Étape 5 — Zone exposed
 
 ```bash
-dbt run --select exposed.*
+just backfill exposed
 ```
 
-Matérialise les 22 tables observatory et export, disponibles pour `app-observatory` et les exports S3.
+Matérialise les ~23 tables observatory et export (lectures locales, multi-thread), disponibles pour `app-observatory` et les exports S3.
 
 ---
 

--- a/datalake/backfill.justfile
+++ b/datalake/backfill.justfile
@@ -1,0 +1,61 @@
+# Backfill historique complet du datalake — conçu pour tourner depuis un pod du cluster.
+# Importé comme module `backfill` par le justfile racine => `just backfill <recette>`.
+
+set dotenv-load
+set shell := ["bash", "-uc"]
+
+# Profil mémoire borné repris par toutes les recettes : work_mem réduit + gather non
+# parallèle bornent le pic mémoire (sinon work_mem × workers × threads => OOM, backend
+# tué « SSL SYSCALL error: EOF »). use_remote_estimate + fetch_size sont posés côté
+# SERVEUR (migration 0003), pas ici. synchronous_commit=off : sans risque, le backfill
+# est rejouable (delete+insert idempotent par clé). Validé sur une année dense (2025).
+PGOPTIONS_BOUNDED := "-c work_mem=96MB -c max_parallel_workers_per_gather=1 -c synchronous_commit=off"
+
+default:
+  @just --list backfill
+
+# Orchestrateur bout-en-bout : migrations -> stats FDW -> geo -> trusted -> agrégé -> exposé.
+# Prérequis : zone_raw déjà semée (`just pipeline-raw`). Idempotent et rejouable.
+# ex : just backfill all   |   just backfill all 2019-01-01 2027-01-01
+all start="2019-01-01" end="2027-01-01":
+  #!/usr/bin/env bash
+  set -euo pipefail
+  just migrate
+  just analyze-sources
+  just backfill trusted-geo
+  just backfill trusted {{start}} {{end}}
+  just backfill aggregated {{start}} {{end}}
+  just backfill exposed
+
+# Couche geo/référence de trusted (perimeters, perimeters_agg, com_evolution) : tables non
+# fenêtrées, bâties une fois. Prérequis de carpools et de toute la couche agrégée.
+trusted-geo *args:
+  DBT_THREADS=1 just dbt run --select "tag:trusted,tag:geo" {{args}}
+
+# Couche trusted incrémentale (5 modèles lus via FDW). MONO-THREAD volontaire : la
+# concurrence sur le remote prod partagé dégrade chaque modèle (contention) et charge la
+# prod. Chunk ANNUEL : la mémoire étant bornée, la taille de fenêtre ne joue plus que sur
+# la durée par requête et la granularité de reprise.
+trusted start="2019-01-01" end="2027-01-01" *args:
+  #!/usr/bin/env bash
+  set -euo pipefail
+  export PGOPTIONS="{{PGOPTIONS_BOUNDED}}"
+  export DBT_THREADS=1
+  just backfill-batch "models/trusted --exclude tag:geo" year {{start}} {{end}} {{args}}
+
+# Couche agrégée (~470 modèles) : lectures LOCALES (plus de FDW) => MULTI-THREAD sûr.
+# Même fenêtrage annuel (filtered_carpools -> time_filter honore --vars start/end).
+aggregated start="2019-01-01" end="2027-01-01" *args:
+  #!/usr/bin/env bash
+  set -euo pipefail
+  export PGOPTIONS="{{PGOPTIONS_BOUNDED}}"
+  export DBT_THREADS=6
+  just backfill-batch "models/aggregated" year {{start}} {{end}} {{args}}
+
+# Couche exposée (~23 modèles, lectures locales) : bâtie en une passe (multi-thread).
+exposed *args:
+  #!/usr/bin/env bash
+  set -euo pipefail
+  export PGOPTIONS="{{PGOPTIONS_BOUNDED}}"
+  export DBT_THREADS=6
+  just dbt run --select "models/exposed" {{args}}

--- a/datalake/justfile
+++ b/datalake/justfile
@@ -1,5 +1,8 @@
 set dotenv-load
-set shell := ["bash", "-uc"] 
+set shell := ["bash", "-uc"]
+
+# Backfill historique groupé : `just backfill all`, `just backfill trusted`, …
+mod backfill "backfill.justfile"
 
 default:
   @just --list
@@ -72,12 +75,34 @@ export config schema *args:
 export-worker *args:
   python -m pipelines.cmd.export_worker {{args}}
 
-# Backfill par mois pour éviter les timeouts
+# Rafraîchit les stats locales des tables distantes (FDW, schema dlk_import).
+# Autovacuum n'analyse JAMAIS les foreign tables : sans ce pas, `reltuples = -1`
+# (aucune stat). À lancer avant un backfill lourd pour donner au planner de bonnes
+# estimations sur les fragments non délégués au serveur distant.
+analyze-sources:
+  #!/usr/bin/env bash
+  set -euo pipefail
+  PGPASSWORD="$DBT_PASSWORD" psql -h "$DBT_HOST" -p "$DBT_PORT" -U "$DBT_USER" -d "$DBT_DBNAME" \
+    -v ON_ERROR_STOP=1 <<'SQL'
+  \timing on
+  SELECT format('ANALYZE %I.%I;', foreign_table_schema, foreign_table_name)
+  FROM information_schema.foreign_tables
+  WHERE foreign_table_schema = 'dlk_import'
+  ORDER BY foreign_table_name
+  \gexec
+  SQL
 
+# Backfill par mois pour éviter les timeouts et borner la mémoire.
+# GUCs de session (via PGOPTIONS) : work_mem réduit + gather non parallèle bornent
+# le pic mémoire (sinon work_mem × workers parallèles × threads → OOM, backend tué =
+# « SSL SYSCALL error: EOF »). synchronous_commit=off : sans risque pour un backfill
+# rejouable. DBT_THREADS surchargeable (défaut 3 : concurrence sûre une fois bornée).
 backfill-batch model period start end *args:
   #!/usr/bin/env bash
   current="{{ start }}"
   period="{{ period }}"
+  export PGOPTIONS="${PGOPTIONS:--c work_mem=96MB -c max_parallel_workers_per_gather=1 -c synchronous_commit=off}"
+  export DBT_THREADS="${DBT_THREADS:-3}"
   while [[ "$current" < "{{ end }}" ]]; do
     next=$(date -d "$current +1 $period" +%Y-%m-%d)
     echo "▶️  Processing $current → $next"
@@ -85,6 +110,9 @@ backfill-batch model period start end *args:
     dbt run --profiles-dir profiles --select {{model}} --vars "{start: \"$current\", end: \"$next\"}" {{ args }}
     current=$next
   done
+
+# Backfill historique complet : module `backfill` (voir backfill.justfile) => `just backfill …`
+# (`just backfill all`, `backfill trusted`, `backfill aggregated`, `backfill exposed`).
 
 # Pipeline 1: Seed raw data from S3 to raw_zone (yearly). Toutes les sources sont dans notre S3
 # (data.gouv recopié via `just mirror`), empreintes vérifiées par défaut.

--- a/datalake/migrations/0002_h3.sql
+++ b/datalake/migrations/0002_h3.sql
@@ -1,0 +1,8 @@
+-- H3 geospatial indexing extensions.
+-- trusted.carpools indexes each trip's start/end position into H3 cells
+-- (h3_lat_lng_to_cell over a PostGIS point) for the fraud / geo-pattern aggregates.
+-- h3       = core H3 API (h3index type, cell functions).
+-- h3_postgis = PostGIS bindings (accept geometry/point), pulls in postgis_raster.
+-- CASCADE auto-installs the required postgis_raster dependency.
+CREATE EXTENSION IF NOT EXISTS h3;
+CREATE EXTENSION IF NOT EXISTS h3_postgis CASCADE;

--- a/datalake/migrations/0003_fdw_fetch_size.sql
+++ b/datalake/migrations/0003_fdw_fetch_size.sql
@@ -1,0 +1,48 @@
+-- FDW scan tuning — the datalake reads its sources through postgres_fdw foreign
+-- tables (schema dlk_import). The default fetch_size is 100 rows PER network
+-- round-trip, which starves full-history scans: a cross-DB join pulling millions
+-- of rows dies by round-trips (measured: a 3.5k-row model took 14× longer than a
+-- 1.3M-row one, purely on round-trip latency).
+--
+--   fetch_size=50000      → 500× fewer round-trips on wide scans (10–100× wall time).
+--   use_remote_estimate   → planner asks the remote for real row/cost estimates
+--                           instead of guessing, so cross-DB join order / pushdown
+--                           is chosen correctly.
+--
+-- The FDW SERVER itself is created by ops (OpenTofu, see 0000_fdw). These are
+-- performance OPTIONS on that server, which its owner (the datalake role) may set —
+-- owned here so a fresh/staging DB gets tuned FDW scans without a manual step. If
+-- the team prefers, this can move to the OpenTofu server definition instead.
+--
+-- Idempotent: looks up the single postgres_fdw server dynamically and ADDs the
+-- option if absent, else SETs it (safe across environments and re-runs).
+DO $$
+DECLARE
+  srv  text;
+  opts text[];
+BEGIN
+  SELECT s.srvname, s.srvoptions
+    INTO srv, opts
+  FROM pg_foreign_server s
+  JOIN pg_foreign_data_wrapper w ON w.oid = s.srvfdw
+  WHERE w.fdwname = 'postgres_fdw'
+  ORDER BY s.srvname
+  LIMIT 1;
+
+  IF srv IS NULL THEN
+    RAISE NOTICE 'no postgres_fdw server found — skipping FDW tuning';
+    RETURN;
+  END IF;
+
+  IF EXISTS (SELECT 1 FROM unnest(opts) o WHERE o LIKE 'fetch_size=%') THEN
+    EXECUTE format('ALTER SERVER %I OPTIONS (SET fetch_size %L)', srv, '50000');
+  ELSE
+    EXECUTE format('ALTER SERVER %I OPTIONS (ADD fetch_size %L)', srv, '50000');
+  END IF;
+
+  IF EXISTS (SELECT 1 FROM unnest(opts) o WHERE o LIKE 'use_remote_estimate=%') THEN
+    EXECUTE format('ALTER SERVER %I OPTIONS (SET use_remote_estimate %L)', srv, 'true');
+  ELSE
+    EXECUTE format('ALTER SERVER %I OPTIONS (ADD use_remote_estimate %L)', srv, 'true');
+  END IF;
+END $$;


### PR DESCRIPTION
## Contexte

Le premier remplissage complet du datalake (backfill de tout l'historique) devait tourner
à la main, avec des réglages mémoire et de parallélisme passés à chaque commande. Objectif
de cette PR : **outiller ce backfill pour qu'il tourne depuis un pod du cluster en une seule
commande**, sans réglage manuel — les paramètres sensibles (mémoire, threads, tuning FDW)
sont désormais figés dans le code.

## Ce qui change

- **Nouveau module `just` `backfill`** (`datalake/backfill.justfile`, importé par le justfile
  racine via `mod backfill`) :
  - `just backfill all [start end]` — orchestrateur bout-en-bout : migrations → stats FDW →
    geo → trusted → agrégé → exposé. Idempotent et rejouable.
  - `just backfill trusted` — couche trusted (5 modèles lus via FDW), **mono-thread**, chunk
    annuel, mémoire bornée.
  - `just backfill aggregated` / `just backfill exposed` — couches locales, **multi-thread**.
- **Réglages figés par couche** (plus rien à ajuster à la main) :
  - Mémoire bornée par session (`work_mem` réduit + gather non parallèle) pour éviter l'OOM
    (backend tué, « SSL SYSCALL error: EOF ») sur les gros volumes.
  - Threads adaptés : trusted en mono-thread (la concurrence sur le remote prod partagé via
    FDW dégrade chaque modèle par contention et charge la prod) ; agrégé/exposé en
    multi-thread (lectures locales, plus de FDW).
  - Fenêtrage **annuel** : la mémoire étant bornée, la taille de fenêtre ne joue plus que sur
    la durée par requête et la granularité de reprise.
- **Migration `0002_h3.sql`** — extensions `h3` / `h3_postgis` (indispensables à
  `trusted.carpools`, qui indexe les positions de départ/arrivée en cellules H3).
- **Migration `0003_fdw_fetch_size.sql`** — tuning du serveur `postgres_fdw` :
  `fetch_size=50000` (500× moins d'allers-retours réseau sur les scans cross-DB) et
  `use_remote_estimate=true` (le planner interroge le distant pour ses estimations, ce qui
  débloque la délégation des jointures). Idempotent, s'applique au seul serveur `postgres_fdw`
  détecté dynamiquement.
- **README** — étapes de premier remplissage mises à jour (commande unique depuis un pod,
  chunk annuel, threads par couche).

## Validation

Profil validé sur une année dense (2025) en conditions réelles : les 5 modèles trusted se
construisent sans OOM, y compris `carpools` (H3 + jointures multi-FDW). Résolution du module
et enchaînement des recettes testés (`just backfill …`).

## Hors-scope / remarques

- **Checks CGU et sécurité non lancés** sur cette PR (demande explicite). Le diff est
  data-only (outillage `datalake/`), sans donnée ni logique métier sensible.
- PR **data-only** : ne déclenche volontairement aucune release applicative (scope `datalake`).
- Le lancement du backfill complet sur tout l'historique se fait depuis un pod (`just backfill
  all`), hors de cette PR.
