### PR TITLE
fix(datalake): parité export — lat/lon en float, oi_details depuis le registre

### DIFF
--- a/datalake/models/exposed/export/export_partners.sql
+++ b/datalake/models/exposed/export/export_partners.sql
@@ -159,14 +159,15 @@ SELECT
   / 1000
     AS distance,
 
-  trunc(st_y(sc.start_position::geometry)::numeric, gps.precision)
+  -- ::float8 : rendu csv de l'API (numeric tronque -> float, sans zeros)
+  trunc(st_y(sc.start_position::geometry)::numeric, gps.precision)::float8
     AS start_lat,
-  trunc(st_x(sc.start_position::geometry)::numeric, gps.precision)
+  trunc(st_x(sc.start_position::geometry)::numeric, gps.precision)::float8
     AS start_lon,
-  trunc(st_y(sc.end_position::geometry)::numeric, gpe.precision)
+  trunc(st_y(sc.end_position::geometry)::numeric, gpe.precision)::float8
     AS end_lat,
 
-  trunc(st_x(sc.end_position::geometry)::numeric, gpe.precision)
+  trunc(st_x(sc.end_position::geometry)::numeric, gpe.precision)::float8
     AS end_lon,
 
   -- operator incentives (spread from JSONB array)
@@ -176,7 +177,7 @@ SELECT
   c.passenger_contribution::float
   / 100
     AS passenger_contribution,
-  -- '1'/'' reproduit le rendu csv-stringify de l'export API (cast booléen -> "1"/"")
+  -- '1'/'' reproduit le rendu csv-stringify de l'API (cast booleen -> "1"/"")
   CASE WHEN cee._id IS NOT NULL THEN '1' ELSE '' END
     AS cee_application,
   c.oi_details[0]
@@ -266,5 +267,7 @@ LEFT JOIN
   ON c._id = sc._id
 LEFT JOIN latest_perimeters AS gps ON c.start_geo_code = gps.arr
 LEFT JOIN latest_perimeters AS gpe ON c.end_geo_code = gpe.arr
-LEFT JOIN {{ ref('cee') }} AS cee ON c._id = cee.carpool_v2_id
+LEFT JOIN
+  {{ ref('cee') }} AS cee
+  ON c._id = cee.carpool_v2_id
 WHERE c.valid_acquisition_status = TRUE

--- a/datalake/models/exposed/export/yml/_export_partners.yml
+++ b/datalake/models/exposed/export/yml/_export_partners.yml
@@ -43,13 +43,13 @@ models:
       - name: distance
         data_type: double precision
       - name: start_lat
-        data_type: numeric
+        data_type: double precision
       - name: start_lon
-        data_type: numeric
+        data_type: double precision
       - name: end_lat
-        data_type: numeric
+        data_type: double precision
       - name: end_lon
-        data_type: numeric
+        data_type: double precision
       - name: start_insee
         data_type: character varying
       - name: start_arr

--- a/datalake/models/trusted/carpools.sql
+++ b/datalake/models/trusted/carpools.sql
@@ -74,12 +74,14 @@ terms_violation_error_labels AS (
 ),
 
 operators AS (
-    SELECT DISTINCT left(siret, 9) AS code, name AS libelle
+    -- classification par SIREN (le nom vient du registre entreprises)
+    SELECT DISTINCT left(siret, 9) AS code
     FROM {{ source('dlk_import', 'operator_operators') }}
 ),
 
 collectivites AS (
-    SELECT DISTINCT code, libelle
+    -- 1 libelle/code (millesimes homonymes) sinon le LEFT JOIN fanne oi_details
+    SELECT DISTINCT code
     FROM {{ ref('perimeters_agg') }}
     WHERE type IN ('epci', 'aom')
 ),
@@ -98,13 +100,15 @@ operator_incentives_agg AS (
             jsonb_build_object(
                 'siret', oi.siret,
                 'type', CASE WHEN c.code IS NOT NULL THEN 'collectivite' WHEN op.code IS NOT NULL THEN 'operator' ELSE 'other' END,
-                'name', CASE WHEN c.code IS NOT NULL THEN c.libelle WHEN op.code IS NOT NULL THEN op.libelle ELSE NULL END,
+                'name', comp.legal_name,
                 'amount', oi.amount
             )
+            ORDER BY oi.siret
         ) AS oi_details
     FROM {{ ref('operator_incentives') }} oi
     LEFT JOIN operators op ON op.code = left(oi.siret, 9)
     LEFT JOIN collectivites c ON c.code = left(oi.siret, 9)
+    LEFT JOIN {{ source('dlk_import', 'company_companies') }} comp ON comp.siret = oi.siret
     WHERE {{ time_filter('oi.start_datetime', 'start_datetime', lookback_nb=3) }}
         AND oi.amount > 0
     GROUP BY 1


