### PR TITLE
feat(datalake): job de publication open-data data.gouv depuis le datalake

### DIFF
--- a/datalake/.env.example
+++ b/datalake/.env.example
@@ -37,3 +37,11 @@ EXPORT_S3_BUCKET=
 API_URL=
 EXPORT_WORKER_ACCESS_KEY=
 EXPORT_WORKER_SECRET_KEY=
+
+# --- Publication open-data data.gouv.fr (job mensuel `just datagouv`) ---
+# Le rapport d'exécution est écrit sous S3_BUCKET/datagouv/logs/.
+APP_DATAGOUV_ENABLED=false
+APP_DATAGOUV_UPLOAD=false
+APP_DATAGOUV_URL=https://www.data.gouv.fr/api/1
+APP_DATAGOUV_KEY=
+APP_DATAGOUV_DATASET=

--- a/datalake/justfile
+++ b/datalake/justfile
@@ -81,6 +81,10 @@ export config schema *args:
 export-worker *args:
   python -m pipelines.cmd.export_worker {{args}}
 
+# Publication open-data mensuelle sur data.gouv.fr (défaut : mois précédent).
+datagouv *args:
+  python -m pipelines.cmd.datagouv {{args}}
+
 # Rafraîchit les stats locales des tables distantes (FDW, schema dlk_import).
 # Autovacuum n'analyse JAMAIS les foreign tables : sans ce pas, `reltuples = -1`
 # (aucune stat). À lancer avant un backfill lourd pour donner au planner de bonnes

--- a/datalake/pipelines/cmd/datagouv.py
+++ b/datalake/pipelines/cmd/datagouv.py
@@ -1,0 +1,147 @@
+"""Publication open-data mensuelle sur data.gouv.fr (job datalake).
+
+Remplace la commande API `export:datagouv`. Pour un mois donné (défaut : le mois
+précédent) : garde de complétude, calcul des stats, extraction CSV (COPY, non compressé),
+garde « dataset vide », publication de la resource + description, puis rapport JSON dans
+`datagouv/logs/` du bucket datalake.
+
+L'upload data.gouv est gaté par `APP_DATAGOUV_UPLOAD` (dry-run par défaut) ; l'ensemble
+par `APP_DATAGOUV_ENABLED`.
+"""
+
+import json
+import os
+import tempfile
+from datetime import date, datetime, timezone
+
+import psycopg
+import typer
+from dotenv import load_dotenv
+
+from pipelines.helpers.datagouv_client import DataGouvClient
+from pipelines.helpers.datagouv_query import (
+    build_opendata_copy_sql,
+    build_stats_sql,
+    default_window,
+)
+from pipelines.helpers.datagouv_report import build_description, build_report
+from pipelines.helpers.pg import pg_conninfo
+from pipelines.helpers.s3 import s3_client, s3_upload
+
+load_dotenv()
+app = typer.Typer()
+
+REPORT_PREFIX = "datagouv/logs"
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def fetch_stats(conn, start: date, end: date, min_occ: int) -> dict:
+    sql, params = build_stats_sql(start, end, min_occ)
+    with conn.cursor() as cur:
+        cur.execute(sql, params)
+        cols = [c.name for c in cur.description]
+        row = cur.fetchone()
+    return dict(zip(cols, row))
+
+
+def stream_csv(conn, start: date, end: date, min_occ: int, csv_path: str) -> None:
+    inner, params = build_opendata_copy_sql(start, end, min_occ)
+    # `;` + header, NON compressé (contrat data.gouv actuel).
+    copy_sql = f"COPY ({inner}) TO STDOUT (FORMAT CSV, DELIMITER ';', HEADER)"
+    with open(csv_path, "wb") as f, conn.cursor() as cur:
+        with cur.copy(copy_sql, params) as copy:
+            for chunk in copy:
+                f.write(chunk)
+
+
+def assert_not_empty(stats: dict, filename: str) -> None:
+    """Refuse de publier un jeu de données vide (amont probablement pas prêt)."""
+    if int(stats.get("count_exposed") or 0) < 1:
+        raise RuntimeError(
+            f"refus de publier un dataset vide {filename} "
+            f"(count_exposed={stats.get('count_exposed')}, "
+            f"count_total={stats.get('count_total')}) — agrégats du mois pas prêts ?"
+        )
+
+
+def write_report(s3, bucket: str, month: str, report: dict) -> None:
+    with tempfile.TemporaryDirectory(prefix="datagouv-report-") as tmp:
+        path = os.path.join(tmp, f"{month}.json")
+        with open(path, "w") as f:
+            json.dump(report, f, ensure_ascii=False, indent=2)
+        s3_upload(bucket, f"{REPORT_PREFIX}/{month}.json", path, client=s3)
+
+
+@app.command()
+def run(
+    start: datetime = typer.Option(None, help="Début du mois (YYYY-MM-DD). Défaut : mois précédent."),
+    end: datetime = typer.Option(None, help="Fin exclusive (YYYY-MM-DD). Défaut : mois courant."),
+    min_occurrences: int = typer.Option(6, help="Seuil k-anonymat sur l'occurrence INSEE."),
+):
+    if not os.getenv("APP_DATAGOUV_ENABLED", "").lower() in ("1", "true", "yes", "on"):
+        print("⚠️ data.gouv publication DISABLED (APP_DATAGOUV_ENABLED)")
+        return
+
+    if start and end:
+        d_start, d_end = start.date(), end.date()
+    else:
+        d_start, d_end = default_window(datetime.now(timezone.utc).date())
+    month = d_start.strftime("%Y-%m")
+    filename = f"{month}.csv"
+    started_at = _now_iso()
+
+    bucket = os.environ["S3_BUCKET"]
+    s3 = s3_client()
+
+    stats: dict = {}
+    resource = None
+    try:
+        with psycopg.connect(pg_conninfo()) as conn:
+            stats = fetch_stats(conn, d_start, d_end, min_occurrences)
+            assert_not_empty(stats, filename)
+
+            with tempfile.TemporaryDirectory(prefix="datagouv-") as tmp:
+                csv_path = os.path.join(tmp, filename)
+                stream_csv(conn, d_start, d_end, min_occurrences, csv_path)
+
+                if os.getenv("APP_DATAGOUV_UPLOAD", "").lower() in ("1", "true", "yes", "on"):
+                    client = DataGouvClient(
+                        os.environ["APP_DATAGOUV_URL"],
+                        os.environ["APP_DATAGOUV_KEY"],
+                        os.environ["APP_DATAGOUV_DATASET"],
+                    )
+                    resource = client.upload(csv_path)
+                    client.set_metadata(resource, build_description(d_start, d_end, stats))
+                    print(f"✅ resource publiée : {resource.get('id')}")
+                else:
+                    print("ℹ️ upload data.gouv désactivé (APP_DATAGOUV_UPLOAD) — dry-run")
+
+        report = build_report(
+            month=month, start=d_start, end=d_end, min_occurrences=min_occurrences,
+            stats=stats, filename=filename, status="success",
+            started_at=started_at, finished_at=_now_iso(), resource=resource,
+        )
+        write_report(s3, bucket, month, report)
+        print(f"✅ {filename} — {stats.get('count_exposed')} trajets exposés")
+    except Exception as e:
+        # Détail complet côté logs k8s uniquement ; le rapport persisté sur S3 ne garde
+        # qu'un message générique (une erreur de connexion PG peut porter host/port/user).
+        report = build_report(
+            month=month, start=d_start, end=d_end, min_occurrences=min_occurrences,
+            stats=stats, filename=filename, status="failure",
+            started_at=started_at, finished_at=_now_iso(),
+            error="publication data.gouv échouée",
+        )
+        try:
+            write_report(s3, bucket, month, report)
+        except Exception as report_err:
+            print(f"⚠️ échec écriture du rapport : {report_err!r}")
+        print(f"❌ publication data.gouv échouée : {e!r}")
+        raise typer.Exit(code=1)
+
+
+if __name__ == "__main__":
+    app()

