### PR TITLE
perf(datalake): indexe operators_od_month, incentives, cee et operator_incentives sur la clé du delete+insert

### DIFF
--- a/datalake/models/aggregated/operators/operators_od_month.sql
+++ b/datalake/models/aggregated/operators/operators_od_month.sql
@@ -1,10 +1,16 @@
+{#
+  Index composite = clé du delete+insert. Sans lui, le DELETE incrémental (semi-jointure
+  sur les 4 colonnes) balaie toute la table (~2,9 M lignes) => très lent. operator_id seul
+  est peu sélectif ; le composite le remplace et couvre les lookups par operator_id (préfixe).
+  Même correctif que operators_od_day (#3272).
+#}
 {{
   config(
     materialized='incremental',
     incremental_strategy='delete+insert',
     unique_key=['operator_id', 'incremental_date', 'start_code', 'end_code'],
     indexes=[
-      { 'columns': ['operator_id'] },
+      { 'columns': ['operator_id', 'incremental_date', 'start_code', 'end_code'] },
       { 'columns': ['incremental_date'] },
       { 'columns': ['start_code', 'end_code'] }
     ],

--- a/datalake/models/trusted/cee.sql
+++ b/datalake/models/trusted/cee.sql
@@ -1,8 +1,14 @@
+{#
+  Index sur _id = clé du delete+insert. Sans lui, le DELETE incrémental balaie toute la
+  table (~2,3 M lignes) à chaque exécution => Seq Scan complet. carpool_v2_id reste indexé
+  pour les jointures aval.
+#}
 {{ config(
     materialized='incremental',
     incremental_strategy='delete+insert',
     unique_key=['_id'],
     indexes = [
+      { 'columns':['_id'] },
       { 'columns':['carpool_v2_id'] },
     ],
     tags=['trusted', 'cee']

--- a/datalake/models/trusted/incentives.sql
+++ b/datalake/models/trusted/incentives.sql
@@ -1,8 +1,14 @@
+{#
+  Index sur _id = clé du delete+insert. Sans lui, le DELETE incrémental balaie toute la
+  table (~32,6 M lignes, ~9,6 Go) à chaque exécution => Seq Scan complet. carpool_v2_id
+  reste indexé pour les jointures aval.
+#}
 {{ config(
     materialized='incremental',
     incremental_strategy='delete+insert',
     unique_key=['_id'],
     indexes = [
+      { 'columns':['_id'] },
       { 'columns':['carpool_v2_id'] },
     ],
     tags=['trusted', 'incentives', 'daily'],

--- a/datalake/models/trusted/operator_incentives.sql
+++ b/datalake/models/trusted/operator_incentives.sql
@@ -1,9 +1,14 @@
+{#
+  Index composite (carpool_id, siret) = clé du delete+insert. Sur cette table volumineuse
+  (~54 M lignes, ~7 Go), il garantit une sonde par index plutôt qu'un Seq Scan et couvre
+  les lookups par carpool_id (préfixe), qu'il remplace.
+#}
 {{ config(
     materialized='incremental',
     incremental_strategy='delete+insert',
     unique_key=['carpool_id', 'siret'],
     indexes = [
-      { 'columns':['carpool_id'] },
+      { 'columns':['carpool_id', 'siret'] },
       { 'columns':['start_datetime'] },
     ],
     tags=['trusted', 'incentives', 'operator', 'daily'],


### PR DESCRIPTION
## Contexte

Plusieurs modèles incrémentaux en stratégie `delete+insert` n'ont pas d'index couvrant la clé du `DELETE` (semi-jointure sur toute la clé unique). Résultat : le `DELETE` balaie l'intégralité de la table à chaque exécution. Cette PR poursuit #3268 et #3272 (qui ont corrigé `user_od_day`, `user_od_month` et `operators_od_day`).

## Changement

- **`operators_od_month`** : index composite `(operator_id, incremental_date, start_code, end_code)` ; `operator_id` seul est peu sélectif. Jumeau de `operators_od_day`.
- **`incentives`** (~32,6 M lignes, ~9,6 Go) et **`cee`** (~2,3 M lignes) : ajout d'un index sur `_id`, la clé du `delete+insert`. Auparavant seul `carpool_v2_id` était indexé.
- **`operator_incentives`** (~54 M lignes, ~7 Go) : index composite `(carpool_id, siret)` en remplacement du préfixe `carpool_id` seul.

`carpools` n'est **pas** modifié : sa clé du `delete+insert` commence par `_id`, déjà indexé et quasi unique ; la sonde par index est donc déjà optimale et un index à quatre colonnes sur une table de 53 Go n'apporterait rien.

## Vérification

- `dbt parse` OK sur le projet complet.
- `EXPLAIN` du `DELETE` en base de production (lecture seule) : `Seq Scan` complet confirmé sur `incentives` (coût ~1,4 M, ~32,6 M lignes) et `cee` avant correctif. L'index sur la clé transforme la semi-jointure en sonde par index (déjà démontré sur les modèles jumeaux dans #3268/#3272).
- Rappel : dbt ne construit les index qu'au premier build / `full-refresh`. Sur les tables déjà en place, prévoir une création hors bande via `CREATE INDEX CONCURRENTLY`.
