### PR TITLE
fix(datalake): découpe le backfill par mois quelles que soient les dates

### DIFF
--- a/.claude/skills/pr-prep/cgu-rules.md
+++ b/.claude/skills/pr-prep/cgu-rules.md
@@ -2,7 +2,7 @@
 name: cgu-rules
 description: Cached, machine-checkable distillation of the RPC CGU - read by the pr-preparer cgu-guard check.
 canonical_url: https://doc.covoiturage.beta.gouv.fr/nos-services/le-registre-de-preuve-de-covoiturage/cgu-conditions-generales-dutilisation-de-covoiturage.beta.gouv
-last_synced: 2026-07-02
+last_synced: 2026-07-10
 ttl_days: 7
 ---
 
@@ -37,10 +37,11 @@ The status of a trip becomes **final and immutable 48h after trip completion**
 terms_violation_error` ignoring this window; all were already definitive. This rule exists to
 catch that class of change before merge.
 
-## CGU-2 - Personal data retention limits  (CGU - données personnelles)  [severity: blocker]
+## CGU-2 - Personal data retention limits  (CGU 2.2.2 / 2.1.3)  [severity: blocker]
 
-Personal data is kept only for the retention period stated in the CGU; beyond it, data is
-deleted or anonymised.
+The CGU does not state explicit retention durations, but mandates informing users of the
+"durées de conservation des données" (2.2.2) and protecting personal data (2.1.3): personal
+data is kept only for a bounded retention period; beyond it, data is deleted or anonymised.
 
 **Flag the diff if it:**
 - extends or removes a retention / TTL / purge boundary on personal data
@@ -48,9 +49,12 @@ deleted or anonymised.
 - disables or weakens an anonymisation / purge job;
 - persists raw personal data into a store that has no retention enforcement.
 
-## CGU-3 - PII minimisation and exposure  (CGU - données personnelles)  [severity: high]
+## CGU-3 - PII minimisation and exposure  (CGU 2.1.4 / Annexe 2)  [severity: high]
 
-Personal and identifying data must not be exposed beyond what the CGU permits.
+Personal and identifying data must not be exposed beyond what the CGU permits. Per Annexe 2:
+full `phone` and `phone_trunc` are exposed to no one; `identity_key` may reach AOMs but never
+open data; open-data geo is INSEE codes / carroyage only, "sans réidentification possible"
+(2.1.4).
 
 **Flag the diff if it:**
 - logs, returns in an API response, or writes to an export raw `*_phone`, `*_identity_key`,

--- a/datalake/README.md
+++ b/datalake/README.md
@@ -276,18 +276,18 @@ just analyze-sources
 ### Étape 3 — Backfill de la couche trusted (FDW)
 
 ```bash
-just backfill trusted            # chunk annuel, 2019 → 2027 par défaut
+just backfill trusted            # chunk mensuel, 2019 → 2027 par défaut
 ```
 
-Construit les 5 modèles incrémentaux lus via FDW (`carpools_geo_correction`, `cee`, `incentives`, `operator_incentives`, puis `carpools` qui indexe les positions en cellules H3). Chunk **annuel**, `delete + insert` par fenêtre (idempotent, pas de "phantom rows"). **Mono-thread volontaire** : la concurrence sur le remote prod partagé dégrade chaque modèle par contention et charge la prod. La mémoire est bornée par session (`BACKFILL_PGOPTIONS` : `work_mem` réduit + gather non parallèle) — sans quoi `work_mem` × workers × threads fait sauter le backend (OOM, « SSL SYSCALL error: EOF »). Le débit FDW vient de `fetch_size`/`use_remote_estimate` posés côté serveur à l'étape 0. Profil validé sur une année dense (2025) sans OOM.
+Construit les 5 modèles incrémentaux lus via FDW (`carpools_geo_correction`, `cee`, `incentives`, `operator_incentives`, puis `carpools` qui indexe les positions en cellules H3). Chunk **mensuel** (toujours, quelles que soient les dates passées), `delete + insert` par fenêtre (idempotent, pas de "phantom rows"). **Mono-thread volontaire** : la concurrence sur le remote prod partagé dégrade chaque modèle par contention et charge la prod. La mémoire est bornée par session (`BACKFILL_PGOPTIONS` : `work_mem` réduit + gather non parallèle) — sans quoi `work_mem` × workers × threads fait sauter le backend (OOM, « SSL SYSCALL error: EOF »). Le chunk mensuel borne en plus le pic mémoire du pod (le chunk annuel OOM sur les années denses). Le débit FDW vient de `fetch_size`/`use_remote_estimate` posés côté serveur à l'étape 0.
 
 ### Étape 4 — Agrégations historiques complètes
 
 ```bash