--- a/datalake/pipelines/helpers/datagouv_client.py
+++ b/datalake/pipelines/helpers/datagouv_client.py
@@ -1,0 +1,67 @@
+"""Client data.gouv.fr (port de l'API Deno `DataGouvAPIProvider`, en `requests`).
+
+Choix : porter le client existant plutôt qu'ajouter la lib pré-1.0 `datagouv_client`
+— `requests` est déjà une dépendance du datalake, zéro dépendance nouvelle.
+
+Opérations : lire le dataset, uploader une resource (nouvelle, ou remplacer si un même
+titre existe déjà — comportement de l'API), poser la description. Auth par `X-API-KEY`.
+"""
+
+import os
+
+import requests
+
+
+class DataGouvClient:
+    def __init__(self, base_url: str, api_key: str, dataset: str, session=None):
+        self.base_url = base_url.rstrip("/")
+        self.api_key = api_key
+        self.dataset = dataset
+        self._session = session or requests.Session()
+
+    def _headers(self, json_body: bool) -> dict:
+        h = {"Accept": "application/json", "X-API-KEY": self.api_key}
+        if json_body:
+            h["Content-Type"] = "application/json"
+        return h
+
+    def get_dataset(self) -> dict:
+        r = self._session.get(
+            f"{self.base_url}/datasets/{self.dataset}",
+            headers=self._headers(json_body=False), timeout=60,
+        )
+        r.raise_for_status()
+        return r.json()
+
+    def _find_resource(self, title: str) -> dict | None:
+        for res in self.get_dataset().get("resources", []):
+            if res.get("title") == title:
+                return res
+        return None
+
+    def upload(self, filepath: str) -> dict:
+        """Upload le fichier comme resource. Remplace si un même titre existe déjà."""
+        title = os.path.basename(filepath)
+        existing = self._find_resource(title)
+        if existing:
+            url = f"{self.base_url}/datasets/{self.dataset}/resources/{existing['id']}/upload/"
+        else:
+            url = f"{self.base_url}/datasets/{self.dataset}/upload/"
+
+        with open(filepath, "rb") as f:
+            r = self._session.post(
+                url, headers=self._headers(json_body=False),
+                files={"file": (title, f)}, timeout=300,
+            )
+        r.raise_for_status()
+        return r.json()
+
+    def set_metadata(self, resource: dict, description: str) -> dict:
+        r = self._session.put(
+            f"{self.base_url}/datasets/{self.dataset}/resources/{resource['id']}",
+            headers=self._headers(json_body=True),
+            json={"title": resource.get("title"), "description": description},
+            timeout=60,
+        )
+        r.raise_for_status()
+        return r.json()