### PR DESCRIPTION
## Contexte

Correctifs trouvés en **rejouant un vrai export S3 sur le nouveau système** et en le
comparant au fichier CSV produit par l'API. Export témoin : un export territoire réel de petite
taille. PR **indépendante** du cutover (#3277) et du fix `cee_application` (#3275).

## Résultat de la comparaison

- **Row-set : parité parfaite** — mêmes lignes, mêmes `journey_id`, en-tête identique.
- **65 colonnes identiques** après les 2 correctifs ci-dessous, à l'exception d'une minorité de
  lignes de `incentive_0_name` : vides côté API (valeur figée avant mise à jour du registre),
  remplies côté datalake (registre actuel). C'est de la **fraîcheur de donnée, pas un écart
  de logique** — le datalake est plus complet.

## Correctifs

### 1. lat/lon en `float` (`export_partners.sql` + yml)

`trunc(…::numeric, precision)` conserve l'échelle (`-4.450`), alors que l'export API rend un
**float sans zéros de fin** (`-4.45`), comme `distance` et `driver_revenue` déjà en float.
Cast `::float8` sur les 4 colonnes ; type yml aligné sur `double precision`.

### 2. `oi_details` : nom depuis le registre + anti fan-out (`trusted/carpools.sql`)

- **Nom d'incitation** : vient désormais de `company_companies.legal_name` joint sur le
  **SIRET complet**, comme l'export sqlmesh d'origine (`LEFT JOIN company.companies … legal_name`),
  au lieu du libellé de périmètre.
- **Fan-out éliminé** : `collectivites`/`operators` étaient joints sur `left(siret, 9)` (SIREN)
  contre des tables **non uniques par code** — un même SIREN portant plusieurs libellés
  (EPCI/AOM homonymes : **1247/1407 codes** concernés) faisait fanner le `LEFT JOIN`, ce qui
  **dupliquait `oi_details`** (colonne `incentive_1_*` remplie à tort) **et doublait**
  `oi_amount_collectivite` / `oi_collectivite`. Les CTE sont réduites à `code` seul (elles ne
  servaient qu'à la classification `type`) → jointure 1:1.

Le bug dépassait l'export : il corrompait les **agrégats d'incitations** du modèle trusted
`carpools`. Validé au niveau source : après correctif, `oi_amount_collectivite` et
`oi_collectivite` ne sont plus doublés (valeur simple au lieu du double), et `oi_details` ne
contient plus qu'une seule entrée par incitation, avec le `legal_name`.

## Validation

- Requête exacte du worker rejouée via un vrai `COPY … FORMAT CSV` contre la prod (vue
  `export_partners` compilée à la main, la vue n'étant pas encore matérialisée).
- Diff clé par `journey_id` : **0 écart** hors les quelques lignes de fraîcheur registre.
- **Pas de fan-out inverse** : `company_companies.siret` est **unique** (0 doublon vérifié en
  prod) → le nouveau `LEFT JOIN` reste 1:1.

## Séquencement

- Scope `datalake` → **pas de release applicative** (data-only ; ni gate 1 fichiers `api/**`,
  ni gate 2 scope). Correct.
- Prend effet au **rebuild de `zone_trusted.carpools`** (le backfill en cours le fera).

## Sécurité

**PASS** (risque LOW). Aucune surface d'injection (toute interpolation passe par des macros dbt
résolues à la compilation). Le `LEFT JOIN company_companies` **ne peut pas fanner** :
`company.companies.siret` porte un index **UNIQUE** (`companies_siret_idx`) → jointure 1:1 ;
au contraire, le correctif **supprime** un vrai fan-out préexistant. `ORDER BY oi.siret` rend la
sortie déterministe (reproductibilité de l'export). Seul point d'attention (informationnel,
donnée open-data) : `legal_name` peut coïncider avec un nom de personne pour un auto-entrepreneur —
champ `name` déjà présent auparavant, risque résiduel faible. Changement sémantique du `name`
`collectivite` (registre vs libellé périmètre) : volontaire, conforme au contrat de l'export API.

## CGU

**PASS** (bloquant, aucun écart). Aucune mutation de statut de trajet, aucune modification de
conservation/purge, aucune PII exposée : les casts `::float8` ne changent que la représentation
numérique (la troncature géo `trunc(…, precision)` est préservée), et `legal_name` provient du
registre entreprises **public** (SIRENE), rattaché à un SIRET d'émetteur d'incitation
(opérateur/collectivité), pas à une personne physique. Aucun secret/PII en dur.

_Note qualité (hors périmètre CGU)_ : `comp.legal_name` peut être `NULL` si un SIRET est absent
de `company_companies` → surveiller le taux de couverture pour éviter des noms manquants.
