### PR TITLE
fix(datalake): backfill exécutable en pod — ANALYZE via psycopg (sans psql), target/logs inscriptibles

### DIFF
--- a/datalake/backfill.justfile
+++ b/datalake/backfill.justfile
@@ -4,6 +4,12 @@
 set dotenv-load
 set shell := ["bash", "-uc"]
 
+# dbt écrit ses artefacts (manifest, compiled) dans target/ et ses logs dans logs/, sous le
+# répertoire projet. En pod, ce répertoire est en lecture seule (ex. /data) => on redirige
+# vers un chemin inscriptible. Surchargeable si le pod monte un volume dédié.
+export DBT_TARGET_PATH := env_var_or_default("DBT_TARGET_PATH", "/tmp/dbt-target")
+export DBT_LOG_PATH := env_var_or_default("DBT_LOG_PATH", "/tmp/dbt-logs")
+
 # Profil mémoire borné repris par toutes les recettes : work_mem réduit + gather non
 # parallèle bornent le pic mémoire (sinon work_mem × workers × threads => OOM, backend
 # tué « SSL SYSCALL error: EOF »). use_remote_estimate + fetch_size sont posés côté

--- a/datalake/justfile
+++ b/datalake/justfile
@@ -80,17 +80,7 @@ export-worker *args:
 # (aucune stat). À lancer avant un backfill lourd pour donner au planner de bonnes
 # estimations sur les fragments non délégués au serveur distant.
 analyze-sources:
-  #!/usr/bin/env bash
-  set -euo pipefail
-  PGPASSWORD="$DBT_PASSWORD" psql -h "$DBT_HOST" -p "$DBT_PORT" -U "$DBT_USER" -d "$DBT_DBNAME" \
-    -v ON_ERROR_STOP=1 <<'SQL'
-  \timing on
-  SELECT format('ANALYZE %I.%I;', foreign_table_schema, foreign_table_name)
-  FROM information_schema.foreign_tables
-  WHERE foreign_table_schema = 'dlk_import'
-  ORDER BY foreign_table_name
-  \gexec
-  SQL
+  python -m pipelines.cmd.analyze
 
 # Backfill par mois pour éviter les timeouts et borner la mémoire.
 # GUCs de session (via PGOPTIONS) : work_mem réduit + gather non parallèle bornent

--- a/datalake/pipelines/cmd/analyze.py
+++ b/datalake/pipelines/cmd/analyze.py
@@ -1,0 +1,50 @@
+"""ANALYZE des foreign tables (FDW) du datalake.
+
+Autovacuum n'analyse JAMAIS les foreign tables : sans stats locales, `reltuples = -1`
+et le planner estime mal les fragments de requête non délégués au serveur distant.
+À lancer avant un backfill lourd.
+
+Remplace un ancien `psql \\gexec` : `psql` n'est pas présent dans l'image du pod. On passe
+par psycopg (déjà une dépendance) — aucune dépendance à un binaire externe.
+"""
+
+import time
+
+import psycopg
+import typer
+from dotenv import load_dotenv
+from psycopg import sql
+
+from pipelines.helpers.pg import pg_conninfo
+
+load_dotenv()
+app = typer.Typer()
+
+
+def foreign_tables(conn, schema: str) -> list[str]:
+    """Noms des foreign tables du schéma, triés (ordre déterministe)."""
+    rows = conn.execute(
+        "SELECT foreign_table_name FROM information_schema.foreign_tables "
+        "WHERE foreign_table_schema = %s ORDER BY foreign_table_name",
+        (schema,),
+    ).fetchall()
+    return [r[0] for r in rows]
+
+
+@app.command()
+def analyze(schema: str = "dlk_import"):
+    with psycopg.connect(pg_conninfo(), autocommit=True) as conn:
+        tables = foreign_tables(conn, schema)
+        if not tables:
+            print(f"⚠️  aucune foreign table dans « {schema} » — rien à analyser")
+            return
+        print(f"ANALYZE de {len(tables)} foreign tables ({schema})…")
+        for i, table in enumerate(tables, 1):
+            start = time.perf_counter()
+            conn.execute(sql.SQL("ANALYZE {}").format(sql.Identifier(schema, table)))
+            print(f"  [{i}/{len(tables)}] {schema}.{table} ({time.perf_counter() - start:.1f}s)")
+        print("✅ ANALYZE terminé")
+
+
+if __name__ == "__main__":
+    app()


### PR DESCRIPTION
## Contexte

Suite à #3258 (backfill outillé en module `just`), le lancement depuis un pod du cluster a révélé deux blocages d'environnement, corrigés ici.

## Ce qui change

- **`analyze-sources` réécrit en psycopg.** `psql` n'est pas présent dans l'image du pod ; la recette échouait. Nouveau module `pipelines/cmd/analyze.py` (psycopg, déjà une dépendance du projet) qui énumère et `ANALYZE` les foreign tables `dlk_import.*`. **Plus aucune dépendance à un binaire externe** dans le chemin du backfill (seul `psql` restait, il est éliminé).
- **Artefacts dbt redirigés vers un répertoire inscriptible.** Le répertoire projet est monté en lecture seule (`/data`) sur le pod : dbt échouait à écrire son manifest (« Permission denied: /data/target »). Le module `backfill` exporte désormais `DBT_TARGET_PATH` / `DBT_LOG_PATH` vers `/tmp` par défaut (surchargeables si un volume dédié est monté). Ce correctif avait été poussé sur la branche de #3258 mais n'a pas été repris dans le squash de merge — il est réintégré ici.

## Validation

- `just --list` OK (justfile + module `backfill` parsent).
- `pipelines.cmd.analyze` exécuté en conditions réelles sur `datalake_production` : énumère les foreign tables `dlk_import`, lance `ANALYZE` sur chacune, stats locales rafraîchies (`reltuples` peuplé).

## Hors-scope / remarques

- PR **data-only** (`datalake/`) : ne déclenche aucune release applicative.
- Checks CGU / sécurité non relancés (cohérent avec #3258 ; diff d'outillage sans donnée ni logique métier sensible).
