### PR TITLE
fix(datalake): durcit l'API observatoire (timeout PG, lecture seule, validation code, readiness)

### DIFF
--- a/api-datalake/.dockerignore
+++ b/api-datalake/.dockerignore
@@ -1,0 +1,13 @@
+# Contexte de build = ./api-datalake. On exclut ce qui ne doit pas entrer dans
+# l'image : secrets locaux, venv, caches, tests, artefacts git.
+.env
+.env.*
+.venv
+__pycache__/
+*.pyc
+.pytest_cache/
+.ruff_cache/
+.mypy_cache/
+.git
+.gitignore
+tests/

--- a/api-datalake/.env.example
+++ b/api-datalake/.env.example
@@ -4,6 +4,8 @@ DBT_PORT=5432
 DBT_USER=postgres
 DBT_PASSWORD=
 DBT_DBNAME=datalake
+# Plafond par requête PG en millisecondes (protège le pool des scans lourds).
+DB_STATEMENT_TIMEOUT_MS=5000
 
 # Cache
 # Dev local : redis:// (clair). Prod : rediss:// (TLS) + REDIS_CA (CA privée PEM).

--- a/api-datalake/src/api_datalake/config.py
+++ b/api-datalake/src/api_datalake/config.py
@@ -4,6 +4,7 @@ Réutilise les variables `DBT_*` du datalake pour pointer sur la même base
 `datalake_production` (lecture des modèles `zone_exposed`).
 """
 
+from psycopg.conninfo import make_conninfo
 from pydantic import field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
@@ -22,6 +23,8 @@ class Settings(BaseSettings):
     dbt_user: str = "postgres"
     dbt_password: str = ""
     dbt_dbname: str = "datalake"
+    # Plafond par requête : borne les scans H3 lourds, protège le pool (ms).
+    db_statement_timeout_ms: int = 5000
 
     # Cache
     redis_url: str | None = None
@@ -43,10 +46,22 @@ class Settings(BaseSettings):
         return str(v).strip().lower() in _TRUTHY
 
     def conninfo(self) -> str:
-        return (
-            f"host={self.dbt_host} port={self.dbt_port} "
-            f"user={self.dbt_user} password={self.dbt_password} "
-            f"dbname={self.dbt_dbname}"
+        # `default_transaction_read_only` : garde-fou en profondeur — même si le rôle
+        # PG a des droits d'écriture, aucune requête de l'API ne peut muter la base.
+        # `statement_timeout` : coupe les requêtes trop longues avant qu'elles ne
+        # saturent le pool. `make_conninfo` échappe correctement chaque valeur
+        # (mot de passe avec espace/quote inclus).
+        options = (
+            f"-c statement_timeout={self.db_statement_timeout_ms} "
+            "-c default_transaction_read_only=on"
+        )
+        return make_conninfo(
+            host=self.dbt_host,
+            port=self.dbt_port,
+            user=self.dbt_user,
+            password=self.dbt_password,
+            dbname=self.dbt_dbname,
+            options=options,
         )
 
 

--- a/api-datalake/src/api_datalake/db.py
+++ b/api-datalake/src/api_datalake/db.py
@@ -1,4 +1,8 @@
-"""Pool de connexions PostgreSQL (lecture seule sur la base datalake)."""
+"""Pool de connexions PostgreSQL (lecture seule sur la base datalake).
+
+Lecture seule imposée côté session via `default_transaction_read_only=on`
+(voir `Settings.conninfo`), indépendamment des droits du rôle PG.
+"""
 
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager

--- a/api-datalake/src/api_datalake/helpers.py
+++ b/api-datalake/src/api_datalake/helpers.py
@@ -1,9 +1,25 @@
 """Validation des paramètres partagés de l'observatoire."""
 
+import re
+
+from fastapi import HTTPException
+
 # Allowlist des types de territoire (défense en profondeur : `type` peut être
 # interpolé dans des noms de colonnes selon l'endpoint). Fallback = "com".
 PERIMETER_TYPES = ("com", "epci", "aom", "dep", "reg", "country")
 
