### PR TITLE
feat(datalake): invalide le cache observatoire après reconstruction de la zone exposée

### DIFF
--- a/datalake/justfile
+++ b/datalake/justfile
@@ -122,3 +122,12 @@ pipeline-trusted-geo *args:
 # Pipeline 3 : daily update:
 pipeline-daily *args:
   just dbt run --select "tag:daily" {{args}}
+
+# Invalide le cache de l'API observatoire (INCR obs:cache:version). No-op sans REDIS_URL.
+cache-bump:
+  python -m pipelines.cmd.cache_bump
+
+# Pipeline 4 : zone exposée + invalidation du cache observatoire (appel unique côté ops).
+pipeline-exposed *args:
+  just dbt run --select "models/exposed" {{args}}
+  just cache-bump

--- a/datalake/pipelines/cmd/cache_bump.py
+++ b/datalake/pipelines/cmd/cache_bump.py
@@ -1,0 +1,22 @@
+"""Invalide le cache de l'API observatoire (INCR obs:cache:version).
+
+À lancer après la (re)construction de la zone exposée : `just cache-bump`, ou enchaîné
+par `just pipeline-exposed`.
+"""
+
+import typer
+from dotenv import load_dotenv
+
+from pipelines.helpers.cache import bump_publication_version
+
+load_dotenv()
+app = typer.Typer()
+
+
+@app.command()
+def run():
+    bump_publication_version()
+
+
+if __name__ == "__main__":
+    app()

--- a/datalake/pipelines/helpers/cache.py
+++ b/datalake/pipelines/helpers/cache.py
@@ -1,0 +1,46 @@
+"""Invalidation du cache de l'API observatoire (api-datalake).
+
+L'API embarque un compteur `obs:cache:version` dans ses clés de cache Redis. Après
+chaque (re)construction de la zone exposée, le pipeline incrémente ce compteur : les
+anciennes entrées deviennent inatteignables et expirent par TTL.
+
+La clé DOIT rester identique à `api_datalake.cache._VERSION_KEY`.
+"""
+
+import os
+
+# Doit correspondre à api_datalake.cache._VERSION_KEY.
+VERSION_KEY = "obs:cache:version"
+
+
+def build_client():
+    """Client Redis depuis l'environnement, ou None si `REDIS_URL` absent (cache off).
+
+    Pour un URL `rediss://`, vérifie le TLS contre la CA privée `REDIS_CA` (PEM en
+    mémoire) — jamais de vérification désactivée. Symétrique de l'ouverture côté API.
+    """
+    url = os.getenv("REDIS_URL")
+    if not url:
+        return None
+    import redis
+
+    kwargs = {}
+    ca = os.getenv("REDIS_CA")
+    if url.startswith("rediss://") and ca:
+        kwargs["ssl_ca_data"] = ca
+    return redis.from_url(url, **kwargs)
+
+
+def bump_publication_version(client=None) -> int | None:
+    """Incrémente `obs:cache:version`. No-op (renvoie None) si le cache est désactivé.
+
+    `INCR` sur une clé absente part de 0 -> 1 (l'API a `0` par défaut, donc la
+    première publication invalide bien le cache).
+    """
+    client = client or build_client()
+    if client is None:
+        print("ℹ️ REDIS_URL absent — pas d'invalidation de cache")
+        return None
+    version = client.incr(VERSION_KEY)
+    print(f"✅ cache observatoire invalidé (obs:cache:version = {version})")
+    return version

--- a/datalake/pyproject.toml
+++ b/datalake/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "duckdb>=1.5.0",
     "typer>=0.24.1",
     "psycopg[binary]>=3.2",
+    "redis>=6",
 ]
 
 [dependency-groups]

--- a/datalake/tests/test_cache_bump.py
+++ b/datalake/tests/test_cache_bump.py
@@ -1,0 +1,68 @@
+import pipelines.helpers.cache as cache
+from pipelines.helpers.cache import VERSION_KEY, bump_publication_version, build_client
+
+
+class FakeRedis:
+    def __init__(self, start=0):
+        self.store = {}
+        self._start = start
+
+    def incr(self, key):
+        self.store[key] = self.store.get(key, self._start) + 1
+        return self.store[key]
+
+
+def test_version_key_matches_api():
+    # invariant : la clé doit rester identique à api_datalake.cache._VERSION_KEY
+    assert VERSION_KEY == "obs:cache:version"
+
+
+def test_bump_increments_the_version_key():
+    r = FakeRedis()
+    assert bump_publication_version(r) == 1
+    assert bump_publication_version(r) == 2
+    assert r.store == {"obs:cache:version": 2}
+
+
+def test_bump_is_noop_when_cache_disabled(monkeypatch):
+    # REDIS_URL absent -> build_client renvoie None -> bump no-op
+    monkeypatch.delenv("REDIS_URL", raising=False)
+    assert bump_publication_version() is None
+
+
+def test_build_client_none_without_url(monkeypatch):
+    monkeypatch.delenv("REDIS_URL", raising=False)
+    assert build_client() is None
+
+
+def test_build_client_passes_ca_for_rediss(monkeypatch):
+    captured = {}
+
+    class FakeRedisModule:
+        @staticmethod
+        def from_url(url, **kwargs):
+            captured["url"] = url
+            captured["kwargs"] = kwargs
+            return object()
+
+    monkeypatch.setenv("REDIS_URL", "rediss://u:p@h:6379/2")
+    monkeypatch.setenv("REDIS_CA", "-----BEGIN CERTIFICATE-----\nX\n-----END CERTIFICATE-----")
+    monkeypatch.setitem(__import__("sys").modules, "redis", FakeRedisModule)
+    build_client()
+    assert captured["kwargs"].get("ssl_ca_data").startswith("-----BEGIN")
+
+
+def test_build_client_no_tls_args_for_plain_url(monkeypatch):
+    captured = {}
+
+    class FakeRedisModule:
+        @staticmethod
+        def from_url(url, **kwargs):
+            captured["kwargs"] = kwargs
+            return object()
+
+    monkeypatch.setenv("REDIS_URL", "redis://h:6379/0")
+    monkeypatch.delenv("REDIS_CA", raising=False)
+    monkeypatch.setitem(__import__("sys").modules, "redis", FakeRedisModule)
+    build_client()
+    assert "ssl_ca_data" not in captured["kwargs"]

