### PR TITLE
perf(datalake): indexe user_od_month et operators_od_day sur la clé du delete+insert

### DIFF
--- a/datalake/models/aggregated/operators/operators_od_day.sql
+++ b/datalake/models/aggregated/operators/operators_od_day.sql
@@ -1,10 +1,15 @@
+{#
+  Index composite = clé du delete+insert. Sans lui, le DELETE incrémental (semi-jointure
+  sur les 4 colonnes) balaie toute la table (~12 M lignes) => très lent. operator_id seul
+  est peu sélectif ; le composite le remplace et couvre les lookups par operator_id (préfixe).
+#}
 {{
   config(
     materialized='incremental',
     incremental_strategy='delete+insert',
     unique_key=['operator_id', 'incremental_date', 'start_code', 'end_code'],
     indexes=[
-      { 'columns': ['operator_id'] },
+      { 'columns': ['operator_id', 'incremental_date', 'start_code', 'end_code'] },
       { 'columns': ['incremental_date'] },
       { 'columns': ['start_code', 'end_code'] }
     ],

--- a/datalake/models/aggregated/users/user_od_month.sql
+++ b/datalake/models/aggregated/users/user_od_month.sql
@@ -1,10 +1,15 @@
+{#
+  Index composite = clé du delete+insert. Sans lui, le DELETE incrémental (semi-jointure
+  sur les 5 colonnes) balaie toute la table (~23 M lignes) => très lent. Il sert aussi les
+  lookups par user_id (préfixe gauche) et remplace donc l'index ['user_id'] seul.
+#}
 {{
   config(
     materialized='incremental',
     incremental_strategy='delete+insert',
     unique_key=['user_id', 'incremental_date', 'role', 'start_code', 'end_code'],
     indexes=[
-      { 'columns': ['user_id'] },
+      { 'columns': ['user_id', 'incremental_date', 'role', 'start_code', 'end_code'] },
       { 'columns': ['incremental_date'] },
       { 'columns': ['start_code', 'end_code'] }
     ],


### PR DESCRIPTION
## Contexte

Pendant le backfill complet de la couche agrégée, trois modèles incrémentaux dominent le temps d'exécution de chaque fenêtre mensuelle : `user_od_day`, `user_od_month` et `operators_od_day` (jusqu'à ~25 min chacun).

Cause : la stratégie `delete+insert` supprime les lignes par semi-jointure sur toute la clé unique, mais ces modèles n'avaient qu'un index partiel sur la première colonne. Le `DELETE` balayait donc l'intégralité de la table à chaque fenêtre (`user_od_month` ~23 M lignes, `operators_od_day` ~12 M lignes ; `operator_id` seul est peu sélectif).

`user_od_day` a déjà été corrigé par #3268 ; cette PR applique le même correctif aux deux modèles restants.

## Changement

Remplace l'index simple par l'index composite correspondant à la clé complète du `delete+insert` :

- `user_od_month` : `(user_id, incremental_date, role, start_code, end_code)`
- `operators_od_day` : `(operator_id, incremental_date, start_code, end_code)`

Le composite couvre aussi les lookups par le préfixe gauche et remplace donc l'index à une colonne.

## Vérification

`EXPLAIN` sur la semi-jointure du `DELETE` : le planificateur passe d'un `Seq Scan` de la table cible à un `Index Scan` (coût ~8 par sonde).

Note : dbt ne construit les index qu'au premier build / `full-refresh`. Sur les tables existantes, les index composites ont été créés hors bande via `CREATE INDEX CONCURRENTLY` (validés, `indisvalid = true`) ; cette PR garantit leur reconstruction automatique lors des prochains `full-refresh`.
