### PR TITLE
fix(apdf): simplifie la synthèse APDF Covoit IDFM (retire le déclaré et le delta)

### DIFF
--- a/api/src/pdc/services/apdf/providers/excel/SlicesWorksheetWriter.ts
+++ b/api/src/pdc/services/apdf/providers/excel/SlicesWorksheetWriter.ts
@@ -247,18 +247,26 @@ export class SlicesWorksheetWriter extends AbstractWorksheetWriter {
   }
 
   // ==================================================================================
-  // GEN-643 — Layout dédié « delta déclaré vs calculé » (campagnes avec
-  // extras.declared_incentives, ex. Covoit IDFM). Colonnes de l'onglet Trajets :
-  // M distance · R rpc_incentive (calculé) · S incentive_type · T passenger_contribution
-  // · U operator_declared_incentive (déclaré).
+  // GEN-643 — Layout des campagnes exposant le montant déclaré par l'opérateur
+  // (extras.declared_incentives, ex. Covoit IDFM). La synthèse résume le calculé et
+  // la contribution passagers via le même tableau que le layout générique ; le déclaré
+  // n'est exposé qu'au trajet (colonne U de l'onglet Trajets) et documenté ci-dessous.
   // ==================================================================================
 
-  private readonly BAND_CALCULATED = "Données calculées par covoiturage.beta";
-  private readonly BAND_DECLARED = "Données déclarées par les opérateurs";
-  private readonly DELTA_NOTE =
-    "un écart de données peut exister du fait d'application de règles métier différentes entre l'opérateur et covoiturage.beta.gouv";
-  private readonly CALC_FILL = "FFDDEBF7"; // bleu clair
-  private readonly DECL_FILL = "FFFCE4D6"; // orange clair
+  private readonly COLUMN_HEADERS_DECLARED_NORMAL = [
+    'Tranche "période normale"',
+    "Montant d'incitation",
+    "Tous les trajets",
+    "Trajets incités",
+    "Contribution passagers",
+  ];
+  private readonly COLUMN_HEADERS_DECLARED_BOOSTER = [
+    'Tranche "période booster"',
+    "Montant d'incitation",
+    "Tous les trajets",
+    "Trajets incités",
+    "Contribution passagers",
+  ];
 
   private async callDeclared(
     wbWriter: excel.stream.xlsx.WorkbookWriter,
@@ -267,144 +275,22 @@ export class SlicesWorksheetWriter extends AbstractWorksheetWriter {
     const options: Partial<excel.AddWorksheetOptions> = { views: [{ showGridLines: false }] };
     const ws: excel.Worksheet = this.initWorkSheet(wbWriter, this.WORKSHEET_NAME, undefined, options);
 
-    // Column styling A..G (B/E/G en euros)
+    // Column styling A..E (B/E en euros)
     const font = { name: "Arial", size: 12 };
     ws.getColumn("A").width = 26;
     ws.getColumn("A").font = font;
-    for (const col of ["B", "C", "D", "E", "F", "G"]) {
+    for (const col of ["B", "C", "D", "E"]) {
       ws.getColumn(col).width = 20;
       ws.getColumn(col).font = font;
     }
-    for (const col of ["B", "E", "G"]) {
-      ws.getColumn(col).numFmt = "# ##0.00€";
-    }
+    ws.getColumn("B").numFmt = "# ##0.00€";
+    ws.getColumn("E").numFmt = "# ##0.00€";
 
-    // Le déclaré (E/F + bandeau) n'est exposé que sur la période normale. Le booster
-    // ne porte que les colonnes calculées (B/C/D) + la contribution passagers (G).
-    const normaleTotal = this.drawDeclaredSliceTable(ws, slices, 'Tranche "période normale"', "normale", true);
-    this.drawDeclaredSliceTable(ws, slices, 'Tranche "période booster"', "booster", false);
-
-    this.drawDeltaBlock(ws, normaleTotal);
+    this.drawSliceTable(ws, slices, this.COLUMN_HEADERS_DECLARED_NORMAL, "normale");
+    this.drawSliceTable(ws, slices, this.COLUMN_HEADERS_DECLARED_BOOSTER, "booster");
     this.drawDeclaredDocumentation(ws);
 
     ws.commit();
-  }
-
-  /**
-   * Dessine un tableau de tranches à 7 colonnes (A tranche ; B/C/D calculé ;
-   * E/F/G déclaré) surmonté d'une ligne de bandeaux colorés. Renvoie le numéro
-   * de la ligne de total (pour les références du bloc Delta).
-   */
-  private drawDeclaredSliceTable(
-    ws: excel.Worksheet,
-    slices: SliceStatInterface[],
-    trancheLabel: string,
-    mode: "normale" | "booster",
-    withDeclaredColumns: boolean,
-  ): number {
-    if (ws.lastRow) this.pad(ws, 2);
-
-    // Ligne de bandeaux (code couleur). Le bandeau « déclaré » (E:G) n'apparaît que
-    // sur la période normale.
-    const bandeau = ws.addRow([]);
-    const bRow = bandeau.number;
-    ws.mergeCells(`B${bRow}:D${bRow}`);
-    ws.getCell(`B${bRow}`).value = this.BAND_CALCULATED;
-    for (const col of ["B", "C", "D"]) this.fillCell(ws, `${col}${bRow}`, this.CALC_FILL);
-    ws.getCell(`B${bRow}`).font = { name: "Arial", size: 11, bold: true };
-    ws.getCell(`B${bRow}`).alignment = { horizontal: "center", vertical: "middle" };
-    if (withDeclaredColumns) {
-      ws.mergeCells(`E${bRow}:G${bRow}`);
-      ws.getCell(`E${bRow}`).value = this.BAND_DECLARED;
-      for (const col of ["E", "F", "G"]) this.fillCell(ws, `${col}${bRow}`, this.DECL_FILL);
-      ws.getCell(`E${bRow}`).font = { name: "Arial", size: 11, bold: true };
-      ws.getCell(`E${bRow}`).alignment = { horizontal: "center", vertical: "middle" };
-    }
-
-    // En-têtes (le booster masque les colonnes déclarées E/F)
-    const headers = ws.addRow(
-      withDeclaredColumns
-        ? [trancheLabel, "Montant d'incitation", "Tous les trajets", "Trajets incités", "Montant d'incitation",
-          "Trajets incités", "Contribution passagers"]
-        : [trancheLabel, "Montant d'incitation", "Tous les trajets", "Trajets incités", null, null,
-          "Contribution passagers"],
-    );
-    headers.font = { name: "Arial", size: 12, bold: true };
-    headers.height = 24;
-    headers.eachCell((c, colNumber) => {
-      c.alignment = colNumber > 1 ? { vertical: "middle", horizontal: "right" } : { vertical: "middle" };
-      c.border = { bottom: { style: "thin" } };
-    });
-
-    // Données
-    for (const s of slices) {
-      const { start, end } = s.slice;
-      const mode_criteria = `Trajets!S:S,"${mode}"`;
-      const slice_criteria = `Trajets!M:M,">=${start}"${end ? `,Trajets!M:M,"<${end}"` : ""}`;
-      const calc = [
-        this.formatSliceLabel(s.slice),
-        { date1904: false, formula: `SUMIFS(Trajets!R:R,${mode_criteria},${slice_criteria})` },
-        { date1904: false, formula: `COUNTIFS(${mode_criteria},${slice_criteria})` },
-        { date1904: false, formula: `COUNTIFS(Trajets!R:R,">0",${mode_criteria},${slice_criteria})` },
-      ];
-      const contribution = { date1904: false, formula: `SUMIFS(Trajets!T:T,${mode_criteria},${slice_criteria})` };
-      const r = ws.addRow(
-        withDeclaredColumns
-          ? [
-            ...calc,
-            { date1904: false, formula: `SUMIFS(Trajets!U:U,${mode_criteria},${slice_criteria})` },
-            { date1904: false, formula: `COUNTIFS(Trajets!U:U,">0",${mode_criteria},${slice_criteria})` },
-            contribution,
-          ]
-          : [...calc, null, null, contribution],
-      );
-      r.height = 20;
-      r.alignment = { vertical: "middle" };
-    }
-
-    // Ligne de total (somme des colonnes présentes uniquement)
-    const first = headers.number + 1;
-    const last = headers.number + slices.length;
-    const totalRow = last + 1;
-    const border: Partial<excel.Borders> = { top: { style: "thin" } };
-    const totalCols = withDeclaredColumns ? ["B", "C", "D", "E", "F", "G"] : ["B", "C", "D", "G"];
-    for (const col of ["A", "B", "C", "D", "E", "F", "G"]) {
-      const cell = ws.getCell(`${col}${totalRow}`);
-      if (slices.length > 0 && totalCols.includes(col)) {
-        cell.value = { date1904: false, formula: `SUM(${col}${first}:${col}${last})` };
-      }
-      cell.border = border;
-    }
-    return totalRow;
-  }
-
-  /**
-   * Bloc « Delta » = calculé − déclaré (montant et volume de trajets incités).
-   * Comparaison sur la seule période normale, seule à porter le déclaré.
-   */
-  private drawDeltaBlock(ws: excel.Worksheet, normaleTotal: number): void {
-    this.pad(ws, 2);
-    const label = ws.addRow(["Delta données covoiturage.beta / opérateurs"]);
-    ws.mergeCells(`A${label.number}:G${label.number}`);
-    ws.getCell(`A${label.number}`).font = { name: "Arial", size: 12, bold: true };
-    ws.getCell(`A${label.number}`).border = { bottom: { style: "thin" } };
-
-    const amount = ws.addRow([
-      "Montant d'incitation",
-      { date1904: false, formula: `B${normaleTotal}-E${normaleTotal}` },
-    ]);
-    ws.getCell(`B${amount.number}`).numFmt = "# ##0.00€";
-
-    ws.addRow([
-      "Trajets incités",
-      { date1904: false, formula: `D${normaleTotal}-F${normaleTotal}` },
-    ]);
-
-    this.pad(ws, 1);
-    const note = ws.addRow([this.DELTA_NOTE]);
-    ws.mergeCells(`A${note.number}:G${note.number}`);
-    ws.getCell(`A${note.number}`).font = { name: "Arial", size: 10, italic: true };
-    ws.getCell(`A${note.number}`).alignment = { wrapText: true, vertical: "top" };
   }
 
   /** Définitions des champs (dont le déclaré + périmètre SIREN) placées sous les tableaux. */
@@ -439,14 +325,6 @@ export class SlicesWorksheetWriter extends AbstractWorksheetWriter {
       ws.getCell(`B${r.number}`).value = description;
       ws.getCell(`B${r.number}`).alignment = { wrapText: true, vertical: "top" };
     }
-  }
-
-  private fillCell(ws: excel.Worksheet, address: string, argb: string): void {
-    ws.getCell(address).fill = {
-      type: "pattern",
-      pattern: "solid",
-      fgColor: { argb },
-    };
   }
 
   private drawSliceTable(

--- a/api/src/pdc/services/apdf/providers/excel/SlicesWorksheetWriter.unit.spec.ts
+++ b/api/src/pdc/services/apdf/providers/excel/SlicesWorksheetWriter.unit.spec.ts
@@ -4,7 +4,7 @@ import excel from "dep:excel";
 import { SliceStatInterface } from "../../contracts/interfaces/PolicySliceStatInterface.ts";
 import { SlicesWorksheetWriter } from "./SlicesWorksheetWriter.ts";
 
-describe("SlicesWorksheetWriter — layout déclaré (GEN-643)", () => {
+describe("SlicesWorksheetWriter — campagne avec déclaré (GEN-643)", () => {
   const slices: SliceStatInterface[] = [
     { count: 10, subsidized: 8, sum: 1000, slice: { start: 0, end: 2000 } },
     { count: 5, subsidized: 4, sum: 500, slice: { start: 2000, end: null } },
@@ -23,43 +23,53 @@ describe("SlicesWorksheetWriter — layout déclaré (GEN-643)", () => {
     return wb.getWorksheet("Synthèse par tranche")!;
   }
 
-  it("affiche les bandeaux calculé / déclaré", async () => {
-    const ws = await render(true);
-    assertStringIncludes(String(ws.getCell("B1").value), "calculées par covoiturage.beta");
-    assertStringIncludes(String(ws.getCell("E1").value), "déclarées par les opérateurs");
-  });
+  function hasCellValue(ws: excel.Worksheet, predicate: (v: string) => boolean): boolean {
+    let found = false;
+    ws.eachRow((row) =>
+      row.eachCell((c) => {
+        if (predicate(String(c.value ?? ""))) found = true;
+      })
+    );
+    return found;
+  }
 
-  it("agrège le déclaré depuis la colonne U de l'onglet Trajets", async () => {
+  it("résume le calculé + la contribution passagers, sans bandeau ni colonne déclarée", async () => {
     const ws = await render(true);
-    // ligne bandeau=1, en-têtes=2, 1re tranche=3
-    assertStringIncludes(ws.getCell("B3").formula, "SUMIFS(Trajets!R:R"); // calculé (existant)
-    assertStringIncludes(ws.getCell("E3").formula, "SUMIFS(Trajets!U:U"); // montant déclaré
-    assertStringIncludes(ws.getCell("F3").formula, 'COUNTIFS(Trajets!U:U,">0"'); // trajets incités déclarés
-    assertStringIncludes(ws.getCell("G3").formula, "SUMIFS(Trajets!T:T"); // contribution passagers (E→G)
-  });
+    // Pas de bandeau : en-têtes en ligne 1, 1re tranche en ligne 2.
+    assertStringIncludes(String(ws.getCell("A1").value), "période normale");
+    assertStringIncludes(String(ws.getCell("B1").value), "Montant d'incitation");
+    assertStringIncludes(String(ws.getCell("E1").value), "Contribution passagers");
 
-  it("calcule le delta = calculé − déclaré sur la période normale (montant et trajets incités)", async () => {
-    const ws = await render(true);
-    // total normale=ligne5 (layout déterministe : 2 tranches). Le delta ne porte que sur la normale.
-    assertStringIncludes(String(ws.getCell("A15").value), "Delta");
-    assertEquals(ws.getCell("B16").formula, "B5-E5"); // delta montant
-    assertEquals(ws.getCell("B17").formula, "D5-F5"); // delta trajets incités
-  });
-
-  it("masque le déclaré (E/F) sur le tableau booster mais garde la contribution (G)", async () => {
-    const ws = await render(true);
-    // booster : bandeau=8, en-têtes=9, 1re tranche=10
-    assertEquals(ws.getCell("E9").value, null); // pas d'en-tête montant déclaré
-    assertEquals(ws.getCell("F9").value, null); // pas d'en-tête trajets déclarés
-    assertStringIncludes(String(ws.getCell("G9").value), "Contribution passagers");
-    assertEquals(ws.getCell("E10").value, null); // pas de formule déclarée sur le booster
-    assertStringIncludes(ws.getCell("G10").formula, "SUMIFS(Trajets!T:T"); // contribution conservée
-  });
-
-  it("laisse le layout générique inchangé quand le déclaré est absent (pas de colonne U/G déclaré)", async () => {
-    const ws = await render(false);
-    // en-têtes en ligne 1, 1re tranche en ligne 2, colonne E = contribution passagers
+    // Données : B calculé (R), C tous, D incités, E contribution passagers (T).
+    assertStringIncludes(ws.getCell("B2").formula, "SUMIFS(Trajets!R:R");
+    assertStringIncludes(ws.getCell("C2").formula, "COUNTIFS(Trajets!S:S");
+    assertStringIncludes(ws.getCell("D2").formula, 'COUNTIFS(Trajets!R:R,">0"');
     assertStringIncludes(ws.getCell("E2").formula, "SUMIFS(Trajets!T:T");
-    assertEquals(ws.getCell("F2").value, null); // pas de colonne déclarée F
+
+    // Aucune colonne déclarée (montant U / trajets incités déclarés) dans la synthèse.
+    assertEquals(ws.getCell("F2").value, null);
+  });
+
+  it("n'affiche plus les bandeaux calculé / déclaré", async () => {
+    const ws = await render(true);
+    assertEquals(hasCellValue(ws, (v) => v.includes("déclarées par les opérateurs")), false);
+    assertEquals(hasCellValue(ws, (v) => v.includes("calculées par covoiturage.beta")), false);
+  });
+
+  it("ne produit plus de bloc Delta", async () => {
+    const ws = await render(true);
+    assertEquals(hasCellValue(ws, (v) => v.includes("Delta")), false);
+  });
+
+  it("conserve la définition operator_declared_incentive dans la documentation", async () => {
+    const ws = await render(true);
+    assertEquals(hasCellValue(ws, (v) => v === "operator_declared_incentive"), true);
+  });
+
+  it("laisse le layout générique inchangé quand le déclaré est absent", async () => {
+    const ws = await render(false);
+    // En-têtes en ligne 1, 1re tranche en ligne 2, colonne E = contribution passagers.
+    assertStringIncludes(ws.getCell("E2").formula, "SUMIFS(Trajets!T:T");
+    assertEquals(ws.getCell("F2").value, null);
   });
 });

--- a/api/src/pdc/services/apdf/providers/excel/TripsWorksheetWriter.ts
+++ b/api/src/pdc/services/apdf/providers/excel/TripsWorksheetWriter.ts
@@ -41,7 +41,7 @@ export class TripsWorksheetWriter extends AbstractWorksheetWriter {
     workbookWriter: excel.stream.xlsx.WorkbookWriter,
   ): Promise<void> {
     // La colonne du déclaré (U) n'est ajoutée que pour les campagnes exposant le
-    // delta déclaré vs calculé (config extras.declared_incentives) — cf. GEN-643.
+    // montant déclaré par l'opérateur (config extras.declared_incentives) — cf. GEN-643.
     const columnKeys = config.extras?.declared_incentives
       ? [...this.BASE_COLUMN_KEYS, "operator_declared_incentive"]
       : this.BASE_COLUMN_KEYS;


### PR DESCRIPTION
## Résumé

Ajuste l'onglet **« Synthèse par tranche »** de l'export APDF pour les campagnes exposant le montant déclaré par l'opérateur (**Covoit IDFM**, campagne 1111), à partir d'un ajustement manuel du fichier de juin 2026. La synthèse ne présente plus la comparaison **calculé / déclaré** : elle résume le calculé et la contribution passagers, comme le layout générique.

Fait suite à #3229 (qui avait introduit le delta déclaré vs calculé). Le montant déclaré reste utile au trajet, mais sa synthèse/delta n'est plus affichée.

## Ce qui change

Onglet **Synthèse par tranche** (campagnes `extras.declared_incentives`, ex. IDFM) :

- **Retrait** des colonnes déclarées de la synthèse : montant déclaré (`E`) et trajets incités déclarés (`F`).
- **Retrait** des bandeaux « Données calculées par covoiturage.beta » / « Données déclarées par les opérateurs ».
- **Retrait** du bloc **Delta** (calculé − déclaré) et de sa note.
- Les tableaux « période normale » et « période booster » résument désormais : `Montant d'incitation` · `Tous les trajets` · `Trajets incités` · **`Contribution passagers`** (colonne `E`), comme le layout générique.
- Code mort supprimé : `drawDeclaredSliceTable`, `drawDeltaBlock`, `fillCell`, constantes de bandeaux/couleurs (−114 lignes nettes).

**Inchangé :**

- Onglet **Trajets** : la colonne `U` `operator_declared_incentive` (montant déclaré au trajet) reste présente, ainsi que sa définition dans les « DEFINITIONS DES CHAMPS ».
- Le layout **générique** des autres collectivités.

## Tests

- Spec unitaire `SlicesWorksheetWriter.unit.spec.ts` réécrite : génère un vrai `.xlsx` puis le relit — vérifie l'absence de bandeau et de bloc Delta, la contribution passagers en colonne `E` (formule `SUMIFS(Trajets!T:T)`), l'absence de colonne déclarée, la présence de la définition `operator_declared_incentive`, et le layout générique préservé.
- Vérification bout-en-bout : rendu d'un `.xlsx` réel depuis le code et relecture cellule par cellule — conforme au fichier ajusté manuellement (totaux propres en `B/C/D/E`).
- `deno fmt` : OK.

## Livraison

Touche `api/**` + `fix(apdf)` (scope non-data) → **coupe une version patch et déploie l'API**. Les fichiers avec le nouveau layout seront produits au prochain run `apdf:export` après déploiement.

## Sécurité — PASS (non bloquant)

Risque **LOW**, aucune action requise. Aucune requête SQL ajoutée/modifiée, aucun nouvel input, aucun secret. Les formules `SUMIFS`/`COUNTIFS` n'utilisent que des bornes numériques de config et des littéraux de mode (`normale`/`booster`) — pas de flux utilisateur vers les formules ; la surface est même réduite (suppression de code + retrait de l'exposition du déclaré dans la synthèse). Authn/authz et gestion d'erreur inchangées.

## CGU — PASS (bloquant)

Aucune violation. Modification purement de mise en page du tableur : pas de mutation de `carpool_v2.status`, pas de rétention/purge, pas d'élargissement d'exposition de PII. Le diff **restreint** l'exposition (retrait des colonnes déclarées de la synthèse) ; la colonne `U` de l'onglet Trajets et sa définition sont inchangées. Le montant déclaré est une donnée financière opérateur, pas un champ identifiant.
