### PR TITLE
perf(datalake): indexe user_od_day sur la clé du delete+insert

### DIFF
--- a/datalake/models/aggregated/users/user_od_day.sql
+++ b/datalake/models/aggregated/users/user_od_day.sql
@@ -1,10 +1,15 @@
+{#
+  Index composite = clé du delete+insert. Sans lui, le DELETE incrémental (semi-jointure
+  sur les 5 colonnes) balaie toute la table (~57 M lignes) => très lent. Il sert aussi les
+  lookups par user_id (préfixe gauche) et remplace donc l'index ['user_id'] seul.
+#}
 {{
   config(
     materialized='incremental',
     incremental_strategy='delete+insert',
     unique_key=['user_id', 'incremental_date', 'role', 'start_code', 'end_code'],
     indexes=[
-      { 'columns': ['user_id'] },
+      { 'columns': ['user_id', 'incremental_date', 'role', 'start_code', 'end_code'] },
       { 'columns': ['incremental_date'] },
       { 'columns': ['start_code', 'end_code'] }
     ],


### PR DESCRIPTION
## Problème

`user_od_day` (~57 M lignes) est la plus grosse table agrégée. Son DELETE incrémental (stratégie `delete+insert`) filtre sur la clé unique à 5 colonnes `(user_id, incremental_date, role, start_code, end_code)`. Aucun index existant (`user_id` seul ; `incremental_date` ; `start_code,end_code`) ne couvre cette clé → la semi-jointure du DELETE balaie toute la table. Observé à **~90 min pour une seule fenêtre** (chunk annuel) lors du backfill.

## Correctif

Remplace l'index `['user_id']` par l'index composite `['user_id','incremental_date','role','start_code','end_code']` (ordre de la clé unique). Il couvre la semi-jointure du DELETE et, par préfixe gauche, les lookups par `user_id` — donc **pas d'index supplémentaire** (stockage maîtrisé, disque contraint).

## Application à la table existante

dbt ne (re)crée les index qu'à la **création de table** ou en `--full-refresh`, pas en incrémental. Pour appliquer l'index à la table existante lors du rejeu :

```
just dbt run --select user_od_day --full-refresh
```

Sinon la config reste correcte pour toute reconstruction future.

## Hors périmètre

`user_od_month`, `operators_od_day`, `operators_od_month` partagent le même motif (clé composite non couverte par un index) mais n'ont pas ralenti — tables plus petites. Laissées en l'état ; à indexer de la même façon si elles deviennent lentes.