--- a/datalake/pipelines/helpers/datagouv_query.py
+++ b/datalake/pipelines/helpers/datagouv_query.py
@@ -1,0 +1,120 @@
+"""Requêtes de la publication open-data data.gouv.fr.
+
+Deux requêtes pures (SQL + params), testables sans base :
+
+- `build_opendata_copy_sql` : le CSV publié. Lit la vue `zone_exposed.export_opendata`
+  (non matérialisée), projette les colonnes du contrat dans l'ordre exact de l'ancien
+  `datagouvListQuery.ts`, applique le filtre k-anonymat (occurrence INSEE >= min).
+- `build_stats_sql` : les compteurs (total / exposés / retirés). Volontairement **allégée** :
+  elle recompte les occurrences INSEE via `zone_trusted.carpools` x les agrégats
+  `territory_month_arr_{from,to}` (matérialisés), **sans** la jointure FDW des positions GPS
+  que porte `export_opendata`. On ne re-scanne donc pas la vue lourde pour compter.
+
+Les valeurs (dates du mois, min_occurrences) sont calculées par le job — pas des entrées
+utilisateur — et passées en **paramètres** psycopg (`%(...)s`).
+"""
+
+from datetime import date
+
+OPENDATA_TABLE = "zone_exposed.export_opendata"
+CARPOOLS_TABLE = "zone_trusted.carpools"
+TERRITORY_FROM = "zone_aggregated.territory_month_arr_from"
+TERRITORY_TO = "zone_aggregated.territory_month_arr_to"
+
+# Ordre des colonnes = ordre des colonnes du CSV publié (port de config/datagouv.ts
+# `fields` et de datagouvListQuery.ts). NE PAS réordonner sans revalider le contrat.
+DATAGOUV_FIELDS = [
+    "journey_id",
+    "trip_id",
+    "journey_start_datetime",
+    "journey_start_date",
+    "journey_start_time",
+    "journey_start_lon",
+    "journey_start_lat",
+    "journey_start_insee",
+    "journey_start_department",
+    "journey_start_town",
+    "journey_start_towngroup",
+    "journey_start_country",
+    "journey_end_datetime",
+    "journey_end_date",
+    "journey_end_time",
+    "journey_end_lon",
+    "journey_end_lat",
+    "journey_end_insee",
+    "journey_end_department",
+    "journey_end_town",
+    "journey_end_towngroup",
+    "journey_end_country",
+    "passenger_seats",
+    "operator_class",
+    "journey_distance",
+    "journey_duration",
+    "has_incentive",
+]
+
+
+def default_window(today: date) -> tuple[date, date]:
+    """Fenêtre par défaut = le mois précédent.
+
+    Renvoie (premier jour du mois précédent, premier jour du mois courant).
+    """
+    end = today.replace(day=1)  # premier jour du mois courant (borne exclusive)
+    prev_year = end.year - 1 if end.month == 1 else end.year
+    prev_month = 12 if end.month == 1 else end.month - 1
+    start = date(prev_year, prev_month, 1)
+    return start, end
+
+
+def build_opendata_copy_sql(start: date, end: date, min_occurrences: int) -> tuple[str, dict]:
+    """SELECT interne du CSV open-data (à envelopper dans un COPY ... TO STDOUT).
+
+    Filtre : mois [start, end) sur `start_date_filter`, et k-anonymat sur les
+    compteurs d'occurrence INSEE déjà exposés par la vue.
+    """
+    cols = ",\n      ".join(DATAGOUV_FIELDS)
+    sql = f"""
+    SELECT
+      {cols}
+    FROM {OPENDATA_TABLE}
+    WHERE start_date_filter >= %(start)s
+      AND start_date_filter < %(end)s
+      AND start_insee_count >= %(min_occ)s
+      AND end_insee_count >= %(min_occ)s
+    ORDER BY start_date_filter ASC
+    """
+    return sql, {"start": start, "end": end, "min_occ": min_occurrences}
+
+
+def build_stats_sql(start: date, end: date, min_occurrences: int) -> tuple[str, dict]:
+    """Compteurs total / exposés / retirés du mois (requête allégée, sans positions).
+
+    Sémantique identique à l'ancien `datagouvStatsQuery` (insee_counters) :
+    `count_removed = count_removed_start + count_removed_end - count_removed_both`.
+    """
+    sql = f"""
+    SELECT
+      count(*) AS count_total,
+      count(*) FILTER (
+        WHERE ts.carpools >= %(min_occ)s AND te.carpools >= %(min_occ)s
+      ) AS count_exposed,
+      count(*) FILTER (
+        WHERE ts.carpools < %(min_occ)s OR te.carpools < %(min_occ)s
+      ) AS count_removed,
+      count(*) FILTER (WHERE ts.carpools < %(min_occ)s) AS count_removed_start,
+      count(*) FILTER (WHERE te.carpools < %(min_occ)s) AS count_removed_end,
+      count(*) FILTER (
+        WHERE ts.carpools < %(min_occ)s AND te.carpools < %(min_occ)s
+      ) AS count_removed_both
+    FROM {CARPOOLS_TABLE} AS c
+    LEFT JOIN {TERRITORY_FROM} AS ts
+      ON c.start_geo_code = ts.code
+      AND date_trunc('month', c.start_datetime) = ts.incremental_date
+    LEFT JOIN {TERRITORY_TO} AS te
+      ON c.end_geo_code = te.code
+      AND date_trunc('month', c.start_datetime) = te.incremental_date
+    WHERE c.valid_acquisition_status
+      AND (c.start_datetime AT TIME ZONE 'Europe/Paris')::date >= %(start)s
+      AND (c.start_datetime AT TIME ZONE 'Europe/Paris')::date < %(end)s
+    """
+    return sql, {"start": start, "end": end, "min_occ": min_occurrences}

