### PR TITLE
fix(observatory): tronque et nettoie le markdown des extraits de ressources

### DIFF
--- a/app-observatory/src/components/ressources/RessourceCard.tsx
+++ b/app-observatory/src/components/ressources/RessourceCard.tsx
@@ -1,13 +1,14 @@
 import { Card } from "@codegouvfr/react-dsfr/Card";
 import { ButtonsGroup } from "@codegouvfr/react-dsfr/ButtonsGroup";
 import { RessourceCardProps } from "@/interfaces/ressources/componentsInterface";
+import { excerpt } from "@/helpers/text";
 
 export default function RessourceCard(props: RessourceCardProps) {
-    
+
   return(
     <Card
       title={props.title}
-      desc={props.content}
+      desc={excerpt(props.content)}
       detail={`Publié le ${props.date}`}
       imageAlt={''}
       imageUrl={props.img}

--- a/app-observatory/src/helpers/cms.ts
+++ b/app-observatory/src/helpers/cms.ts
@@ -6,10 +6,7 @@ export const cmsHost = Config.get<string>("cms.host");
 export const cmsActusByPage = Config.get<number>("cms.actusByPage");
 export const cmsRessourcesByPage = Config.get<number>("cms.ressourcesByPage");
 
-export const shorten = (str: string, maxLen: number, separator = " ", end = "...") => {
-  if (str.length <= maxLen) return str;
-  return `${str.substring(0, str.lastIndexOf(separator, maxLen))} ${end}`;
-};
+export { shorten } from "./text";
 
 export const getNbPages = (total: number, max: number) => {
   return total / max > 1 ? Math.round(total / max) : 1;

--- a/app-observatory/src/helpers/text.ts
+++ b/app-observatory/src/helpers/text.ts
@@ -1,0 +1,24 @@
+export const shorten = (str: string, maxLen: number, separator = " ", end = "...") => {
+  if (str.length <= maxLen) return str;
+  return `${str.substring(0, str.lastIndexOf(separator, maxLen))} ${end}`;
+};
+
+// Retire la syntaxe markdown inline pour obtenir du texte brut.
+const stripMarkdown = (str: string) =>
+  str
+    .replace(/!\[[^\]]*\]\([^)]*\)/g, "") // images
+    .replace(/\[([^\]]*)\]\([^)]*\)/g, "$1") // liens -> texte
+    .replace(/[*_`]+/g, "") // gras / italique / code
+    .replace(/^\s*[-*+]\s+/, "") // puce de liste en tête
+    .trim();
+
+// Ligne de titre à ignorer : heading markdown ou ligne entièrement en gras/italique.
+const isTitleLine = (line: string) => /^#{1,6}\s/.test(line) || (/^[*_]/.test(line) && /[*_]$/.test(line));
+
+// Extrait un aperçu texte : ignore le(s) titre(s), garde la 1re vraie ligne, tronque.
+export const excerpt = (content: string, maxLen = 200) => {
+  const lines = content.split(/\r?\n/).map((l) => l.trim()).filter(Boolean);
+  let i = 0;
+  while (i < lines.length - 1 && isTitleLine(lines[i])) i++;
+  return shorten(stripMarkdown(lines[i] ?? ""), maxLen);
+};


### PR DESCRIPTION
## Résumé

Sur la page **Ressources** de l'observatoire, les cartes affichaient le contenu markdown **brut** : titre `#`, gras `**`, liens `[texte](url)`, listes… et l'article entier était déversé dans le corps de la carte, sans troncature ni points de suspension (la première carte affichait plus de 8 000 caractères).

Cette PR fait afficher aux cartes un **aperçu texte propre et tronqué**.

## Ce qui change

- **`helpers/text.ts`** (nouveau, fonctions pures) : ajoute `excerpt(content, maxLen = 200)` qui
  1. ignore la ou les lignes de titre en tête (heading markdown `#` **ou** ligne entièrement en gras/italique) ;
  2. garde la première vraie ligne (gère les paragraphes séparés par un simple `\n`) ;
  3. retire la syntaxe markdown inline (liens → texte, images/gras/italique/code supprimés) ;
  4. tronque avec des points de suspension via `shorten`.
- **`helpers/cms.ts`** : `shorten` est déplacé dans `text.ts` et **ré-exporté** ici — tous les imports existants (`import { shorten } from "@/helpers/cms"`) restent valides.
- **`RessourceCard.tsx`** : `desc={excerpt(props.content)}` au lieu du contenu brut. Correction appliquée en un seul point → couvre les 4 listes de ressources + les cartes ressources de la page d'accueil.

## Vérification

- **12 tests unitaires** (TDD, rouge → vert) sur `excerpt` (via le runner TS natif de Node).
- **Audit sur les 51 ressources publiées** (données récupérées en direct depuis le CMS de prod) : **0 markdown résiduel, 0 aperçu vide, 0 aperçu trop court** — chaque aperçu se lit comme une phrase.
- `tsc --noEmit` propre ; rendu vérifié en local (page Ressources, accueil, catégories → 200).

## Sécurité

**Verdict : PASS** (aucun constat bloquant).
- **ReDoS — RAS** : toutes les regex sont linéaires (classes de caractères disjointes, pas de quantificateur imbriqué).
- **XSS — RAS** : la sortie alimente la prop `desc` du composant DSFR `Card`, rendue en nœud texte React (échappement automatique), sans `dangerouslySetInnerHTML`. `stripMarkdown` nettoie le markdown, pas le HTML — à ne pas réutiliser comme sanitizer si un jour la sortie devait alimenter du HTML brut.
- **Fuite de secret — RAS** : aucun token/clé/credential dans le diff.

## CGU

**Verdict : PASS** (vérificateur bloquant).
- CGU-1 / CGU-2 / CGU-3 non applicables : uniquement du formatage de texte côté frontend, aucun champ PII ni statut de trajet touché.
- Aucun token CMS ni valeur `.env` dans le diff.