### PR TITLE
ci(datalake): déclenche le workflow api-datalake sur ses propres modifs

### DIFF
--- a/.github/workflows/quality-datalake-api.yml
+++ b/.github/workflows/quality-datalake-api.yml
@@ -15,6 +15,7 @@ on:
     paths:
       - "api-datalake/**"
       - "docker/datalake-api/**"
+      - ".github/workflows/quality-datalake-api.yml"
 
 jobs:
   tests:


### PR DESCRIPTION
## Contexte

Suite de #3270 (exécution en CI de la suite de tests `api-datalake`). Le workflow
`quality-datalake-api.yml` se déclenche sur `api-datalake/**` et `docker/datalake-api/**`,
mais **pas** sur ses propres modifications : une PR qui n'édite que le fichier de
workflow était ignorée par le filtre de chemins (c'est précisément ce qui s'est passé
sur #3270 — le job `(datalake-api) tests` n'a pas tourné sur la PR qui l'introduisait).

## Ce que contient la PR

- Ajoute `.github/workflows/quality-datalake-api.yml` aux `paths` du trigger. Toute
  édition future du workflow exécute désormais la suite de tests — le CI se valide
  lui-même. Cette PR en est le premier cas : le job `(datalake-api) tests` tourne dessus.

## Portée / release

Diff limité à `.github/**` : aucun code app-stack → **aucune release ni déploiement**.