+# Codes territoire : INSEE commune (dont Corse 2A/2B), SIREN EPCI/AOM, dep, reg.
+# Alphanumérique borné — rejette les entrées absurdes (clés de cache infinies,
+# scans PG à répétition) avant tout accès base. `fullmatch` : `$` laisserait
+# passer un `\n` final.
+_CODE_RE = re.compile(r"[0-9A-Za-z]{1,15}")
+
 
 def check_territory_param(territory: str | None) -> str:
     return territory if territory in PERIMETER_TYPES else "com"
+
+
+def check_code_param(code: str) -> str:
+    if not _CODE_RE.fullmatch(code):
+        raise HTTPException(status_code=422, detail="invalid territory code")
+    return code

--- a/api-datalake/src/api_datalake/main.py
+++ b/api-datalake/src/api_datalake/main.py
@@ -59,7 +59,22 @@ def create_app() -> FastAPI:
 
     @app.get("/health")
     async def health():
+        """Liveness : le process répond. Toujours 200 (y compris en maintenance)."""
         return {"status": "ok"}
+
+    @app.get("/health/ready")
+    async def ready():
+        """Readiness : le pool PG répond (SELECT 1). 503 si la base est injoignable,
+        pour que k8s retire le pod du service. En maintenance, le middleware 503 avant."""
+        try:
+            async with open_pool().connection() as conn:
+                async with conn.cursor() as cur:
+                    await cur.execute("SELECT 1")
+                    await cur.fetchone()
+        except Exception:
+            logger.exception("readiness check failed")
+            return JSONResponse({"status": "unavailable"}, status_code=503)
+        return {"status": "ready"}
 
     app.include_router(observatory.router)
     return app

