### PR TITLE
fix(datalake): aligne cee_application de l'export sur le format CSV historique

### DIFF
--- a/datalake/models/exposed/export/export_partners.sql
+++ b/datalake/models/exposed/export/export_partners.sql
@@ -176,7 +176,8 @@ SELECT
   c.passenger_contribution::float
   / 100
     AS passenger_contribution,
-  cee._id IS NOT NULL
+  -- '1'/'' reproduit le rendu csv-stringify de l'export API (cast booléen -> "1"/"")
+  CASE WHEN cee._id IS NOT NULL THEN '1' ELSE '' END
     AS cee_application,
   c.oi_details[0]
   ->> 'siret'

--- a/datalake/models/exposed/export/yml/_export_partners.yml
+++ b/datalake/models/exposed/export/yml/_export_partners.yml
@@ -123,7 +123,7 @@ models:
       - name: passenger_seats
         data_type: smallint
       - name: cee_application
-        data_type: boolean
+        data_type: text
       - name: incentive_type
         data_type: text
       - name: incentive_0_siret

--- a/datalake/tests/exposed/export/export_partners_cee_application_format.sql
+++ b/datalake/tests/exposed/export/export_partners_cee_application_format.sql
@@ -1,0 +1,9 @@
+{{ config(severity='error', tags=['exposed', 'export']) }}
+
+-- cee_application doit rester au format CSV historique '1'/'' (contrat partenaire),
+-- pas le rendu booleen 't'/'f' de COPY. Fenetre bornee pour limiter le cout FDW.
+SELECT cee_application
+FROM {{ ref('export_partners') }}
+WHERE start_datetime_tz >= CURRENT_DATE - INTERVAL '90 days'
+  AND cee_application IS DISTINCT FROM '1'
+  AND cee_application IS DISTINCT FROM ''