--- a/datalake/pipelines/helpers/datagouv_report.py
+++ b/datalake/pipelines/helpers/datagouv_report.py
@@ -1,0 +1,63 @@
+"""Description du jeu de données et rapport d'exécution data.gouv.fr."""
+
+from datetime import date, timedelta
+
+_FR_MONTHS = [
+    "janvier", "février", "mars", "avril", "mai", "juin",
+    "juillet", "août", "septembre", "octobre", "novembre", "décembre",
+]
+
+
+def _fr_date(d: date) -> str:
+    return f"{d.day} {_FR_MONTHS[d.month - 1]} {d.year}"
+
+
+def build_description(start: date, end: date, stats: dict) -> str:
+    """Texte FR du jeu de données (port de DataGouvMetadataProvider.description).
+
+    `end` est exclusif : la dernière journée décrite est `end - 1 jour`.
+    """
+    start_fr = _fr_date(start)
+    end_fr = _fr_date(end - timedelta(days=1))
+    return f"""
+Spécificités jeu de données entre le {start_fr} et le {end_fr} :
+
+Les données concernent également les trajets dont le point de départ OU d'arrivée est situé en dehors du territoire français.
+
+- Nombre trajets collectés et validés par le registre de preuve de covoiturage {stats['count_total']}.
+- Nombre de trajets exposés dans le jeu de données : {stats['count_exposed']}.
+- Nombre de trajets supprimés du jeu de données : {stats['count_removed']} = {stats['count_removed_start']} + {stats['count_removed_end']} - {stats['count_removed_both']}.
+  - Nombre de trajets dont l'occurrence du code INSEE de départ est < 6 : {stats['count_removed_start']}
+  - Nombre de trajets dont l'occurrence du code INSEE d'arrivée est < 6 : {stats['count_removed_end']}
+  - Nombre de trajets dont l'occurrence du code INSEE de départ ET d'arrivée est < 6 : {stats['count_removed_both']}
+    """.strip()
+
+
+def build_report(
+    *,
+    month: str,
+    start: date,
+    end: date,
+    min_occurrences: int,
+    stats: dict,
+    filename: str,
+    status: str,
+    started_at: str,
+    finished_at: str,
+    resource: dict | None = None,
+    error: str | None = None,
+) -> dict:
+    """Rapport d'exécution, écrit en JSON sous `datagouv/logs/<mois>.json`."""
+    return {
+        "month": month,
+        "start": start.isoformat(),
+        "end": end.isoformat(),
+        "min_occurrences": min_occurrences,
+        "filename": filename,
+        "status": status,
+        "started_at": started_at,
+        "finished_at": finished_at,
+        "stats": stats,
+        "resource": {"id": resource.get("id"), "url": resource.get("url")} if resource else None,
+        "error": error,
+    }

--- a/datalake/tests/test_datagouv_client.py
+++ b/datalake/tests/test_datagouv_client.py
@@ -1,0 +1,79 @@
+import os
+import tempfile
+
+from pipelines.helpers.datagouv_client import DataGouvClient
+
+
+class FakeResponse:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def raise_for_status(self):
+        pass
+
+    def json(self):
+        return self._payload
+
+
+class FakeSession:
+    """Enregistre les appels et renvoie des réponses scriptées."""
+
+    def __init__(self, dataset_payload, upload_payload=None, put_payload=None):
+        self.dataset_payload = dataset_payload
+        self.upload_payload = upload_payload or {"id": "new", "title": "x"}
+        self.put_payload = put_payload or {"id": "new"}
+        self.calls = []
+
+    def get(self, url, headers=None, timeout=None):
+        self.calls.append(("GET", url, headers))
+        return FakeResponse(self.dataset_payload)
+
+    def post(self, url, headers=None, files=None, timeout=None):
+        self.calls.append(("POST", url, headers, list(files.keys())))
+        return FakeResponse(self.upload_payload)
+
+    def put(self, url, headers=None, json=None, timeout=None):
+        self.calls.append(("PUT", url, headers, json))
+        return FakeResponse(self.put_payload)
+
+
+def _tmpfile(name):
+    d = tempfile.mkdtemp()
+    p = os.path.join(d, name)
+    with open(p, "w") as f:
+        f.write("a;b\n1;2\n")
+    return p
+
+
+def test_auth_header_on_every_call():
+    s = FakeSession({"resources": []})
+    c = DataGouvClient("https://x/api/1", "SECRET", "ds", session=s)
+    c.get_dataset()
+    assert s.calls[0][2]["X-API-KEY"] == "SECRET"
+
+
+def test_upload_new_resource_uses_dataset_upload_url():
+    s = FakeSession({"resources": []})
+    c = DataGouvClient("https://x/api/1", "k", "ds", session=s)
+    c.upload(_tmpfile("2026-06.csv"))
+    post = [call for call in s.calls if call[0] == "POST"][0]
+    assert post[1].endswith("/datasets/ds/upload/")
+    assert post[3] == ["file"]  # multipart, pas de Content-Type json
+    assert "Content-Type" not in s.calls[-1][2]
+
+
+def test_upload_existing_title_replaces_resource():
+    s = FakeSession({"resources": [{"id": "R1", "title": "2026-06.csv"}]})
+    c = DataGouvClient("https://x/api/1", "k", "ds", session=s)
+    c.upload(_tmpfile("2026-06.csv"))
+    post = [call for call in s.calls if call[0] == "POST"][0]
+    assert post[1].endswith("/datasets/ds/resources/R1/upload/")
+
+
+def test_set_metadata_puts_description():
+    s = FakeSession({"resources": []})
+    c = DataGouvClient("https://x/api/1", "k", "ds", session=s)
+    c.set_metadata({"id": "R9", "title": "t"}, "ma description")
+    put = [call for call in s.calls if call[0] == "PUT"][0]
+    assert put[1].endswith("/datasets/ds/resources/R9")
+    assert put[3] == {"title": "t", "description": "ma description"}

--- a/datalake/tests/test_datagouv_cmd.py
+++ b/datalake/tests/test_datagouv_cmd.py
@@ -1,0 +1,47 @@
+from datetime import date
+
+import pytest
+
+from pipelines.cmd import datagouv as cmd
+
+
+class FakeCursor:
+    def __init__(self, row, cols):
+        self._row = row
+        self.description = [type("C", (), {"name": c}) for c in cols]
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+    def execute(self, sql, params):
+        self.sql, self.params = sql, params
+
+    def fetchone(self):
+        return self._row
+
+
+class FakeConn:
+    def __init__(self, row, cols):
+        self._row, self._cols = row, cols
+
+    def cursor(self):
+        return FakeCursor(self._row, self._cols)
+
+
+def test_assert_not_empty_raises_when_no_exposed():
+    with pytest.raises(RuntimeError, match="dataset vide"):
+        cmd.assert_not_empty({"count_exposed": 0, "count_total": 5}, "2026-06.csv")
+
+
+def test_assert_not_empty_passes_with_rows():
+    cmd.assert_not_empty({"count_exposed": 998086}, "2026-06.csv")  # ne lève pas
+
+
+def test_fetch_stats_maps_columns_to_dict():
+    cols = ["count_total", "count_exposed"]
+    conn = FakeConn((1025610, 998086), cols)
+    stats = cmd.fetch_stats(conn, date(2026, 6, 1), date(2026, 7, 1), 6)
+    assert stats == {"count_total": 1025610, "count_exposed": 998086}

