### PR TITLE
fix(datalake): redirige target/logs dbt aussi pour `just dbt` direct

### DIFF
--- a/datalake/backfill.justfile
+++ b/datalake/backfill.justfile
@@ -4,11 +4,8 @@
 set dotenv-load
 set shell := ["bash", "-uc"]
 
-# dbt écrit ses artefacts (manifest, compiled) dans target/ et ses logs dans logs/, sous le
-# répertoire projet. En pod, ce répertoire est en lecture seule (ex. /data) => on redirige
-# vers un chemin inscriptible. Surchargeable si le pod monte un volume dédié.
-export DBT_TARGET_PATH := env_var_or_default("DBT_TARGET_PATH", "/tmp/dbt-target")
-export DBT_LOG_PATH := env_var_or_default("DBT_LOG_PATH", "/tmp/dbt-logs")
+# DBT_TARGET_PATH / DBT_LOG_PATH : exportés par le justfile racine (redirection target/logs
+# vers /tmp), hérités ici automatiquement en tant que module `backfill`.
 
 # Profil mémoire borné repris par toutes les recettes : work_mem réduit + gather non
 # parallèle bornent le pic mémoire (sinon work_mem × workers × threads => OOM, backend

--- a/datalake/justfile
+++ b/datalake/justfile
@@ -4,6 +4,12 @@ set shell := ["bash", "-uc"]
 # Backfill historique groupé : `just backfill all`, `just backfill trusted`, …
 mod backfill "backfill.justfile"
 
+# dbt écrit ses artefacts (target/) et ses logs (logs/) sous le répertoire projet. En pod,
+# ce répertoire est en lecture seule (/data appartient à root) => on redirige vers un chemin
+# inscriptible. Surchargé par l'env du pod si présent ; hérité par le module backfill.
+export DBT_TARGET_PATH := env_var_or_default("DBT_TARGET_PATH", "/tmp/dbt/target")
+export DBT_LOG_PATH := env_var_or_default("DBT_LOG_PATH", "/tmp/dbt/logs")
+
 default:
   @just --list
 


### PR DESCRIPTION
## Contexte

Suite de #3259. La redirection `DBT_TARGET_PATH` / `DBT_LOG_PATH` vers `/tmp` ne
vivait que dans le module `backfill.justfile`. Un appel **direct** hors module —
`just dbt run --select "tag:trusted,tag:geo"` — utilise la recette `dbt` du
justfile racine, qui n'exportait pas ces variables. En pod, dbt retombait alors
sur le répertoire projet en lecture seule pour uid 1000 :

```
PermissionError: [Errno 13] Permission denied: '/data/target'
```

(`/data` appartient à root — `WORKDIR /data` le crée en root, le `COPY --chown`
ne réattribue que le contenu — donc uid 1000 ne peut pas y créer `target/`.)

## Changement

- Remonte l'export `DBT_TARGET_PATH` / `DBT_LOG_PATH` au **justfile racine**, de
  sorte que `just dbt …` en direct redirige aussi vers `/tmp`. Le module
  `backfill` en **hérite automatiquement** (vérifié), la définition dupliquée y
  est donc retirée (source unique).
- Aligne le repli sur la convention du pod : `/tmp/dbt/target`, `/tmp/dbt/logs`
  (au lieu de `/tmp/dbt-target`), cohérent avec l'env posé par le CronJob infra.
- L'env du pod, s'il est présent, continue de surcharger le repli
  (`env_var_or_default`).

## Vérification

- `just --evaluate` : repli résolu à `/tmp/dbt/{target,logs}`.
- Surcharge par l'env : une valeur passée en env l'emporte.
- Héritage du module : recette `backfill` voit bien la variable exportée par le
  racine (testé sur copie des fichiers réels).