--- a/api-datalake/src/api_datalake/repositories/observatory.py
+++ b/api-datalake/src/api_datalake/repositories/observatory.py
@@ -118,6 +118,10 @@ def build_campaigns_query(type_: str | None = None, code: str | None = None,
         filters.append("type = %(type)s")
         params["type"] = check_territory_param(type_)
 
+    # `SELECT *` assumé : la vue `zone_exposed.campaigns` EST la frontière du
+    # contrat public (projection curée qui écarte déjà les colonnes internes —
+    # email, siren…). Énumérer ici dupliquerait ce contrat et créerait un risque
+    # de dérive entre les deux couches.
     sql = f"SELECT * FROM {CAMPAIGNS_TABLE} WHERE " + " AND ".join(filters)
     return sql, params
 

--- a/api-datalake/src/api_datalake/routers/observatory.py
+++ b/api-datalake/src/api_datalake/routers/observatory.py
@@ -12,7 +12,7 @@ from ..cache import (
 )
 from ..config import settings
 from ..db import connection
-from ..helpers import check_territory_param
+from ..helpers import check_code_param, check_territory_param
 from ..period import is_published, last_record_cutoff
 from ..repositories import observatory as repo
 
@@ -61,6 +61,7 @@ async def last_record(
     conn=Depends(get_conn),
 ):
     """Dernier mois disponible pour un territoire, borné par le cutoff de publication."""
+    check_code_param(code)
     cutoff = last_record_cutoff(settings.app_observatory_published_until)
     max_ym = cutoff[0] * 100 + cutoff[1] if cutoff else None
     return await repo.get_last_record(conn, type, code, max_ym)
@@ -79,6 +80,7 @@ async def location(
     redis=Depends(get_redis),
 ):
     """Heatmap de densité (H3) d'un territoire. Binning en SQL, réponse gzip cachée."""
+    check_code_param(code)
     # Fenêtre de publication : période non publiée -> heatmap vide.
     if not is_published(settings.app_observatory_published_until, year, month, trimester, semester):
         return _gzip_json(gzip_payload([]), "BYPASS")
@@ -102,6 +104,8 @@ async def campaigns(
     redis=Depends(get_redis),
 ):
     """Campagnes d'incitation (avec géométrie du territoire). Réponse gzip cachée."""
+    if code is not None:
+        check_code_param(code)
     params = {"type": check_territory_param(type) if type is not None else None,
               "code": code, "year": year}
     return await _serve_cached(

--- a/api-datalake/tests/test_config.py
+++ b/api-datalake/tests/test_config.py
@@ -1,0 +1,18 @@
+from psycopg.conninfo import conninfo_to_dict
+
+from api_datalake.config import Settings
+
+
+def test_conninfo_enforces_read_only_and_statement_timeout():
+    s = Settings(dbt_host="db", dbt_user="u", dbt_password="p",
+                 dbt_dbname="datalake", db_statement_timeout_ms=1234)
+    opts = conninfo_to_dict(s.conninfo())["options"]
+    assert "default_transaction_read_only=on" in opts
+    assert "statement_timeout=1234" in opts
+
+
+def test_conninfo_escapes_special_chars_in_password():
+    # Un mot de passe avec espace/quote ne doit pas casser la chaîne de connexion.
+    s = Settings(dbt_password="p ass'w\\ord")
+    parsed = conninfo_to_dict(s.conninfo())
+    assert parsed["password"] == "p ass'w\\ord"

--- a/api-datalake/tests/test_health.py
+++ b/api-datalake/tests/test_health.py
@@ -1,0 +1,58 @@
+from fastapi.testclient import TestClient
+
+import api_datalake.main as main_mod
+
+
+class _Cursor:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def execute(self, sql):
+        pass
+
+    async def fetchone(self):
+        return (1,)
+
+
+class _Conn:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    def cursor(self):
+        return _Cursor()
+
+
+class _OkPool:
+    def connection(self):
+        return _Conn()
+
+
+class _DownPool:
+    def connection(self):
+        raise RuntimeError("pool closed / db unreachable")
+
+
+def test_liveness_always_ok():
+    c = TestClient(main_mod.create_app())
+    r = c.get("/health")
+    assert r.status_code == 200 and r.json() == {"status": "ok"}
+
+
+def test_readiness_ok_when_db_answers(monkeypatch):
+    monkeypatch.setattr(main_mod, "open_pool", _OkPool)
+    c = TestClient(main_mod.create_app())
+    r = c.get("/health/ready")
+    assert r.status_code == 200 and r.json() == {"status": "ready"}
+
+
+def test_readiness_503_when_db_unreachable(monkeypatch):
+    monkeypatch.setattr(main_mod, "open_pool", _DownPool)
+    c = TestClient(main_mod.create_app())
+    r = c.get("/health/ready")
+    assert r.status_code == 503 and r.json() == {"status": "unavailable"}

--- a/api-datalake/tests/test_location.py
+++ b/api-datalake/tests/test_location.py
@@ -41,6 +41,12 @@ def test_query_period_filters_by_grain():
     assert p_tri["trimester"] == 2
 
 
+def test_query_semester_maps_to_quarter_case():
+    sql_s, p_sem = build_location_query("com", "75056", 2022, 8, semester=2)
+    assert "CASE WHEN EXTRACT(QUARTER FROM start_datetime)::int > 3 THEN 2 ELSE 1 END" in sql_s
+    assert p_sem["semester"] == 2
+
+
 # --- endpoint /observatory/location ---
 
 
@@ -139,6 +145,18 @@ def test_location_out_of_range_params_return_422_not_500():
     # month=13 est hors bornes -> 422 de validation, pas un 500 (ValueError sur date())
     r = c.get("/observatory/location", params={"code": "75056", "type": "com", "year": 2022, "month": 13, "n": 8})
     assert r.status_code == 422
+
+
+def test_location_rejects_malformed_code_with_422():
+    c = TestClient(make_client([]))
+    # Code hors charset/longueur : rejeté avant tout accès PG (anti cache-flooding).
+    r = c.get("/observatory/location", params={"code": "75'; DROP--", "type": "com", "year": 2022, "n": 8})
+    assert r.status_code == 422
+    r_long = c.get("/observatory/location", params={"code": "x" * 20, "type": "com", "year": 2022, "n": 8})
+    assert r_long.status_code == 422
+    # `$` laisserait passer un newline final ; `fullmatch` le rejette.
+    r_nl = c.get("/observatory/location", params={"code": "75056\n", "type": "com", "year": 2022, "n": 8})
+    assert r_nl.status_code == 422
 
 
 def test_location_unpublished_period_is_bypassed_and_empty():


### PR DESCRIPTION
## Contexte

Suites de la relecture de #3264 (API observatoire `api-datalake`). Cette PR applique
les correctifs de robustesse et de défense en profondeur identifiés, **sans changer
la surface fonctionnelle publique**. Périmètre exclusivement `api-datalake/**` : aucune
release ni déploiement déclenché (cohérent avec #3264).

## Ce que contient la PR

- **Connexion PG durcie** (`config.py`) — `conninfo()` reconstruit via `make_conninfo`
  (échappe correctement un mot de passe contenant espace/quote/backslash) et impose sur
  chaque session :
  - `default_transaction_read_only=on` — garde-fou en profondeur : même si le rôle PG a
    des droits d'écriture, aucune requête de l'API ne peut muter la base ;
  - `statement_timeout` (défaut 5000 ms, `DB_STATEMENT_TIMEOUT_MS`) — borne les scans H3
    lourds avant qu'ils ne saturent le pool (max 8 connexions).
- **Validation du paramètre `code`** (`helpers.check_code_param`) — regex charset/longueur
  (`fullmatch`, rejette un `\n` final) → `422` avant tout accès PG. Coupe le remplissage
  de cache Redis et les scans répétés par des `code` absurdes. Les codes légitimes (INSEE
  dont Corse `2A/2B`, SIREN 9 chiffres, dep/reg/pays) passent.
- **Sonde de readiness** `GET /health/ready` (`main.py`) — exécute `SELECT 1` sur le pool ;
  `503` générique si la base est injoignable, pour que k8s retire le pod du service. Le
  `GET /health` (liveness) reste inconditionnellement `200`.
- **`.dockerignore`** — empêche un `.env` local (mot de passe) et le dossier `tests/`
  d'entrer dans l'image (le contexte de build est `./api-datalake`, `COPY . /app`).
- **Tests** (`+7`) — conninfo (options read-only/timeout + échappement mot de passe),
  validation `code` → 422 (dont injection et `\n`), branche `semester` de la requête
  (lacune de couverture), readiness `200`/`503`. Suite complète : **58 passent**.

## Choix assumés — non traités volontairement

Vérifiés pendant la relecture, écartés à dessein (à traiter séparément si besoin) :

- **Fenêtre de publication** — le comportement « rolling » (une année/semestre partiel
  reste visible tant que son début précède le cutoff) est un **portage fidèle et documenté**
  du legacy Deno (`publishedDate.ts`), pas un bug. La note legacy « si un cache de route est
  ajouté, l'invalidation doit suivre le cutoff » est **déjà satisfaite** par la clé de cache
  versionnée sur la publication. Le modifier romprait l'iso-fonctionnalité de la migration.
- **k-anonymat** de la heatmap (un hexagone `count=1` à résolution fine) — modifie la
  sémantique des données publiques ; relève d'une décision produit/RGPD (valeur de `k`),
  hors du périmètre de cette migration iso-fonctionnelle. Point de vigilance hérité du legacy.
- **Test d'intégration SQL** (exécution réelle des requêtes) — nécessite un Postgres + extension
  H3 en CI ; à traiter en suivi. La branche `semester` non couverte a été ajoutée en unitaire.
- **`SELECT *` campaigns** — conservé : la vue `zone_exposed.campaigns` **est** la frontière
  du contrat public (projection curée qui écarte déjà email/siren…). Énumérer les colonnes
  côté API dupliquerait ce contrat et créerait un risque de dérive. Commentaire ajouté.

## Sécurité (relecture — PASS)

Relecture indépendante contre la checklist `check-security`. **Verdict : PASS.** Aucune
injection : `code` toujours paramétré (`%(code)s`), seul `type` est interpolé et reste borné
par l'allowlist `check_territory_param`. Option libpq read-only/timeout correctement formée et
couverte par test. Sonde readiness sans fuite d'info (corps générique, stack en logs seuls).
`.dockerignore` n'exclut aucun fichier nécessaire au build. Le finding LOW relevé (le motif en
`$` laissait passer un `\n` final) est **corrigé dans cette PR** (`fullmatch`) avec test de
non-régression.

## CGU (garde-fou — PASS)

Aucune règle enfreinte (définitivité 48 h, rétention, minimisation/PII). La PR **n'élargit pas**
le contrat public : la surface reste des agrégats (`{hex, count}`, `{year, month}`) et le
contrat campaigns existant. La lecture seule forcée rend même toute mutation impossible.

> Note : la distillation CGU en cache (`cgu-rules.md`) a 8 jours (TTL 7). Diff sans nouvelle
> donnée exposée → verdict inchangé ; refresh du fichier partagé non effectué pour ne pas
> polluer cette PR de durcissement.