### PR TITLE
fix(datalake): charge le seed aom_region avant la couche agrégée

### DIFF
--- a/datalake/backfill.justfile
+++ b/datalake/backfill.justfile
@@ -32,7 +32,11 @@ all start="2019-01-01" end="2027-01-01":
 
 # Couche geo/référence de trusted (perimeters, perimeters_agg, com_evolution) : tables non
 # fenêtrées, bâties une fois. Prérequis de carpools et de toute la couche agrégée.
+# Charge d'abord le seed aom_region (-> zone_trusted.aom_region), référence statique lue par
+# la macro filtered_carpools (variantes AOM). Nécessaire car `dbt run` ne matérialise pas les
+# seeds : sans ce pas, les ~100 modèles agrégés aom/aomreg échouent (relation inexistante).
 trusted-geo *args:
+  just dbt seed --select aom_region
   DBT_THREADS=1 just dbt run --select "tag:trusted,tag:geo" {{args}}
 
 # Couche trusted incrémentale (5 modèles lus via FDW). MONO-THREAD volontaire : la


### PR DESCRIPTION
## Problème

Les ~100 modèles agrégés `aom` / `aomreg` (fraud, operators, territory, od) échouent à chaque backfill sur :

```
relation "zone_trusted.aom_region" does not exist
```

La macro `filtered_carpools` (variantes AOM) lit `zone_trusted.aom_region` via `ref('aom_region')`. Ce seed (`datalake/seeds/trusted/aom_region.csv`, cible `zone_trusted`) n'était jamais matérialisé : l'orchestrateur `backfill all` enchaîne `migrate → analyze-sources → trusted-geo → trusted → aggregated → exposed` sans aucun `dbt seed`, et `dbt run` ne construit pas les seeds.

## Correctif

Ajoute `just dbt seed --select aom_region` en tête de la recette `trusted-geo` (couche geo/référence, prérequis de la couche agrégée). Toute exécution qui bâtit la couche agrégée passe d'abord par `trusted-geo`, donc charge le seed. Idempotent.

## Validation

- `just -n backfill trusted-geo` rend bien `dbt seed --select aom_region` puis le `dbt run` geo, dans cet ordre.
- Chargement effectif du seed exercé au prochain backfill complet.

## Hors périmètre

Lenteur de `user_od_day` (delete incrémental sur clé composite à 5 colonnes) : différée, à ré-évaluer sur un rejeu en chunks mensuels avant d'ajouter un index (coût stockage).