--- a/datalake/tests/test_datagouv_query.py
+++ b/datalake/tests/test_datagouv_query.py
@@ -1,0 +1,60 @@
+from datetime import date
+
+from pipelines.helpers.datagouv_query import (
+    DATAGOUV_FIELDS,
+    build_opendata_copy_sql,
+    build_stats_sql,
+    default_window,
+)
+
+
+def test_default_window_is_previous_month():
+    assert default_window(date(2026, 7, 11)) == (date(2026, 6, 1), date(2026, 7, 1))
+
+
+def test_default_window_year_rollover():
+    assert default_window(date(2026, 1, 15)) == (date(2025, 12, 1), date(2026, 1, 1))
+
+
+def test_copy_sql_projects_contract_columns_in_order():
+    sql, params = build_opendata_copy_sql(date(2026, 6, 1), date(2026, 7, 1), 6)
+    assert "SELECT *" not in sql
+    # ordre du contrat préservé : chaque colonne apparaît après la précédente
+    idx = [sql.index(c) for c in DATAGOUV_FIELDS]
+    assert idx == sorted(idx)
+    assert DATAGOUV_FIELDS[0] == "journey_id"
+    assert DATAGOUV_FIELDS[-1] == "has_incentive"
+
+
+def test_copy_sql_applies_kanon_and_month_filter():
+    sql, params = build_opendata_copy_sql(date(2026, 6, 1), date(2026, 7, 1), 6)
+    assert "start_insee_count >= %(min_occ)s" in sql
+    assert "end_insee_count >= %(min_occ)s" in sql
+    assert "start_date_filter >= %(start)s" in sql
+    assert "start_date_filter < %(end)s" in sql
+    assert "ORDER BY start_date_filter ASC" in sql
+    assert params == {"start": date(2026, 6, 1), "end": date(2026, 7, 1), "min_occ": 6}
+
+
+def test_copy_sql_reads_only_exposed_zone():
+    sql, _ = build_opendata_copy_sql(date(2026, 6, 1), date(2026, 7, 1), 6)
+    assert "zone_exposed.export_opendata" in sql
+    assert "zone_raw." not in sql
+
+
+def test_stats_sql_is_light_no_positions():
+    sql, params = build_stats_sql(date(2026, 6, 1), date(2026, 7, 1), 6)
+    # requête allégée : trusted + agrégés, jamais la vue lourde ni les positions GPS
+    assert "zone_exposed.export_opendata" not in sql
+    assert "start_position" not in sql and "st_x" not in sql.lower()
+    assert "zone_trusted.carpools" in sql
+    assert "territory_month_arr_from" in sql
+    assert "territory_month_arr_to" in sql
+
+
+def test_stats_sql_counts_match_inclusion_exclusion_semantics():
+    sql, _ = build_stats_sql(date(2026, 6, 1), date(2026, 7, 1), 6)
+    for col in ("count_total", "count_exposed", "count_removed",
+                "count_removed_start", "count_removed_end", "count_removed_both"):
+        assert col in sql
+    assert "c.valid_acquisition_status" in sql

--- a/datalake/tests/test_datagouv_report.py
+++ b/datalake/tests/test_datagouv_report.py
@@ -1,0 +1,51 @@
+from datetime import date
+
+from pipelines.helpers.datagouv_report import build_description, build_report
+
+STATS = {
+    "count_total": 1025610,
+    "count_exposed": 998086,
+    "count_removed": 27524,
+    "count_removed_start": 14958,
+    "count_removed_end": 15373,
+    "count_removed_both": 2807,
+}
+
+
+def test_description_french_dates_and_counts():
+    d = build_description(date(2026, 6, 1), date(2026, 7, 1), STATS)
+    # end exclusif -> dernier jour décrit = 30 juin
+    assert "entre le 1 juin 2026 et le 30 juin 2026" in d
+    assert "998086" in d
+    assert "27524 = 14958 + 15373 - 2807" in d
+
+
+def test_description_year_rollover_last_day():
+    d = build_description(date(2025, 12, 1), date(2026, 1, 1), STATS)
+    assert "entre le 1 décembre 2025 et le 31 décembre 2025" in d
+
+
+def test_report_success_shape():
+    r = build_report(
+        month="2026-06", start=date(2026, 6, 1), end=date(2026, 7, 1),
+        min_occurrences=6, stats=STATS, filename="2026-06.csv",
+        status="success", started_at="2026-07-11T00:00:00Z",
+        finished_at="2026-07-11T00:05:00Z",
+        resource={"id": "abc", "url": "https://data.gouv/x"},
+    )
+    assert r["status"] == "success"
+    assert r["resource"] == {"id": "abc", "url": "https://data.gouv/x"}
+    assert r["error"] is None
+    assert r["stats"]["count_exposed"] == 998086
+
+
+def test_report_failure_shape():
+    r = build_report(
+        month="2026-06", start=date(2026, 6, 1), end=date(2026, 7, 1),
+        min_occurrences=6, stats={}, filename="2026-06.csv",
+        status="failure", started_at="s", finished_at="f",
+        error="upload failed",
+    )
+    assert r["status"] == "failure"
+    assert r["resource"] is None
+    assert r["error"] == "upload failed"