--- a/docs/superpowers/specs/2026-07-07-on-demand-export-datalake-migration-design.md
+++ b/docs/superpowers/specs/2026-07-07-on-demand-export-datalake-migration-design.md
@@ -135,6 +135,14 @@ Live queue targets are **operator** and **territory** only (`datagouv` is an unr
 8. **Do NOT delete `export_opendata_list` in this migration.** `datagouvListQuery.ts` still reads it and the monthly data.gouv publication stays on the API until the separate later spec. Task-8 deletion is limited to `export_carpool_list` (+ the count query, which dies with `progress`).
 9. **Pod ephemeral disk.** Large exports write CSV + zip to local pod disk before upload — size the ephemeral storage or stream to S3 multipart.
 
+## Contract diff — result (blocking task 2, resolved)
+
+Ran the three-way diff against `datalake_production` on settled ranges (2023-08-07 = jour avec CEE, 2026-06-15 = sans). All 64 `operator`-target columns resolve, order + header names match `config/export.ts` `fields`. After parsing the CSV (quotes removed), **one** material value drift:
+
+- **`cee_application`.** The API's `CSVWriter` casts the boolean via `csv-stringify` (default cast `value ? "1" : ""`) → **`1` / empty**. Raw `COPY … FORMAT CSV` renders a Postgres boolean as **`t` / `f`** — a real break for any partner parser matching on the value. **Fix:** `export_partners` now emits `CASE WHEN cee._id IS NOT NULL THEN '1' ELSE '' END` (column type `text`), guarded by `tests/exposed/export/export_partners_cee_application_format.sql`.
+- **False positive — coordinates.** An apparent `6.47` vs `6.470` drift was an artefact of the validation harness (JSON round-trip coerces `numeric` to a JS number, dropping the trailing zero). The old sqlmesh model uses the identical `TRUNC(…::numeric, precision)`; node-postgres returns `numeric` as a string, so the live output is `6.470` too. No drift.
+- **Accepted cosmetic delta — quoting.** `CSVWriter` sets `quoted_string: true` (every string cell + header name quoted); `COPY` quotes minimally. Both are valid RFC-4180 CSV with the same `;` delimiter, columns, order and values, so downstream CSV parsers are unaffected. Exact parity is not reproducible via `COPY` anyway (it never quotes the header). Left as-is; revisit with `FORCE_QUOTE` only if a partner needs byte-level quoting.
+
 ## Datalake DB migration runner (deploy-time)
 
 dbt manages models (tables/views) but **not** the prerequisite DB objects the models assume — custom functions (`ts_ceil`), grants, etc. Local setup proved these are unmanaged (a fresh DB can't build the export models). A lightweight runner owns that layer:


### PR DESCRIPTION
## Contexte

Migration des exports à la demande vers le datalake. Le worker produit le CSV via
`COPY ... FORMAT CSV` (moteur Postgres), là où l'export historique de l'API sérialise via
`csv-stringify` (JS). Le **diff de contrat** (tâche bloquante) a comparé les deux sorties sur
des plages figées de `datalake_production`.

## Résultat du diff de contrat

- **64 colonnes** (cible `operator`) résolues ; ordre + noms d'en-tête identiques à
  `api/.../config/export.ts` `fields`.
- **Une seule divergence matérielle : `cee_application`.**
  - API (`csv-stringify`, cast booléen par défaut `value ? "1" : ""`) → `1` / vide.
  - `COPY` (booléen Postgres) → `t` / `f` — casse tout parseur partenaire qui teste la valeur.
- **Faux positif écarté** : un écart apparent `6.47` vs `6.470` (lat/lon) était un artefact du
  harnais de validation (round-trip JSON qui coerce `numeric` → nombre JS et perd le zéro
  final). Le modèle sqlmesh d'origine utilise le même `TRUNC(::numeric, precision)` et
  node-postgres renvoie les `numeric` en chaîne → sortie live identique. Aucune dérive.
- **Delta cosmétique accepté** : quoting (`quoted_string:true` côté API : toutes les chaînes +
  l'en-tête quotés ; `COPY` quote au minimum). CSV RFC-4180 valide des deux côtés, mêmes
  colonnes/ordre/valeurs/délimiteur `;`. Parité exacte non reproductible via `COPY` (il ne
  quote jamais l'en-tête). Laissé tel quel ; `FORCE_QUOTE` seulement si un partenaire l'exige.

## Changement

- `datalake/models/exposed/export/export_partners.sql` : `cee_application` émet
  `CASE WHEN cee._id IS NOT NULL THEN '1' ELSE '' END` (texte) au lieu du booléen.
- `datalake/models/exposed/export/yml/_export_partners.yml` : `data_type` `boolean` → `text`.
- `datalake/tests/exposed/export/export_partners_cee_application_format.sql` : test dbt
  singulier, garde-fou contre le retour au rendu booléen (fenêtre bornée pour le coût FDW).
- Spec : résultat du diff de contrat consigné.

## Validation

Vue patchée exécutée en CTE (lecture seule) sur `datalake_production` :

- 2023-08-07 (jour avec dossiers CEE) → lignes `1` **et** vides présentes.
- 2026-06-15 (jour sans dossier CEE) → uniquement des valeurs vides.

## Sécurité

**PASS** (non bloquant, risque LOW). SQL statique sans interpolation d'entrée
(injection : RAS). Aucune nouvelle colonne exposée — `cee_application` change seulement de
représentation (booléen → `'1'`/`''`), toujours un simple indicateur de présence d'un dossier
CEE déjà exporté (PII : RAS). Aucun secret, aucun contrôle d'accès touché.

## CGU

**PASS** (bloquant). Aucune mutation de statut (règle 48 h), aucune modification de
conservation/purge, aucune donnée personnelle nouvellement exposée. Le changement est un pur
format de rendu sur une colonne existante.

## Déploiement / release

Data-only (scope `datalake`) : **pas de release applicative**. L'image datalake se reconstruit
via `deploy-datalake.yml` sur modification de `datalake/**` ; la vue est (re)créée au prochain
`dbt run` de la couche exposée (backfill en cours).
