### PR TITLE
ci(datalake): exécute la suite de tests api-datalake en CI

### DIFF
--- a/.github/workflows/quality-datalake-api.yml
+++ b/.github/workflows/quality-datalake-api.yml
@@ -1,0 +1,39 @@
+name: "Quality Datalake API"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+on:
+  pull_request:
+    branches:
+      - main
+      - datalake
+    paths:
+      - "api-datalake/**"
+      - "docker/datalake-api/**"
+
+jobs:
+  tests:
+    name: "(datalake-api) tests"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - name: Install uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          python-version: "3.13"
+      # `--locked` échoue si uv.lock est désynchronisé de pyproject : double
+      # garde-fou (intégrité du lock + installation du groupe dev pour pytest).
+      - name: Install dependencies
+        working-directory: api-datalake
+        run: uv sync --locked
+      - name: Run tests
+        working-directory: api-datalake
+        run: uv run python -m pytest -q


### PR DESCRIPTION
## Contexte

Suite du durcissement de l'API observatoire `api-datalake` (mergé via #3267). Ce
service n'avait aucune garde CI : sa suite de tests ne tournait qu'en local. Cette
PR l'exécute en intégration continue.

## Ce que contient la PR

- **Nouveau workflow `.github/workflows/quality-datalake-api.yml`** — dédié à
  `api-datalake`, déclenché uniquement sur `api-datalake/**` et `docker/datalake-api/**`.
- **Séparé de `quality-datalake.yml`** volontairement : une PR purement `api-datalake`
  ne doit pas déclencher `dbt-parse` / `sqlfluff` / `dockerfile build` du datalake (et
  leurs services Postgres). Même logique que la séparation `deploy-datalake` /
  `deploy-datalake-api`.
- **Job `(datalake-api) tests`** : `uv sync --locked` (intégrité du lock + groupe dev
  pour pytest) puis `uv run pytest`. Action `setup-uv` épinglée par SHA, permissions
  `contents: read`, aucune entrée non fiable dans les `run:`.

## Portée / release

Diff limité à `.github/**` : ne touche aucun code app-stack → **aucune release ni
déploiement** (cohérent avec le service, déployé par son propre workflow).
