### PR TITLE
fix(datalake): durcit l'API observatoire (docs coupées, projection explicite, bannière serveur)

### DIFF
--- a/api-datalake/src/api_datalake/main.py
+++ b/api-datalake/src/api_datalake/main.py
@@ -4,6 +4,7 @@ import logging
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
+from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.responses import JSONResponse
@@ -47,8 +48,18 @@ async def lifespan(app: FastAPI):
 
 
 def create_app() -> FastAPI:
-    app = FastAPI(title="api-datalake", lifespan=lifespan)
+    # openapi_url=None coupe /openapi.json ET, par voie de conséquence, /docs et /redoc
+    # (les UI dérivent du schéma) : on n'expose pas le schéma sur une API publique.
+    app = FastAPI(title="api-datalake", lifespan=lifespan, openapi_url=None)
     app.state.settings = settings  # source de vérité unique, surchargeable en test
+
+    @app.exception_handler(RequestValidationError)
+    async def _validation_handler(request, exc):
+        # Réponse laconique : ne pas renvoyer la valeur invalide ni la structure du champ.
+        # Trace d'observabilité sans la valeur brute (détection de scan/fuzzing).
+        logger.info("validation error on %s %s", request.method, request.url.path)
+        return JSONResponse({"detail": "invalid request parameters"}, status_code=422)
+
     app.add_middleware(MaintenanceMiddleware)
     app.add_middleware(
         CORSMiddleware,

--- a/api-datalake/src/api_datalake/repositories/observatory.py
+++ b/api-datalake/src/api_datalake/repositories/observatory.py
@@ -11,6 +11,21 @@ LOCATION_TABLE = "zone_exposed.location"      # remplace observatoire_stats.view
 PERIMETERS_TABLE = "zone_exposed.observatory_perimeters"  # remplace geo.perimeters
 CAMPAIGNS_TABLE = "zone_exposed.campaigns"    # remplace raw_zone.campaigns + jointure geom
 
+# Contrat public de /observatory/campaigns : colonnes projetées explicitement.
+# `SELECT *` serait fragile — toute colonne ajoutée à la vue fuiterait sur l'API
+# publique. Un test fige cet ensemble (test_hardening).
+CAMPAIGNS_COLUMNS = (
+    "type", "code", "premiere_campagne", "budget_incitations", "date_debut",
+    "date_fin", "conducteur_montant_max_par_passager",
+    "conducteur_montant_max_par_mois", "conducteur_montant_min_par_passager",
+    "conducteur_trajets_max_par_mois", "passager_trajets_max_par_mois",
+    "passager_gratuite", "passager_eligible_gratuite", "passager_reduction_ticket",
+    "passager_eligibilite_reduction", "passager_montant_ticket",
+    "zone_sens_des_trajets", "zone_exclusion", "si_zone_exclue_liste",
+    "autre_exclusion", "trajet_longueur_min", "trajet_longueur_max",
+    "trajet_classe_de_preuve", "operateurs", "autres_informations", "lien", "geom",
+)
+
 # type de territoire -> colonne de périmètre. `com` = grain arrondissement (`arr`),
 # comme l'ancienne requête de l'API (SELECT arr AS com ...).
 _PERIM_COL = {
@@ -118,11 +133,10 @@ def build_campaigns_query(type_: str | None = None, code: str | None = None,
         filters.append("type = %(type)s")
         params["type"] = check_territory_param(type_)
 
-    # `SELECT *` assumé : la vue `zone_exposed.campaigns` EST la frontière du
-    # contrat public (projection curée qui écarte déjà les colonnes internes —
-    # email, siren…). Énumérer ici dupliquerait ce contrat et créerait un risque
-    # de dérive entre les deux couches.
-    sql = f"SELECT * FROM {CAMPAIGNS_TABLE} WHERE " + " AND ".join(filters)
+    # Projection explicite (pas de SELECT *) : défense en profondeur si une colonne
+    # est ajoutée à la vue, elle ne fuite pas automatiquement sur l'API publique.
+    cols = ", ".join(CAMPAIGNS_COLUMNS)
+    sql = f"SELECT {cols} FROM {CAMPAIGNS_TABLE} WHERE " + " AND ".join(filters)
     return sql, params
 
 

--- a/api-datalake/tests/test_hardening.py
+++ b/api-datalake/tests/test_hardening.py
@@ -1,0 +1,119 @@
+import asyncio
+
+from fastapi.testclient import TestClient
+
+from api_datalake.cache import get_redis
+from api_datalake.main import create_app
+from api_datalake.repositories.observatory import (
+    CAMPAIGNS_COLUMNS,
+    build_campaigns_query,
+)
+from api_datalake.routers.observatory import get_conn
+
+
+class FakeCursor:
+    def __init__(self, rows, delay=0.0):
+        self._rows = rows
+        self._delay = delay
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def execute(self, sql, params):
+        if self._delay:
+            await asyncio.sleep(self._delay)
+
+    async def fetchall(self):
+        return self._rows
+
+    async def fetchone(self):
+        return self._rows[0] if self._rows else None
+
+
+class FakeConn:
+    def __init__(self, rows=None, delay=0.0):
+        self._rows = rows or []
+        self._delay = delay
+
+    def cursor(self):
+        return FakeCursor(self._rows, self._delay)
+
+
+def client(rows=None, delay=0.0):
+    app = create_app()
+
+    async def override_conn():
+        yield FakeConn(rows, delay)
+
+    app.dependency_overrides[get_conn] = override_conn
+    app.dependency_overrides[get_redis] = lambda: None
+    return TestClient(app, raise_server_exceptions=False)
+
+
+# --- 1. docs / openapi coupés ---
+
+
+def test_openapi_and_docs_are_404():
+    c = client()
+    assert c.get("/openapi.json").status_code == 404
+    assert c.get("/docs").status_code == 404
+    assert c.get("/redoc").status_code == 404
+
+
+# --- 1bis. erreurs de validation laconiques (pas d'écho de l'entrée) ---
+
+
+def test_validation_error_is_terse_and_does_not_echo_input():
+    c = client()
+    r = c.get("/observatory/location", params={"code": "75056", "type": "com", "year": 2022, "month": 13, "n": 8})
+    assert r.status_code == 422
+    assert r.json() == {"detail": "invalid request parameters"}
+    assert "13" not in r.text  # la valeur invalide ne fuit pas
+
+
+# --- 2. projection explicite des colonnes de campaigns ---
+
+
+def test_campaigns_query_projects_explicit_allowlist():
+    sql, _ = build_campaigns_query(type_="aom", code="217500016", year=2024)
+    assert "SELECT *" not in sql
+    assert "select *" not in sql.lower()
+    for col in CAMPAIGNS_COLUMNS:
+        assert col in sql
+    # colonnes internes du seed jamais exposées
+    for leaked in ("email", "collectivite", "siren_et_code_région"):
+        assert leaked not in CAMPAIGNS_COLUMNS
+
+
+# --- 3. validation du paramètre code (régression du garde-fou #3267) ---
+# Note : la validation du code (check_code_param, charset alphanumérique borné) et le
+# timeout par requête (statement_timeout PG côté session) sont déjà livrés par #3267 ;
+# on garde ici une régression légère, sans re-implémenter.
+
+
+def test_invalid_code_charset_returns_422():
+    c = client()
+    r = c.get("/observatory/location", params={"code": "75%56", "type": "com", "year": 2022, "n": 8})
+    assert r.status_code == 422
+
+
+def test_too_long_code_returns_422():
+    c = client()
+    r = c.get("/observatory/location", params={"code": "1234567890123456", "type": "com", "year": 2022, "n": 8})
+    assert r.status_code == 422
+
+
+def test_valid_corsican_code_accepted():
+    # 2A004 (arrondissement corse) : alphanumérique valide, atteint la requête.
+    c = client(rows=[{"hex": "abc", "count": 1}])
+    r = c.get("/observatory/location", params={"code": "2A004", "type": "com", "year": 2022, "n": 8})
+    assert r.status_code == 200
+
+
+def test_campaigns_invalid_code_returns_422():
+    c = client()
+    r = c.get("/observatory/campaigns", params={"code": "bad!", "year": 2024})
+    assert r.status_code == 422

--- a/api-datalake/tests/test_maintenance.py
+++ b/api-datalake/tests/test_maintenance.py
@@ -1,25 +1,53 @@
 import pytest
 from fastapi.testclient import TestClient
 
+from api_datalake.cache import get_redis
 from api_datalake.config import Settings
 from api_datalake.main import create_app
+from api_datalake.routers.observatory import get_conn
 
 
-def app_with_maintenance(on):
+class _FakeCursor:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def execute(self, sql, params):
+        pass
+
+    async def fetchall(self):
+        return []
+
+
+class _FakeConn:
+    def cursor(self):
+        return _FakeCursor()
+
+
+def app_with_maintenance(on, fake_db=False):
     app = create_app()
     app.state.settings = Settings(maintenance_mode=on)  # isolé du singleton
+    if fake_db:
+        async def override_conn():
+            yield _FakeConn()
+
+        app.dependency_overrides[get_conn] = override_conn
+        app.dependency_overrides[get_redis] = lambda: None
     return TestClient(app)
 
 
 def test_off_serves_routes_normally():
-    c = app_with_maintenance(False)
-    assert c.get("/openapi.json").status_code == 200
+    # /health (exempt) + une vraie route observatoire servie depuis une DB factice.
+    c = app_with_maintenance(False, fake_db=True)
     assert c.get("/health").status_code == 200
+    assert c.get("/observatory/campaigns", params={"year": 2024}).status_code == 200
 
 
 def test_on_returns_503_with_retry_after_and_body():
     c = app_with_maintenance(True)
-    r = c.get("/openapi.json")
+    r = c.get("/observatory/campaigns", params={"year": 2024})
     assert r.status_code == 503
     assert r.headers["Retry-After"] == "3600"
     assert r.json() == {"status": "maintenance"}

--- a/docker/datalake-api/prod/Dockerfile
+++ b/docker/datalake-api/prod/Dockerfile
@@ -52,4 +52,5 @@ ENV PATH="/app/.venv/bin:$PATH" \
 
 USER datalake
 EXPOSE 8081
-ENTRYPOINT ["uvicorn", "api_datalake.main:app", "--app-dir", "src", "--host", "0.0.0.0", "--port", "8081"]
+# --no-server-header : masque la bannière `Server: uvicorn` (durcissement API8/API9).
+ENTRYPOINT ["uvicorn", "api_datalake.main:app", "--app-dir", "src", "--host", "0.0.0.0", "--port", "8081", "--no-server-header"]


### PR DESCRIPTION
## Contexte

Suite de la revue OWASP de l'API publique `api-datalake` (plan
`~/shared/api-datalake-owasp-durcissement.md`). L'essentiel était déjà sain (SQL
paramétré, `type` en allowlist, bornes numériques, 500 générique, CORS verrouillé,
dégradation gracieuse du cache). Cette PR est de la **défense en profondeur**, sans
régression fonctionnelle. La validation du `code` territoire et le timeout par requête
étant déjà livrés par #3267, ils ne sont **pas** repris ici.

## Ce que contient la PR

- **API8/API9 — surface d'information réduite**
  - `openapi_url=None` : `/openapi.json`, `/docs` et `/redoc` renvoient `404` (le schéma
    de l'API n'est plus exposé publiquement, et Swagger UI ne charge plus de JS depuis un
    CDN externe).
  - Handler `RequestValidationError` laconique : `{"detail": "invalid request parameters"}`
    en `422`, **sans** écho de la valeur invalide ni de la structure du champ. Chirurgical :
    n'avale que le 4xx de validation, laisse le handler 500 par défaut intact. Trace
    d'observabilité (chemin + méthode, sans la valeur brute) pour la détection de scan.
  - `--no-server-header` dans le Dockerfile : masque la bannière `Server: uvicorn`.
- **API3 — projection explicite de `/observatory/campaigns`**
  - Fin du `SELECT *` : les colonnes du contrat public sont énumérées dans `CAMPAIGNS_COLUMNS`.
    Une colonne ajoutée plus tard à la vue `zone_exposed.campaigns` ne fuiterait plus
    automatiquement. L'ensemble est **figé par test** et croisé avec les **27 colonnes réelles
    de la vue** (match exact vérifié). Les noms de colonnes sont une constante littérale — pas
    d'input utilisateur, aucune injection.

## Tests

65 tests verts. Nouveau `test_hardening.py` : `/docs` `/redoc` `/openapi.json` → 404 ;
réponse 422 laconique sans écho de l'entrée ; projection = allowlist figée ;
régression légère de la validation `code` (garde-fou #3267). `test_maintenance.py` adapté
(les probes utilisaient `/openapi.json`, désormais 404 → vraie route observatoire sur DB
factice).

## Portée & déploiement

PR **data-only** (`api-datalake/**` + `docker/**`) → **ne déclenche aucune release**
(attendu ; le service se déploie via le build d'image `deploy-datalake-api`).

## Sécurité (relecture — PASS)

Aucune régression. `openapi_url=None` ne casse aucune route fonctionnelle. Le handler 422
ne masque pas les vrais 500 (exception distincte). Projection sans injection (constante
figée, filtres paramétrés). Constats mineurs non bloquants : `geom` exposé = **périmètre
public de campagne** (déjà dans le contrat, confirmé) ; log d'observabilité ajouté sur les
erreurs de validation.

## CGU (garde-fou — PASS)

La PR **restreint** l'exposition. Aucune colonne PII/identifiante dans l'allowlist ; les
colonnes internes (`email`, `collectivite`, `siren`) sont explicitement exclues et
verrouillées par test. Les montants projetés sont des **barèmes publics de campagne**, pas
des montants privés individuels.