-just backfill aggregated         # chunk annuel, 2019 → 2027 par défaut
+just backfill aggregated         # chunk mensuel, 2019 → 2027 par défaut
 ```
 
-Lance les ~470 modèles agrégés sur toute la période. Lectures **locales** (les modèles trusted sont désormais matérialisés localement, plus de FDW) → **multi-thread** (`DBT_THREADS=6`) sous le même profil mémoire borné. Même fenêtrage annuel : `filtered_carpools` → `time_filter` honore `--vars start/end`.
+Lance les ~470 modèles agrégés sur toute la période. Lectures **locales** (les modèles trusted sont désormais matérialisés localement, plus de FDW) → **multi-thread** (`DBT_THREADS=6`) sous le même profil mémoire borné. Même fenêtrage mensuel : `filtered_carpools` → `time_filter` honore `--vars start/end`.
 
 ### Étape 5 — Zone exposed
 

--- a/datalake/backfill.justfile
+++ b/datalake/backfill.justfile
@@ -37,23 +37,23 @@ trusted-geo *args:
 
 # Couche trusted incrémentale (5 modèles lus via FDW). MONO-THREAD volontaire : la
 # concurrence sur le remote prod partagé dégrade chaque modèle (contention) et charge la
-# prod. Chunk ANNUEL : la mémoire étant bornée, la taille de fenêtre ne joue plus que sur
-# la durée par requête et la granularité de reprise.
+# prod. Chunk MENSUEL toujours (quelles que soient start/end) : borne le pic mémoire du pod
+# (chunk annuel = OOM sur les années denses) et affine la granularité de reprise.
 trusted start="2019-01-01" end="2027-01-01" *args:
   #!/usr/bin/env bash
   set -euo pipefail
   export PGOPTIONS="{{PGOPTIONS_BOUNDED}}"
   export DBT_THREADS=1
-  just backfill-batch "models/trusted --exclude tag:geo" year {{start}} {{end}} {{args}}
+  just backfill-batch "models/trusted --exclude tag:geo" month {{start}} {{end}} {{args}}
 
 # Couche agrégée (~470 modèles) : lectures LOCALES (plus de FDW) => MULTI-THREAD sûr.
-# Même fenêtrage annuel (filtered_carpools -> time_filter honore --vars start/end).
+# Même fenêtrage MENSUEL (filtered_carpools -> time_filter honore --vars start/end).
 aggregated start="2019-01-01" end="2027-01-01" *args:
   #!/usr/bin/env bash
   set -euo pipefail
   export PGOPTIONS="{{PGOPTIONS_BOUNDED}}"
   export DBT_THREADS=6
-  just backfill-batch "models/aggregated" year {{start}} {{end}} {{args}}
+  just backfill-batch "models/aggregated" month {{start}} {{end}} {{args}}
 
 # Couche exposée (~23 modèles, lectures locales) : bâtie en une passe (multi-thread).
 exposed *args:


### PR DESCRIPTION
## Résumé

Le backfill du datalake découpe désormais **toujours par mois**, quelles que soient les dates `start`/`end` passées en argument. Auparavant les couches `trusted` et `aggregated` étaient fenêtrées à l'année : sur les années denses, le pic mémoire faisait sauter le pod (OOM) en cours de backfill.

## Contexte

`just backfill all` a été OOM-killed dans le cluster au niveau de la couche `trusted`. Le profil mémoire borné (`work_mem` réduit + gather non parallèle) borne le backend Postgres, mais un chunk annuel sur une année dense charge trop le pod. Le découpage mensuel borne le pic mémoire et affine la granularité de reprise (une fenêtre ratée = un mois à rejouer, pas une année).

## Ce qui change

- `datalake/backfill.justfile`
  - `backfill trusted` : passe `month` au lieu de `year` à `backfill-batch`.
  - `backfill aggregated` : idem.
  - Commentaires mis à jour (raison du chunk mensuel : OOM pod sur années denses).
- `datalake/README.md` : wording synchronisé (« chunk annuel » → « chunk mensuel ») aux endroits concernés.

La primitive `backfill-batch` garde son paramètre `period` générique ; seules les deux recettes de haut niveau sont épinglées au mois. `backfill exposed` et `trusted-geo` (non fenêtrés) sont inchangés.

## Propriétés préservées

- **Idempotent** : `delete + insert` par clé, inchangé. Une fenêtre rejouée réécrit proprement ses lignes, pas de trou ni de doublon.
- Le découpage mensuel part toujours du 1er du mois (défauts `2019-01-01` → `2027-01-01`), donc pas d'effet de bord fin-de-mois sur le stepping `date -d "+1 month"`.

## Périmètre / déploiement

PR **data-only** (`datalake/` + outillage `.claude/`) : ne coupe pas de version et ne déclenche aucun déploiement applicatif — comportement attendu.

> Commit annexe `chore(pr-prep)` : rafraîchit le cache des règles CGU (`cgu-rules.md`, TTL 7j dépassé) resynchronisé depuis la source canonique. Sans lien fonctionnel avec le backfill, groupé ici à la demande.

## Sécurité

**PASS** — aucun problème détecté. Le seul changement fonctionnel remplace le littéral `year` par `month` (constante statique, non dérivée d'une entrée utilisateur) : aucune surface d'injection shell ajoutée, `PGOPTIONS` borné inchangé, aucune requête SQL touchée, aucun secret, aucune nouvelle dépendance. Modifications `README.md` purement rédactionnelles.

## CGU

**PASS** — aucune règle CGU impliquée. Le changement porte sur la granularité mémoire du backfill (fenêtrage `delete + insert` inchangé, toujours idempotent) : pas de mutation de statut de trajet, pas de rétention/purge, pas d'exposition PII.