--- a/datalake/uv.lock
+++ b/datalake/uv.lock
@@ -1067,6 +1067,15 @@ wheels = [
 ]
 
 [[package]]
+name = "redis"
+version = "8.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cc/c3/928b290c2c0ca99ab96eea5b4ff8f30be8112b075301a7d3ba214a3c8c12/redis-8.0.1.tar.gz", hash = "sha256:afc5a7a2f5a084f5b1880dec548dd45be17db7e43c82a30d84f952aefb05cfb0", size = 5114170, upload-time = "2026-06-23T14:52:37.728Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/0a/c2345ebf1ebe70840ce3f6c6ee612f8fa749cfbd1b03069c53bf0c62aaad/redis-8.0.1-py3-none-any.whl", hash = "sha256:47daa35a058c23468d6437f17a8c76882cb316b838ef763036af99b96cedd743", size = 502406, upload-time = "2026-06-23T14:52:36.137Z" },
+]
+
+[[package]]
 name = "referencing"
 version = "0.37.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1191,6 +1200,7 @@ dependencies = [
     { name = "duckdb" },
     { name = "psycopg", extra = ["binary"] },
     { name = "python-dotenv" },
+    { name = "redis" },
     { name = "requests" },
     { name = "typer" },
 ]
@@ -1211,6 +1221,7 @@ requires-dist = [
     { name = "duckdb", specifier = ">=1.5.0" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.2" },
     { name = "python-dotenv", specifier = ">=1.2.1" },
+    { name = "redis", specifier = ">=6" },
     { name = "requests", specifier = ">=2.32.5" },
     { name = "typer", specifier = ">=0.24.1" },
 ]


### PR DESCRIPTION
## Contexte

L'API observatoire (`api-datalake`) sert ses réponses depuis un cache Redis dont les clés
embarquent un compteur de version, `obs:cache:version`. Tant que ce compteur ne bouge pas,
l'API peut servir les données d'une **publication précédente** jusqu'à expiration du TTL.
Il manquait le maillon côté pipeline : incrémenter ce compteur **après** la reconstruction
de la zone exposée.

## Ce que contient la PR

- **`pipelines/helpers/cache.py`** — `bump_publication_version()` = `INCR obs:cache:version`
  (clé identique à `api_datalake.cache._VERSION_KEY`). La connexion réutilise le schéma de
  l'API : `rediss://` + CA privée (`REDIS_CA`, PEM en mémoire), vérification TLS jamais
  désactivée ; **no-op** si `REDIS_URL` est absent (cache désactivé).
- **`pipelines/cmd/cache_bump.py`** + **`just cache-bump`**.
- **`just pipeline-exposed`** : reconstruit `models/exposed` puis invalide le cache — un
  seul appel côté ops enchaîne publication + invalidation.
- Nouvelle dépendance **`redis`** (justifiée : TLS + CA, comme l'API).

## Tests

6 tests unitaires : incrément du compteur, invariant de la clé (= côté API), no-op sans
`REDIS_URL`, `ssl_ca_data` passé pour `rediss://` et absent en clair. Suite datalake
complète : 58 passés, 2 skips (pré-existants). Python pur → n'affecte pas les jobs CI
datalake (dbt parse / sqlfluff).

## Portée & déploiement

PR **data-only** (`datalake/**`) → **ne déclenche aucune release** (attendu ; le pipeline
tourne dans l'image datalake). Côté ops : appeler `just pipeline-exposed` (ou `just
cache-bump` après le run exposé), avec `REDIS_URL`/`REDIS_CA` fournis au pod.

## Sécurité (relecture — PASS)

TLS jamais désactivé (pas de `ssl_cert_reqs=none`) : `ssl_ca_data` uniquement pour
`rediss://`, symétrique de l'API ; `rediss://` sans CA échoue **en fermé** (pas de
dégradation silencieuse). Secrets (`REDIS_URL`/`REDIS_CA`) depuis l'env, jamais committés
ni journalisés (les `print` n'émettent que le numéro de version). `INCR` sur une clé
constante (pas d'injection). Dépendance `redis==8.0.1` (PyPI, hash épinglé). No-op sûr sans
`REDIS_URL`.

Constat mineur (pas d'action) : `INCR` non entouré d'un `try/except` → une panne Redis fait
échouer l'étape. **Choix délibéré** : une invalidation ratée signifie des données périmées
servies aux utilisateurs ; l'échec doit être visible, pas avalé (côté API, la lecture reste
tolérante — `publication_version` retombe sur `0`).

## CGU (garde-fou — PASS)

Aucune donnée de trajet, PII ou secret : le changement se limite à un compteur entier Redis
et à des `print` d'un numéro de version. Aucune écriture DB, aucun statut de trajet touché.