--- a/docs/superpowers/specs/2026-07-11-datagouv-datalake-migration-design.md
+++ b/docs/superpowers/specs/2026-07-11-datagouv-datalake-migration-design.md
@@ -1,0 +1,194 @@
+# Publication data.gouv.fr : sqlmesh/API → datalake
+
+**Date :** 2026-07-11
+**Statut :** Design — approuvé pour planification
+**Périmètre :** La publication mensuelle open-data sur data.gouv.fr uniquement. C'est le
+volet explicitement reporté par le spec de l'export à la demande
+(`2026-07-07-on-demand-export-datalake-migration-design.md`, risque #8 : « ne pas
+supprimer `export_opendata_list` dans cette migration »). L'export à la demande
+(operator/territory) est déjà migré et hors périmètre.
+
+## Problème
+
+Aujourd'hui l'API produit elle-même la publication open-data mensuelle : la commande CLI
+`export:datagouv` (`api/src/pdc/services/export/commands/DataGouvCommand.ts`) découpe la
+plage par mois, génère un CSV en lisant la vue **sqlmesh** `refined_zone.export_opendata_list`
+(via `datagouvListQuery.ts`), calcule des statistiques via `trusted_zone.insee_counters`
+(via `datagouvStatsQuery.ts`), construit une description de jeu de données, puis publie la
+resource sur data.gouv.fr (`DataGouvAPIProvider` + `DataGouvMetadataProvider`).
+
+Ces deux modèles sqlmesh déménagent dans le datalake (base `datalake_production`, séparée),
+inaccessible à l'API. La production du fichier doit donc passer côté datalake.
+
+**Différence clé avec l'export à la demande.** L'export à la demande a gardé un *control
+plane* parce que l'API **possède la file** `export.exports` (déclenchée par un utilisateur,
+avec état). La publication data.gouv est **mensuelle, sans utilisateur, sans état possédé
+par l'API** : l'API n'héberge la commande que par accident historique. Il n'y a donc **rien
+à posséder côté API** → on déplace **tout le job** dans le datalake.
+
+## Principes / contraintes
+
+- **L'API sort totalement du circuit data.gouv.** Pas de control plane, pas d'état côté API.
+- **Le contrat CSV ne doit pas dériver.** Mêmes colonnes, ordre, en-têtes, délimiteur,
+  **sans compression** (`.csv` nu), et format de nom de fichier — identiques au dataset
+  publié aujourd'hui. Validation **contre les resources réellement en ligne** sur data.gouv.fr.
+- **Le k-anonymat est préservé.** On retire les trajets dont un code INSEE (départ ou
+  arrivée) apparaît moins de `min_occurrences` (= 6) fois dans le mois.
+- **On ne matérialise pas `export_opendata`.** Le modèle reste une **vue** (économie de
+  place en base). Le job mensuel a le droit d'être lent.
+- **Vérification TLS et secrets** : les credentials data.gouv.fr migrent vers l'env/secret
+  du datalake, gérés par l'ops.
+
+## Architecture
+
+Un **job Python mensuel dans le datalake**, sur le modèle de `export.py` / `export_worker.py` :
+
+- `datalake/pipelines/cmd/datagouv.py` (Typer), recette `just datagouv`, **CronJob k8s
+  mensuel** (repo ops).
+
+### Flux (cible)
+
+```
+CronJob datalake (mensuel, k8s, repo ops) :
+  1. Déterminer le mois cible (défaut : mois précédent ; option --start/--end pour backfill)
+  2. Garde de complétude : les agrégats territory_month_arr_{from,to} du mois sont matérialisés
+  3. COPY (SELECT … FROM zone_exposed.export_opendata
+           WHERE start_date_filter dans le mois
+             AND start_insee_count >= :min_occ AND end_insee_count >= :min_occ)
+        TO STDOUT (FORMAT CSV, HEADER)  → fichier CSV local (NON compressé)
+  4. Stats (requête allégée, cf. §Données) : count_total/exposed/removed/…
+  5. Garde « dataset vide » : abandon si count_exposed < 1
+  6. Description du jeu de données (texte FR à partir des stats)
+  7. Publication data.gouv.fr : get dataset → upload nouvelle resource → set metadata
+  8. Rapport JSON → bucket datalake, clé datagouv/logs/<AAAA-MM>.json
+```
+
+Pas de file, pas de reprise pilotée par l'API : le CronJob est idempotent et rejouable par
+mois (chaque run publie une nouvelle resource, comportement actuel préservé).
+
+## Données & k-anonymat (le point central)
+
+- **Source CSV** : `zone_exposed.export_opendata` (déjà existant). Il **embarque déjà** les
+  compteurs d'occurrence INSEE par mois — `start_insee_count` / `end_insee_count`, dérivés
+  des agrégats matérialisés `territory_month_arr_from` / `territory_month_arr_to`, avec le
+  commentaire explicite *« for filtering by API »*.
+- **Conséquence majeure** : **aucun modèle `insee_counters` à porter**. Le rôle de l'ancien
+  `trusted_zone.insee_counters` (fournir les compteurs) est absorbé par `export_opendata`.
+- **Filtre k-anon dans le job** : `WHERE start_insee_count >= :min_occ AND end_insee_count
+  >= :min_occ`. Le modèle reste **non filtré** exprès, pour que les stats puissent compter
+  les trajets **exposés ET retirés**.
+- **Stats — attention aux performances.** On ne calcule **pas** les compteurs à travers la
+  vue `export_opendata` : elle fait une **jointure FDW sur les positions GPS** (nécessaire
+  au CSV, inutile pour compter). Les stats (`count_total`, `count_exposed`,
+  `count_removed`, `count_removed_start`, `count_removed_end`, `count_removed_both`) se
+  calculent par une **requête allégée** — `trusted.carpools` × `territory_month_arr_{from,to}`
+  (tous deux matérialisés), `COUNT(*) FILTER (… >= :min_occ)`, **sans positions ni
+  périmètres**, bornée au mois cible (pushdown d'index). Le CSV, lui, paie la vue complète
+  **une seule fois** par mois.
+
+## Composants
+
+### 1. Extraction CSV
+`psycopg` `COPY (SELECT … WHERE k-anon … AND mois) TO STDOUT (FORMAT CSV, HEADER,
+DELIMITER '<contrat>')` en streaming vers un fichier local, **sans compression**. L'ordre
+des colonnes du SELECT **définit le CSV** → il doit reproduire exactement l'ordre du contrat
+(cf. tâche bloquante ci-dessous).
+
+### 2. Client data.gouv.fr (décision à confirmer par spike)
+La lib officielle **[`datagouv/datagouv_client`](https://github.com/datagouv/datagouv_client)**
+est maintenue par l'équipe data.gouv.fr (v0.5.0 en juin 2026, Python ≥ 3.10) et couvre le
+besoin : `create_static_resource(file_to_upload=…, payload=…)`, update de resource/métadonnée,
+get dataset.
+
+**Décision** : la retenir, **gatée par un spike court** validant, contre un dataset de test :
+(a) auth par clé API, (b) upload d'une **nouvelle** resource par mois, (c) mise à jour de la
+description, (d) gestion d'erreurs exploitable. **Fallback** : portage de `DataGouvAPIProvider`
+(≈ 140 lignes, `requests`, déjà dep) si le spike révèle un manque. Réserves de la lib :
+pré-1.0, faible adoption (14★).
+
+La **description FR** du jeu de données (à partir des stats) est portée de
+`DataGouvMetadataProvider`.
+
+### 3. Config / secrets
+`APP_DATAGOUV_*` (`enabled`, `upload`, `notify`, `contact`, `key`, `url`, `dataset`) migrent
+vers l'env/secret du datalake. Câblage secret côté ops.
+
+### 4. Rapports d'export (nouveau)
+Chaque run écrit un **rapport JSON** dans le bucket S3 du datalake sous **`datagouv/logs/`**
+(p. ex. `datagouv/logs/<AAAA-MM>.json`) : mois, horodatages début/fin, stats détaillées
+(total / exposés / retirés + ventilation début / arrivée / les-deux), nom du fichier,
+`min_occurrences` appliqué, id + URL de la resource data.gouv publiée, statut succès/échec +
+message d'erreur. Donne un historique auditable, remplace `LogService`/`NotificationService`
+de l'API pour ce flux.
+
+## Contrat CSV & publication (tâche bloquante)
+
+Le CSV publié a un contrat que des consommateurs externes parsent. Reproduire **à
+l'identique** : ensemble et **ordre** des colonnes (cf. `config/datagouv.ts` `fields`),
+noms d'en-tête, délimiteur, absence de compression, format du nom de fichier
+(`NameService.datagouv`), et **une nouvelle resource par mois** sur le dataset.
+
+**Validation** : diff **à trois voies** sur un mois settled — (a) resource **réellement
+publiée en ligne** sur le dataset data.gouv.fr (récupérée via l'API), (b) sortie actuelle de
+l'API, (c) sortie du nouveau job datalake. Toute dérive silencieuse casse les parseurs aval.
+
+## Garde-fous & fraîcheur
+
+- **Refus de dataset vide** : abandon bruyant si `count_exposed < 1` (port de
+  `assertDatagouvNotEmpty`). Protège contre l'upload d'un fichier vide si l'amont n'est pas
+  prêt.
+- **Complétude du mois** : on publie le **mois précédent** (défaut). Les agrégats
+  `territory_month_arr_{from,to}` du mois doivent être matérialisés — garde explicite avant
+  extraction (analogue à la fraîcheur trusted de l'export à la demande).
+- **Rejouable** : plage `--start/--end` conservée (backfill d'historique) ; nouvelle resource
+  par run.
+
+## Décommission (finalise le report de l'export à la demande)
+
+Une fois la parité validée et le CronJob en prod :
+
+- **API** : supprimer `DataGouvCommand`, `datagouvListQuery`, `datagouvStatsQuery`, les
+  providers `providers/datagouv/*`, la config `config/datagouv.ts`, et le câblage associé.
+- **sqlmesh** : `DROP` de `refined_zone.export_opendata_list` **et** de
+  `trusted_zone.insee_counters` (plus aucun lecteur).
+
+## Tests
+
+- **Unit (Python)** : requête CSV avec/sans filtre k-anon (bon `min_occurrences`) ; requête
+  de stats (count_total/exposed/removed + ventilations) ; garde « dataset vide » ; garde de
+  complétude du mois ; description FR à partir de stats connues.
+- **Spike (bloquant)** : `datagouv_client` valide upload nouvelle resource + set description
+  + auth + erreurs, contre un dataset de test.
+- **Contrat (bloquant)** : diff à trois voies (publié en ligne / API actuelle / datalake) sur
+  un mois settled.
+- **E2E staging** : run → resource uploadée sur dataset de test + métadonnée + rapport écrit
+  dans `datagouv/logs/`.
+
+## Risques
+
+1. **Maturité de la lib** — pré-1.0, faible adoption ; mitigé par le spike + fallback portage.
+2. **Perf de la vue sur gros mois** — `export_opendata` non matérialisée + jointure FDW
+   positions ; accepté (mensuel, lent toléré), CSV payé une fois ; stats déportées sur une
+   requête allégée pour ne pas re-scanner la vue.
+3. **Fraîcheur au bord du mois** — un run avant matérialisation des agrégats du mois donnerait
+   des compteurs faux → garde de complétude.
+4. **Migration des credentials** — `APP_DATAGOUV_KEY` etc. vers le secret datalake ; risque
+   d'upload accidentel en test → garder `enabled`/`upload` en flags, dataset de test d'abord.
+5. **Egress réseau** — le datalake (infra séparée) doit joindre data.gouv.fr (confirmer route
+   + TLS) et le bucket S3.
+
+## Hors périmètre
+
+- Export à la demande (déjà migré).
+- Matérialisation de `zone_aggregated` / `zone_exposed` en prod (chantier backfill séparé).
+- Refonte des colonnes / du contenu du jeu de données open-data (migration iso-contrat).
+
+## Points ouverts pour la planification
+
+- Résultat du spike `datagouv_client` (retenue vs portage).
+- Source exacte de `min_occurrences` (config datalake ; défaut 6) et confirmation que la
+  vue expose bien les compteurs au grain attendu par le filtre.
+- Confirmation de la stratégie de resource (nouvelle par mois vs rolling) contre le dataset
+  réel.
+- Schéma précis du rapport JSON `datagouv/logs/`.
+- Notification de fin (les `TODO notify users` actuels) : conservée ou abandonnée (YAGNI ?).


### PR DESCRIPTION
## Contexte

La publication mensuelle open-data sur data.gouv.fr était le volet reporté par la migration
de l'export à la demande. L'API la produit aujourd'hui via la commande `export:datagouv`, qui
lit les modèles **sqlmesh** `refined_zone.export_opendata_list` et `trusted_zone.insee_counters`.
Ces modèles déménagent dans le datalake (base séparée), inaccessible à l'API.

Contrairement à l'export à la demande, cette publication est **mensuelle, sans état possédé
par l'API** → on déplace **tout le job** dans le datalake, l'API sort du circuit data.gouv.

Spec : `docs/superpowers/specs/2026-07-11-datagouv-datalake-migration-design.md` (inclus).

## Ce que contient la PR

- **`pipelines/cmd/datagouv.py`** (`just datagouv`) : mois cible (défaut = mois précédent,
  `--start/--end` pour backfill), garde « dataset vide », extraction CSV via `COPY` (délimiteur
  `;`, **non compressé** — contrat actuel), publication data.gouv gatée par
  `APP_DATAGOUV_ENABLED` / `APP_DATAGOUV_UPLOAD`, **rapport JSON** dans `S3_BUCKET/datagouv/logs/`.
- **`datagouv_query.py`** : le CSV lit `zone_exposed.export_opendata` (**vue non matérialisée**,
  on économise la place) et applique le **filtre k-anonymat** sur les compteurs d'occurrence
  INSEE déjà exposés par la vue → **aucun modèle `insee_counters` à porter**.
- **Stats (perf)** : calculées par une requête **allégée** — `zone_trusted.carpools` ×
  `territory_month_arr_{from,to}` (matérialisés), **sans** la jointure FDW des positions GPS.
  On ne re-scanne pas la vue lourde pour compter ; le CSV la paie une seule fois par mois.
- **`datagouv_client.py`** : client data.gouv.fr **porté en `requests`** (déjà dépendance —
  pas de nouvelle lib pré-1.0). Upload d'une resource (nouvelle ou remplacement par titre) +
  description FR.
- **`datagouv_report.py`** : description FR du jeu de données (port de `DataGouvMetadataProvider`)
  + schéma du rapport d'exécution.

## Tests

18 tests unitaires (builders SQL, ordre des colonnes du contrat, filtre k-anon, requête stats
allégée, description FR avec bascule d'année, rapport succès/échec, client HTTP mocké, garde
« vide »). Suite datalake complète : **70 passés, 2 skips** (pré-existants). Les fichiers sont
du Python pur + justfile → n'affectent pas les jobs CI datalake (dbt parse / sqlfluff sur SQL).

## Portée & déploiement

PR **data-only** (`datalake/**` + `docs/**`) → **ne déclenche aucune release** (attendu ; le
job tourne dans l'image datalake, déployée par son propre build).

## Hors périmètre (follow-ups explicites)

- **Décommission API** (`DataGouvCommand`, `datagouv*Query`, providers `datagouv/*`,
  `config/datagouv.ts`) + **drop sqlmesh** `export_opendata_list` & `insee_counters` — après
  validation de parité en prod (l'exposé n'est pas encore matérialisé).
- **CronJob k8s mensuel** (repo ops).
- **Validation du contrat CSV** contre les resources réellement publiées en ligne (mois settled).
- **Spike lib officielle `datagouv_client`** : choix documenté du portage `requests` (zéro dep,
  conforme à la préférence « peu de dépendances »).

## Sécurité (relecture — PASS)

Injection SQL : valeurs (`start`/`end`/`min_occ`) liées en paramètres psycopg `%(...)s`, noms
de table constants, colonnes issues de la constante `DATAGOUV_FIELDS` — pas d'entrée utilisateur
(CronJob). `COPY (SELECT …)` paramétré correct. Client data.gouv : `X-API-KEY` en en-tête (jamais
dans les exceptions/logs/rapport), TLS par défaut actif, timeouts partout (60/300/60 s). Aucun
secret committé (`.env.example` vide). Rapport S3 = agrégats seulement, pas de PII. Défauts en
dry-run (`APP_DATAGOUV_ENABLED`/`UPLOAD` = false) + garde « vide ».

Constat mineur traité : le champ `error` du rapport persisté ne porte plus `str(e)` (une erreur
de connexion PG pouvait contenir host/port/user) mais un message générique ; le détail complet
reste dans les logs k8s (convention de `export_worker`).

## CGU (garde-fou — PASS)

Migration iso-contrat, aucune règle enfreinte. Filtre **k-anonymat** (seuil 6 sur l'occurrence
INSEE) préservé et testé. Aucune PII dans `DATAGOUV_FIELDS` (pas de téléphone / identity_key /
travelpass), aucun montant privé (seul `has_incentive` booléen). Lecture depuis `zone_exposed`
uniquement ; stats allégées sans re-scan des positions. L'arrondi des positions GPS vit dans la
vue `export_opendata` (amont, non modifiée) — couvert par la validation contrat en follow-up.