### PR TITLE
feat(datalake): endpoints observatoire agrégés dans api-datalake (flux, occupation, distribution, incentive, keyfigures, infra)

### DIFF
--- a/api-datalake/README.md
+++ b/api-datalake/README.md
@@ -62,16 +62,26 @@ just test              # pytest
 > modèles qui lisent `zone_trusted`/`zone_raw`, jamais l'API.
 
 - [x] Squelette FastAPI + cache + fenêtre de publication
-- [x] Modèles dbt `zone_exposed.{location, observatory_perimeters, campaigns}` — validés sur prod
-- [x] `GET /observatory/location` — heatmap H3, cache Redis gzip (SQL validé sur prod)
-- [x] `GET /observatory/campaigns` — campagnes d'incitation + géométrie (SQL validé sur prod)
-- [~] `GET /observatory/last-record` (canari) → `zone_exposed.od_month`
-      (**bloqué** : `zone_aggregated`/`zone_exposed.od_*` pas encore matérialisés en prod)
-- [ ] Endpoints `flux`, `incentive`, `distribution`, `occupation`, `keyfigures`, `infra`
-      (bloqués sur la matérialisation de l'agrégé/exposé)
+- [x] Modèles dbt `zone_exposed.{location, observatory_perimeters, campaigns, aires_covoiturage}` — validés sur prod
+- [x] `GET /observatory/location`, `campaigns`, `last-record`
+- [x] **Endpoints agrégés** : `flux`, `best-flux`, `evol-flux`, `incentive`,
+      `occupation`, `best-territories`, `evol-occupation`, `journeys-by-hours`,
+      `journeys-by-distances`, `keyfigures`, `aires-covoiturage`
+      (code + tests ; validation données au fil de la matérialisation de l'exposé)
 - [ ] Repointage `app-observatory` puis décommission du service Deno
 
-> **Note prod** : au moment du dev, seuls `dlk_import`/`zone_raw`/`zone_trusted` sont
-> construits en base. `location`, `perimeters` et `campaigns` dérivent de `zone_trusted`/
-> `zone_raw` (dispos), d'où leur validation immédiate ; les endpoints agrégés attendent
-> `dbt run --select aggregated exposed`.
+> **Note prod** : les endpoints agrégés lisent `zone_exposed.{od,occupation,distribution,
+> incentive,users}_*`, matérialisés par le pipeline dbt (`dbt run --select aggregated exposed`).
+> La parité des flux a été validée à ~91 % (région/dép) et 100 % (commune) contre l'API en
+> ligne au grain agrégé ; les endpoints reproduisent cette donnée.
+
+### Limites connues (endpoints agrégés)
+
+- **`direction`** : les modèles exposés `occupation`/`incentive`/`users` viennent de
+  `territory_month_*_both` → **direction `both` uniquement**. Le filtre `direction=from|to`
+  du legacy est ignoré (émis en dur `both`). `distribution` a bien la dimension direction.
+- **`keyfigures`** : recomposition (od + occupation + users), direction `both` — pas de
+  modèle exposé dédié.
+- **`evol-flux` indic `has_incentive`** : absent de `od_*` → retombe sur `journeys`.
+- **Libellés EPCI/AOM** : forme IGN 2025 abrégée, différente du legacy (décision équipe en
+  cours) — voir la tâche Notion dédiée.

--- a/api-datalake/src/api_datalake/observatory_sql.py
+++ b/api-datalake/src/api_datalake/observatory_sql.py
@@ -1,0 +1,62 @@
+"""Fragments SQL partagés des endpoints observatoire.
+
+Deux briques réutilisées par toutes les familles (flux, occupation, distribution,
+incentive, keyfigures) :
+
+- `resolve_grain` : choix du suffixe de table selon le param temporel présent
+  (priorité month > trimester > semester > year), avec le renommage legacy
+  `trimester` -> table `quarter` côté datalake.
+- `perimeter_in_subquery` : porte la sous-requête `code IN (SELECT <observe> FROM
+  geo.perimeters WHERE <type>=<code>)` de l'API Deno vers `zone_exposed.observatory_perimeters`
+  (l'API ne lit que la zone exposée). Le millésime reproduit `get_latest_millesime_or`.
+
+`type`/`observe` sont des **noms de colonnes** interpolés : ils sont validés par
+`check_territory_param` (allowlist) avant d'arriver ici. Les valeurs (year, code, …)
+sont passées en paramètres psycopg `%(...)s`.
+"""
+
+PERIMETERS_TABLE = "zone_exposed.observatory_perimeters"
+
+
+def resolve_grain(month: int | None, trimester: int | None,
+                  semester: int | None) -> tuple[str, str | None, int | None]:
+    """(suffixe_table, colonne_temporelle, valeur) selon le grain demandé.
+
+    Priorité stricte month > trimester > semester > year (comme getTableName).
+    Le suffixe suit les tables datalake : month/quarter/semester/year.
+    """
+    if month is not None:
+        return "month", "month", month
+    if trimester is not None:
+        return "quarter", "quarter", trimester
+    if semester is not None:
+        return "semester", "semester", semester
+    return "year", None, None
+
+
+def perimeter_in_subquery(observe_col: str, type_col: str) -> str:
+    """Sous-requête `IN (...)` des codes `observe` contenus dans (type=code).
+
+    Reproduit `SELECT arr AS com, epci, ... FROM geo.perimeters` de l'API Deno,
+    en lisant `zone_exposed.observatory_perimeters`. Le millésime = celui de l'année
+    demandée s'il existe, sinon le plus récent (get_latest_millesime_or).
+
+    `observe_col`/`type_col` doivent être pré-validés (allowlist territoire).
+    """
+    return f"""(
+      SELECT t.{observe_col}
+      FROM (
+        SELECT arr AS com, epci, aom, dep, reg, country
+        FROM {PERIMETERS_TABLE}
+        WHERE year = (
+          SELECT year FROM (
+            SELECT max(year) AS year FROM {PERIMETERS_TABLE} WHERE year = %(year)s
+            UNION ALL
+            SELECT max(year) AS year FROM {PERIMETERS_TABLE}
+            ORDER BY year
+            LIMIT 1
+          ) m
+        )
+      ) t
+      WHERE t.{type_col} = %(code)s
+    )"""

--- a/api-datalake/src/api_datalake/repositories/observatory_aggregated.py
+++ b/api-datalake/src/api_datalake/repositories/observatory_aggregated.py
@@ -1,0 +1,363 @@
+"""Requêtes des endpoints observatoire agrégés (flux, occupation, distribution,
+incentive, keyfigures, infra) sur la zone exposée.
+
+Porté depuis `api/src/pdc/services/observatory/providers/*`. Chaque `build_*`
+renvoie `(sql, params)` — pur et testable sans base. Les valeurs sont liées
+(`%(...)s`) ; `type`/`observe`/`indic` sont des noms de colonnes interpolés,
+validés par allowlist avant d'arriver ici (défense contre l'injection).
+
+Différences structurelles avec le legacy, assumées et documentées :
+- Les modèles exposés `occupation_*`, `incentive_*`, `users_*` proviennent de
+  `territory_month_<type>_both` : ils n'ont **pas** de dimension `direction`
+  (direction = `both` seulement). Le filtre `direction` legacy est donc ignoré
+  pour ces familles ; `direction='both'` est émis en dur pour préserver la forme.
+- Le grain `trimester` (param API) mappe la table `_quarter` (colonne `quarter`).
+"""
+
+from ..helpers import check_territory_param
+from ..observatory_sql import perimeter_in_subquery, resolve_grain
+
+# indics interpolés (noms de colonnes) -> allowlist par famille, fallback legacy.
+_FLUX_INDICS = ("journeys", "passengers", "distance", "duration")
+_OCCUPATION_INDICS = ("journeys", "trips", "has_incentive", "occupation_rate")
+
+
+def _check_indic(indic: str | None, allowed: tuple[str, ...]) -> str:
+    return indic if indic in allowed else "journeys"
+
+
+def normalize_flux_indic(indic: str | None) -> str:
+    """indic de flux normalisé (allowlist) — pour la clé de cache et le SQL."""
+    return _check_indic(indic, _FLUX_INDICS)
+
+
+def normalize_occupation_indic(indic: str | None) -> str:
+    return _check_indic(indic, _OCCUPATION_INDICS)
+
+
+async def fetch(conn, sql: str, params: dict) -> list[dict]:
+    async with conn.cursor() as cur:
+        await cur.execute(sql, params)
+        return list(await cur.fetchall())
+
+
+# --------------------------------------------------------------------------- #
+# FLUX
+# --------------------------------------------------------------------------- #
+
+def build_flux(type_: str, observe: str, code: str, year: int,
+               month: int | None = None, trimester: int | None = None,
+               semester: int | None = None) -> tuple[str, dict]:
+    """Flux OD entre territoires (porté de getFlux)."""
+    observe = check_territory_param(observe)
+    type_ = check_territory_param(type_)
+    suffix, tcol, tval = resolve_grain(month, trimester, semester)
+    perim = perimeter_in_subquery(observe, type_)
+
+    where = [
+        "type = %(observe)s",
+        "(distance / journeys) <= 80",
+        f"(territory_1 IN {perim} OR territory_2 IN {perim})",
+        "territory_1 <> territory_2",
+        "year = %(year)s",
+    ]
+    params = {"year": year, "code": code, "observe": observe}
+    if tcol:
+        where.append(f"{tcol} = %(tval)s")
+        params["tval"] = tval
+    sql = f"""
+      SELECT
+        l_territory_1 AS ter_1, lng_1, lat_1,
+        l_territory_2 AS ter_2, lng_2, lat_2,
+        passengers, distance, duration
+      FROM zone_exposed.od_{suffix}
+      WHERE {' AND '.join(where)}
+    """
+    return sql, params
+
+
+def build_best_flux(type_: str, code: str, year: int, limit: int = 10,
+                    month: int | None = None, trimester: int | None = None,
+                    semester: int | None = None) -> tuple[str, dict]:
+    """Meilleurs flux d'un territoire (porté de getBestFlux). Périmètre = grain com."""
+    type_ = check_territory_param(type_)
+    suffix, tcol, tval = resolve_grain(month, trimester, semester)
+    perim = perimeter_in_subquery("com", type_)
+
+    where = [
+        "year = %(year)s",
+        f"(territory_1 IN {perim} OR territory_2 IN {perim})",
+    ]
+    params = {"year": year, "code": code, "limit": limit}
+    if tcol:
+        where.append(f"{tcol} = %(tval)s")
+        params["tval"] = tval
+    sql = f"""
+      SELECT DISTINCT territory_1, l_territory_1, territory_2, l_territory_2, journeys
+      FROM zone_exposed.od_{suffix}
+      WHERE {' AND '.join(where)}
+      ORDER BY journeys DESC
+      LIMIT %(limit)s
+    """
+    return sql, params
+
+
+def build_evol_flux(type_: str, code: str, indic: str, past: int = 2,
+                    month: int | None = None, trimester: int | None = None,
+                    semester: int | None = None) -> tuple[str, dict]:
+    """Évolution temporelle d'un indicateur de flux (porté de getEvolFlux).
+
+    Pas de jointure périmètre : filtre direct territory_1/territory_2 = code.
+    `has_incentive` (indic legacy) n'existe pas dans od_* -> retombe sur journeys.
+    """
+    type_ = check_territory_param(type_)
+    indic = _check_indic(indic, _FLUX_INDICS)
+    suffix, tcol, _ = resolve_grain(month, trimester, semester)
+    limit = past * 12 + 1
+
+    cols = ["year", f"sum({indic}::numeric) AS {indic}"]
+    group = ["year"]
+    if tcol:
+        cols.append(tcol)
+        group.append(tcol)
+    if indic == "distance":
+        cols.append("sum(journeys) AS journeys")
+    sql = f"""
+      SELECT {', '.join(cols)}
+      FROM zone_exposed.od_{suffix}
+      WHERE type = %(type)s AND (territory_1 = %(code)s OR territory_2 = %(code)s)
+      GROUP BY {', '.join(group)}
+      ORDER BY ({', '.join(group)}) DESC
+      LIMIT %(limit)s
+    """
+    return sql, {"type": type_, "code": code, "limit": limit}
+
+
+# --------------------------------------------------------------------------- #
+# OCCUPATION
+# --------------------------------------------------------------------------- #
+
+def build_occupation(type_: str, observe: str, code: str, year: int,
+                     month: int | None = None, trimester: int | None = None,
+                     semester: int | None = None) -> tuple[str, dict]:
+    """Taux d'occupation par territoire (porté de getOccupation).
+
+    Le modèle exposé est `both`-only : le filtre `direction` legacy est ignoré.
+    """
+    observe = check_territory_param(observe)
+    type_ = check_territory_param(type_)
+    suffix, tcol, tval = resolve_grain(month, trimester, semester)
+    perim = perimeter_in_subquery(observe, type_)
+
+    where = [
+        "year = %(year)s",
+        "type = %(observe)s",
+        f"code IN {perim}",
+    ]
+    params = {"year": year, "code": code, "observe": observe}
+    if tcol:
+        where.append(f"{tcol} = %(tval)s")
+        params["tval"] = tval
+    sql = f"""
+      SELECT year, type, code, libelle, journeys, occupation_rate, geom
+      FROM zone_exposed.occupation_{suffix}
+      WHERE {' AND '.join(where)}
+    """
+    return sql, params
+
+
+def build_best_territories(type_: str, observe: str, code: str, year: int,
+                           limit: int = 10, month: int | None = None,
+                           trimester: int | None = None,
+                           semester: int | None = None) -> tuple[str, dict]:
+    """Meilleurs territoires par trajets (porté de getBestTerritories, direction=both)."""
+    observe = check_territory_param(observe)
+    type_ = check_territory_param(type_)
+    suffix, tcol, tval = resolve_grain(month, trimester, semester)
+    perim = perimeter_in_subquery(observe, type_)
+
+    where = [
+        "year = %(year)s",
+        "type = %(observe)s",
+        f"code IN {perim}",
+    ]
+    params = {"year": year, "code": code, "limit": limit, "observe": observe}
+    if tcol:
+        where.append(f"{tcol} = %(tval)s")
+        params["tval"] = tval
+    sql = f"""
+      SELECT code, libelle, journeys
+      FROM zone_exposed.occupation_{suffix}
+      WHERE {' AND '.join(where)}
+      ORDER BY journeys DESC
+      LIMIT %(limit)s
+    """
+    return sql, params
+
+
+def build_evol_occupation(type_: str, code: str, indic: str, past: int = 2,
+                          month: int | None = None, trimester: int | None = None,
+                          semester: int | None = None) -> tuple[str, dict]:
+    """Évolution temporelle d'un indicateur d'occupation (porté, direction=both)."""
+    type_ = check_territory_param(type_)
+    indic = _check_indic(indic, _OCCUPATION_INDICS)
+    suffix, tcol, _ = resolve_grain(month, trimester, semester)
+    limit = past * 12 + 1
+
+    cols = ["year", f"{indic}::float AS {indic}"]
+    order = ["year"]
+    if tcol:
+        cols.append(tcol)
+        order.append(tcol)
+    sql = f"""
+      SELECT {', '.join(cols)}
+      FROM zone_exposed.occupation_{suffix}
+      WHERE type = %(type)s AND code = %(code)s
+      ORDER BY ({', '.join(order)}) DESC
+      LIMIT %(limit)s
+    """
+    return sql, {"type": type_, "code": code, "limit": limit}
+
+
+# --------------------------------------------------------------------------- #
+# DISTRIBUTION
+# --------------------------------------------------------------------------- #
+
+def _distribution(column: str, type_: str, code: str, year: int, direction: str | None,
+                  month, trimester, semester) -> tuple[str, dict]:
+    type_ = check_territory_param(type_)
+    suffix, tcol, tval = resolve_grain(month, trimester, semester)
+    where = ["year = %(year)s", "type = %(type)s", "code = %(code)s"]
+    params = {"year": year, "type": type_, "code": code}
+    if direction is not None:
+        where.append("direction = %(direction)s")
+        params["direction"] = direction
+    if tcol:
+        where.append(f"{tcol} = %(tval)s")
+        params["tval"] = tval
+    sql = f"""
+      SELECT code, libelle, direction, {column}
+      FROM zone_exposed.distribution_{suffix}
+      WHERE {' AND '.join(where)}
+    """
+    return sql, params
+
+
+def build_journeys_by_hours(type_: str, code: str, year: int,
+                            month=None, trimester=None, semester=None) -> tuple[str, dict]:
+    """Distribution horaire (porté de getJourneysByHours). Toutes directions."""
+    return _distribution("hours", type_, code, year, None, month, trimester, semester)
+
+
+def build_journeys_by_distances(type_: str, code: str, year: int, direction: str,
+                                month=None, trimester=None, semester=None) -> tuple[str, dict]:
+    """Distribution kilométrique (porté de getJourneysByDistances). Direction requise."""
+    return _distribution("distances", type_, code, year, direction, month, trimester, semester)
+
+
+# --------------------------------------------------------------------------- #
+# INCENTIVE
+# --------------------------------------------------------------------------- #
+
+def build_incentive(type_: str, code: str, year: int,
+                    month=None, trimester=None, semester=None) -> tuple[str, dict]:
+    """Répartition des incitations (porté de getIncentive, direction=both)."""
+    type_ = check_territory_param(type_)
+    suffix, tcol, tval = resolve_grain(month, trimester, semester)
+    where = ["year = %(year)s", "type = %(type)s", "code = %(code)s"]
+    params = {"year": year, "type": type_, "code": code}
+    if tcol:
+        where.append(f"{tcol} = %(tval)s")
+        params["tval"] = tval
+    sql = f"""
+      SELECT code, libelle, 'both'::text AS direction, collectivite, operateur, autres
+      FROM zone_exposed.incentive_{suffix}
+      WHERE {' AND '.join(where)}
+    """
+    return sql, params
+
+
+# --------------------------------------------------------------------------- #
+# KEYFIGURES (recomposition, direction=both)
+# --------------------------------------------------------------------------- #
+
+def build_keyfigures(type_: str, code: str, year: int,
+                     month=None, trimester=None, semester=None) -> tuple[str, dict]:
+    """Chiffres clés d'un territoire (recomposition — pas de modèle exposé dédié).
+
+    Compose od_* (passengers/distance/duration sommés + intra), occupation_*
+    (journeys, occupation_rate, has_incentive) et users_* (new_drivers/passengers).
+    Direction `both` uniquement (modèles exposés sans dimension direction).
+    """
+    type_ = check_territory_param(type_)
+    suffix, tcol, tval = resolve_grain(month, trimester, semester)
+
+    od_time = f"AND {tcol} = %(tval)s" if tcol else ""
+    occ_time = f"AND o.{tcol} = %(tval)s" if tcol else ""
+    users_join_time = f"AND u.{tcol} = o.{tcol}" if tcol else ""
+    params = {"year": year, "type": type_, "code": code}
+    if tcol:
+        params["tval"] = tval
+
+    sql = f"""
+      WITH od_agg AS (
+        SELECT
+          sum(passengers)::int AS passengers,
+          sum(distance)::int   AS distance,
+          sum(duration)::int   AS duration
+        FROM zone_exposed.od_{suffix}
+        WHERE type = %(type)s AND year = %(year)s {od_time}
+          AND (territory_1 = %(code)s OR territory_2 = %(code)s)
+      ),
+      intra AS (
+        SELECT sum(journeys)::int AS intra_journeys
+        FROM zone_exposed.od_{suffix}
+        WHERE type = %(type)s AND year = %(year)s {od_time}
+          AND territory_1 = %(code)s AND territory_2 = %(code)s
+      )
+      SELECT
+        o.code, o.libelle, 'both'::text AS direction,
+        od_agg.passengers, od_agg.distance, od_agg.duration,
+        o.journeys::int AS journeys,
+        intra.intra_journeys,
+        o.has_incentive::int AS has_incentive,
+        o.occupation_rate::float AS occupation_rate,
+        u.new_drivers::int AS new_drivers,
+        u.new_passengers::int AS new_passengers
+      FROM zone_exposed.occupation_{suffix} o
+      LEFT JOIN zone_exposed.users_{suffix} u
+        ON u.type = o.type AND u.year = o.year AND u.code = o.code {users_join_time}
+      CROSS JOIN od_agg
+      CROSS JOIN intra
+      WHERE o.type = %(type)s AND o.code = %(code)s AND o.year = %(year)s {occ_time}
+    """
+    return sql, params
+
+
+# --------------------------------------------------------------------------- #
+# INFRA (aires de covoiturage)
+# --------------------------------------------------------------------------- #
+
+def build_aires_covoiturage(type_: str, code: str | None = None) -> tuple[str, dict]:
+    """Aires de covoiturage ouvertes (porté de getAiresCovoiturage).
+
+    Lit `zone_exposed.aires_covoiturage` (déjà filtré ouvert=true, geom en GeoJSON).
+    Filtre territorial optionnel via `observatory_perimeters` (comme geo.perimeters).
+    """
+    type_ = check_territory_param(type_)
+    where = ["true"]
+    params: dict = {}
+    if code:
+        where.append(f"""insee IN (
+          SELECT arr FROM zone_exposed.observatory_perimeters
+          WHERE year = (SELECT max(year) FROM zone_exposed.observatory_perimeters)
+            AND {type_} = %(code)s
+        )""")
+        params["code"] = code
+    sql = f"""
+      SELECT id_lieu, nom_lieu, com_lieu, type, date_maj,
+             nbre_pl, nbre_pmr, duree, horaires, proprio, lumiere, geom
+      FROM zone_exposed.aires_covoiturage
+      WHERE {' AND '.join(where)}
+    """
+    return sql, params

--- a/api-datalake/src/api_datalake/routers/observatory.py
+++ b/api-datalake/src/api_datalake/routers/observatory.py
@@ -1,5 +1,7 @@
 """Endpoints publics de l'observatoire."""
 
+from typing import Literal
+
 from fastapi import APIRouter, Depends, Query, Response
 
 from ..cache import (
@@ -15,8 +17,11 @@ from ..db import connection
 from ..helpers import check_code_param, check_territory_param
 from ..period import is_published, last_record_cutoff
 from ..repositories import observatory as repo
+from ..repositories import observatory_aggregated as agg
 
 router = APIRouter(prefix="/observatory", tags=["observatory"])
+
+Direction = Literal["from", "to", "both"]
 
 
 async def get_conn():
@@ -112,3 +117,236 @@ async def campaigns(
         redis, "/observatory/campaigns", params,
         lambda: repo.get_campaigns(conn, type, code, year),
     )
+
+
+# --------------------------------------------------------------------------- #
+# Endpoints agrégés (flux, occupation, distribution, incentive, keyfigures, infra)
+# Tous : GET public, réponse gzip cachée. Détail des requêtes dans
+# repositories/observatory_aggregated.py.
+# --------------------------------------------------------------------------- #
+
+
+def _serve_rows(redis, route: str, params: dict, sql: str, sql_params: dict, conn):
+    return _serve_cached(redis, route, params,
+                         lambda: agg.fetch(conn, sql, sql_params))
+
+
+@router.get("/flux")
+async def flux(
+    code: str = Query(..., min_length=1, max_length=15),
+    type: str = Query(...),
+    observe: str = Query(...),
+    year: int = Query(..., ge=2020, le=2100),
+    month: int | None = Query(None, ge=1, le=12),
+    trimester: int | None = Query(None, ge=1, le=4),
+    semester: int | None = Query(None, ge=1, le=2),
+    conn=Depends(get_conn),
+    redis=Depends(get_redis),
+):
+    """Flux OD entre territoires."""
+    check_code_param(code)
+    sql, sp = agg.build_flux(type, observe, code, year, month, trimester, semester)
+    params = {"code": code, "type": check_territory_param(type),
+              "observe": check_territory_param(observe), "year": year,
+              "month": month, "trimester": trimester, "semester": semester}
+    return await _serve_rows(redis, "/observatory/flux", params, sql, sp, conn)
+
+
+@router.get("/best-flux")
+async def best_flux(
+    code: str = Query(..., min_length=1, max_length=15),
+    type: str = Query(...),
+    year: int = Query(..., ge=2020, le=2100),
+    limit: int = Query(10, ge=5, le=100),
+    month: int | None = Query(None, ge=1, le=12),
+    trimester: int | None = Query(None, ge=1, le=4),
+    semester: int | None = Query(None, ge=1, le=2),
+    conn=Depends(get_conn),
+    redis=Depends(get_redis),
+):
+    """Meilleurs flux d'un territoire (top N par trajets)."""
+    check_code_param(code)
+    sql, sp = agg.build_best_flux(type, code, year, limit, month, trimester, semester)
+    params = {"code": code, "type": check_territory_param(type), "year": year,
+              "limit": limit, "month": month, "trimester": trimester, "semester": semester}
+    return await _serve_rows(redis, "/observatory/best-flux", params, sql, sp, conn)
+
+
+@router.get("/evol-flux")
+async def evol_flux(
+    code: str = Query(..., min_length=1, max_length=15),
+    type: str = Query(...),
+    indic: str = Query(..., min_length=1, max_length=32),
+    past: int = Query(2, ge=1, le=5),
+    month: int | None = Query(None, ge=1, le=12),
+    trimester: int | None = Query(None, ge=1, le=4),
+    semester: int | None = Query(None, ge=1, le=2),
+    conn=Depends(get_conn),
+    redis=Depends(get_redis),
+):
+    """Évolution temporelle d'un indicateur de flux."""
+    check_code_param(code)
+    sql, sp = agg.build_evol_flux(type, code, indic, past, month, trimester, semester)
+    params = {"code": code, "type": check_territory_param(type),
+              "indic": agg.normalize_flux_indic(indic),
+              "past": past, "month": month, "trimester": trimester, "semester": semester}
+    return await _serve_rows(redis, "/observatory/evol-flux", params, sql, sp, conn)
+
+
+@router.get("/incentive")
+async def incentive(
+    code: str = Query(..., min_length=1, max_length=15),
+    type: str = Query(...),
+    year: int = Query(..., ge=2020, le=2100),
+    month: int | None = Query(None, ge=1, le=12),
+    trimester: int | None = Query(None, ge=1, le=4),
+    semester: int | None = Query(None, ge=1, le=2),
+    conn=Depends(get_conn),
+    redis=Depends(get_redis),
+):
+    """Répartition des incitations par territoire."""
+    check_code_param(code)
+    sql, sp = agg.build_incentive(type, code, year, month, trimester, semester)
+    params = {"code": code, "type": check_territory_param(type), "year": year,
+              "month": month, "trimester": trimester, "semester": semester}
+    return await _serve_rows(redis, "/observatory/incentive", params, sql, sp, conn)
+
+
+@router.get("/occupation")
+async def occupation(
+    code: str = Query(..., min_length=1, max_length=15),
+    type: str = Query(...),
+    observe: str = Query(...),
+    year: int = Query(..., ge=2020, le=2100),
+    month: int | None = Query(None, ge=1, le=12),
+    trimester: int | None = Query(None, ge=1, le=4),
+    semester: int | None = Query(None, ge=1, le=2),
+    conn=Depends(get_conn),
+    redis=Depends(get_redis),
+):
+    """Taux d'occupation par territoire (avec géométrie)."""
+    check_code_param(code)
+    sql, sp = agg.build_occupation(type, observe, code, year, month, trimester, semester)
+    params = {"code": code, "type": check_territory_param(type),
+              "observe": check_territory_param(observe), "year": year,
+              "month": month, "trimester": trimester, "semester": semester}
+    return await _serve_rows(redis, "/observatory/occupation", params, sql, sp, conn)
+
+
+@router.get("/best-territories")
+async def best_territories(
+    code: str = Query(..., min_length=1, max_length=15),
+    type: str = Query(...),
+    observe: str = Query(...),
+    year: int = Query(..., ge=2020, le=2100),
+    limit: int = Query(10, ge=5, le=100),
+    month: int | None = Query(None, ge=1, le=12),
+    trimester: int | None = Query(None, ge=1, le=4),
+    semester: int | None = Query(None, ge=1, le=2),
+    conn=Depends(get_conn),
+    redis=Depends(get_redis),
+):
+    """Meilleurs territoires par nombre de trajets."""
+    check_code_param(code)
+    sql, sp = agg.build_best_territories(type, observe, code, year, limit,
+                                         month, trimester, semester)
+    params = {"code": code, "type": check_territory_param(type),
+              "observe": check_territory_param(observe), "year": year, "limit": limit,
+              "month": month, "trimester": trimester, "semester": semester}
+    return await _serve_rows(redis, "/observatory/best-territories", params, sql, sp, conn)
+
+
+@router.get("/evol-occupation")
+async def evol_occupation(
+    code: str = Query(..., min_length=1, max_length=15),
+    type: str = Query(...),
+    indic: str = Query(..., min_length=1, max_length=32),
+    past: int = Query(2, ge=1, le=5),
+    month: int | None = Query(None, ge=1, le=12),
+    trimester: int | None = Query(None, ge=1, le=4),
+    semester: int | None = Query(None, ge=1, le=2),
+    conn=Depends(get_conn),
+    redis=Depends(get_redis),
+):
+    """Évolution temporelle d'un indicateur d'occupation."""
+    check_code_param(code)
+    sql, sp = agg.build_evol_occupation(type, code, indic, past, month, trimester, semester)
+    params = {"code": code, "type": check_territory_param(type),
+              "indic": agg.normalize_occupation_indic(indic),
+              "past": past, "month": month, "trimester": trimester, "semester": semester}
+    return await _serve_rows(redis, "/observatory/evol-occupation", params, sql, sp, conn)
+
+
+@router.get("/journeys-by-hours")
+async def journeys_by_hours(
+    code: str = Query(..., min_length=1, max_length=15),
+    type: str = Query(...),
+    year: int = Query(..., ge=2020, le=2100),
+    month: int | None = Query(None, ge=1, le=12),
+    trimester: int | None = Query(None, ge=1, le=4),
+    semester: int | None = Query(None, ge=1, le=2),
+    conn=Depends(get_conn),
+    redis=Depends(get_redis),
+):
+    """Distribution horaire des trajets (toutes directions)."""
+    check_code_param(code)
+    sql, sp = agg.build_journeys_by_hours(type, code, year, month, trimester, semester)
+    params = {"code": code, "type": check_territory_param(type), "year": year,
+              "month": month, "trimester": trimester, "semester": semester}
+    return await _serve_rows(redis, "/observatory/journeys-by-hours", params, sql, sp, conn)
+
+
+@router.get("/journeys-by-distances")
+async def journeys_by_distances(
+    code: str = Query(..., min_length=1, max_length=15),
+    type: str = Query(...),
+    year: int = Query(..., ge=2020, le=2100),
+    direction: Direction = Query(...),
+    month: int | None = Query(None, ge=1, le=12),
+    trimester: int | None = Query(None, ge=1, le=4),
+    semester: int | None = Query(None, ge=1, le=2),
+    conn=Depends(get_conn),
+    redis=Depends(get_redis),
+):
+    """Distribution kilométrique des trajets (direction requise)."""
+    check_code_param(code)
+    sql, sp = agg.build_journeys_by_distances(type, code, year, direction,
+                                              month, trimester, semester)
+    params = {"code": code, "type": check_territory_param(type), "year": year,
+              "direction": direction, "month": month,
+              "trimester": trimester, "semester": semester}
+    return await _serve_rows(redis, "/observatory/journeys-by-distances", params, sql, sp, conn)
+
+
+@router.get("/keyfigures")
+async def keyfigures(
+    code: str = Query(..., min_length=1, max_length=15),
+    type: str = Query(...),
+    year: int = Query(..., ge=2020, le=2100),
+    month: int | None = Query(None, ge=1, le=12),
+    trimester: int | None = Query(None, ge=1, le=4),
+    semester: int | None = Query(None, ge=1, le=2),
+    conn=Depends(get_conn),
+    redis=Depends(get_redis),
+):
+    """Chiffres clés d'un territoire (recomposition ; direction both)."""
+    check_code_param(code)
+    sql, sp = agg.build_keyfigures(type, code, year, month, trimester, semester)
+    params = {"code": code, "type": check_territory_param(type), "year": year,
+              "month": month, "trimester": trimester, "semester": semester}
+    return await _serve_rows(redis, "/observatory/keyfigures", params, sql, sp, conn)
+
+
+@router.get("/aires-covoiturage")
+async def aires_covoiturage(
+    type: str = Query("com"),
+    code: str | None = Query(None, min_length=1, max_length=15),
+    conn=Depends(get_conn),
+    redis=Depends(get_redis),
+):
+    """Aires de covoiturage ouvertes (optionnellement filtrées par territoire)."""
+    if code is not None:
+        check_code_param(code)
+    sql, sp = agg.build_aires_covoiturage(type, code)
+    params = {"type": check_territory_param(type), "code": code}
+    return await _serve_rows(redis, "/observatory/aires-covoiturage", params, sql, sp, conn)

--- a/api-datalake/tests/test_aggregated.py
+++ b/api-datalake/tests/test_aggregated.py
@@ -1,0 +1,190 @@
+import gzip
+import json
+
+from fastapi.testclient import TestClient
+
+from api_datalake.cache import get_redis
+from api_datalake.main import create_app
+from api_datalake.observatory_sql import perimeter_in_subquery, resolve_grain
+from api_datalake.repositories import observatory_aggregated as agg
+from api_datalake.routers.observatory import get_conn
+
+ALL_BUILDERS = [
+    ("build_flux", agg.build_flux, ("reg", "reg", "11", 2022, 6, None, None)),
+    ("build_best_flux", agg.build_best_flux, ("reg", "11", 2022, 10, None, None, None)),
+    ("build_evol_flux", agg.build_evol_flux, ("reg", "11", "journeys", 2, 6, None, None)),
+    ("build_incentive", agg.build_incentive, ("reg", "11", 2022, 6, None, None)),
+    ("build_occupation", agg.build_occupation, ("reg", "reg", "11", 2022, 6, None, None)),
+    ("build_best_territories", agg.build_best_territories, ("reg", "reg", "11", 2022, 10, None, None, None)),
+    ("build_evol_occupation", agg.build_evol_occupation, ("reg", "11", "journeys", 2, 6, None, None)),
+    ("build_journeys_by_hours", agg.build_journeys_by_hours, ("reg", "11", 2022, 6, None, None)),
+    ("build_journeys_by_distances", agg.build_journeys_by_distances, ("reg", "11", 2022, "both", 6, None, None)),
+    ("build_keyfigures", agg.build_keyfigures, ("reg", "11", 2022, 6, None, None)),
+    ("build_aires_covoiturage", agg.build_aires_covoiturage, ("dep", "33")),
+]
+
+
+# --- garde-fou architectural : l'API ne lit QUE la zone exposée ---
+
+
+def test_all_builders_read_only_exposed_zone():
+    for name, fn, args in ALL_BUILDERS:
+        sql, _ = fn(*args)
+        for forbidden in ("zone_trusted.", "zone_raw.", "zone_aggregated."):
+            assert forbidden not in sql, f"{name} lit {forbidden}"
+        assert "zone_exposed." in sql, f"{name} ne lit pas zone_exposed"
+
+
+# --- resolve_grain : priorité + renommage trimester -> quarter ---
+
+
+def test_resolve_grain_priority_and_quarter_rename():
+    assert resolve_grain(6, None, None) == ("month", "month", 6)
+    assert resolve_grain(None, 2, None) == ("quarter", "quarter", 2)  # trimester -> quarter
+    assert resolve_grain(None, None, 1) == ("semester", "semester", 1)
+    assert resolve_grain(None, None, None) == ("year", None, None)
+    # month l'emporte sur les autres
+    assert resolve_grain(6, 2, 1)[0] == "month"
+
+
+def test_perimeter_subquery_reads_exposed_perimeters():
+    sub = perimeter_in_subquery("epci", "reg")
+    assert "zone_exposed.observatory_perimeters" in sub
+    assert "geo.perimeters" not in sub
+    assert "t.epci" in sub and "t.reg = %(code)s" in sub
+
+
+# --- structure des requêtes (grain + filtres clés) ---
+
+
+def test_flux_uses_od_table_and_kanon_filter():
+    sql, p = agg.build_flux("reg", "reg", "11", 2022, month=6)
+    assert "zone_exposed.od_month" in sql
+    assert "(distance / journeys) <= 80" in sql
+    assert "territory_1 <> territory_2" in sql
+    assert "type = %(observe)s" in sql        # filtre type = observe (lié)
+    assert p == {"year": 2022, "code": "11", "tval": 6, "observe": "reg"}
+
+
+def test_flux_quarter_grain_maps_od_quarter():
+    sql, _ = agg.build_flux("reg", "reg", "11", 2022, trimester=2)
+    assert "zone_exposed.od_quarter" in sql
+    assert "quarter = %(tval)s" in sql
+
+
+def test_incentive_emits_both_direction_constant():
+    sql, _ = agg.build_incentive("reg", "11", 2022, month=6)
+    assert "'both'::text AS direction" in sql
+    assert "zone_exposed.incentive_month" in sql
+
+
+def test_distances_requires_direction_filter():
+    sql, p = agg.build_journeys_by_distances("reg", "11", 2022, "from", month=6)
+    assert "direction = %(direction)s" in sql
+    assert p["direction"] == "from"
+    # hours ne filtre pas la direction
+    sql_h, _ = agg.build_journeys_by_hours("reg", "11", 2022, month=6)
+    assert "direction = %(direction)s" not in sql_h
+
+
+def test_evol_indic_allowlist_fallback_journeys():
+    # indic inconnu -> fallback journeys (garde anti-injection)
+    sql, _ = agg.build_evol_flux("reg", "11", "DROP TABLE", 2, month=6)
+    assert "sum(journeys::numeric) AS journeys" in sql
+    assert "DROP TABLE" not in sql
+
+
+def test_evol_flux_limit_is_past_times_12_plus_1():
+    _, p = agg.build_evol_flux("reg", "11", "journeys", past=3, month=6)
+    assert p["limit"] == 37
+
+
+def test_keyfigures_composes_od_occupation_users():
+    sql, _ = agg.build_keyfigures("reg", "11", 2022, month=6)
+    assert "zone_exposed.od_month" in sql
+    assert "zone_exposed.occupation_month" in sql
+    assert "zone_exposed.users_month" in sql
+    assert "intra_journeys" in sql
+
+
+def test_aires_optional_code_filter():
+    sql_all, p_all = agg.build_aires_covoiturage("com", None)
+    assert "insee IN" not in sql_all and p_all == {}
+    sql_code, p_code = agg.build_aires_covoiturage("dep", "33")
+    assert "insee IN" in sql_code and p_code == {"code": "33"}
+
+
+# --- endpoints (fake DB) ---
+
+
+class FakeCursor:
+    def __init__(self, rows):
+        self._rows = rows
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def execute(self, sql, params):
+        pass
+
+    async def fetchall(self):
+        return self._rows
+
+
+class FakeConn:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def cursor(self):
+        return FakeCursor(self._rows)
+
+
+def client(rows):
+    app = create_app()
+
+    async def override():
+        yield FakeConn(rows)
+
+    app.dependency_overrides[get_conn] = override
+    app.dependency_overrides[get_redis] = lambda: None
+    return TestClient(app)
+
+
+def test_flux_endpoint_gzipped_rows():
+    rows = [{"ter_1": "Île-de-France", "passengers": 1198}]
+    c = client(rows)
+    r = c.get("/observatory/flux", params={"code": "11", "type": "reg", "observe": "reg", "year": 2022, "month": 6})
+    assert r.status_code == 200
+    assert r.headers["content-encoding"] == "gzip"
+    assert r.json() == rows
+
+
+def test_keyfigures_endpoint():
+    rows = [{"code": "11", "journeys": 5, "intra_journeys": 2}]
+    c = client(rows)
+    r = c.get("/observatory/keyfigures", params={"code": "11", "type": "reg", "year": 2022, "month": 6})
+    assert r.status_code == 200
+    assert r.json() == rows
+
+
+def test_aires_endpoint_without_code():
+    rows = [{"id_lieu": "A1", "nom_lieu": "Aire test", "geom": {"type": "Point"}}]
+    c = client(rows)
+    r = c.get("/observatory/aires-covoiturage", params={"type": "com"})
+    assert r.status_code == 200
+    assert r.json() == rows
+
+
+def test_journeys_by_distances_requires_direction():
+    c = client([])
+    r = c.get("/observatory/journeys-by-distances", params={"code": "11", "type": "reg", "year": 2022, "month": 6})
+    assert r.status_code == 422  # direction manquante
+
+
+def test_invalid_code_returns_422():
+    c = client([])
+    r = c.get("/observatory/flux", params={"code": "bad!code", "type": "reg", "observe": "reg", "year": 2022})
+    assert r.status_code == 422

--- a/datalake/models/exposed/observatory/aires_covoiturage.sql
+++ b/datalake/models/exposed/observatory/aires_covoiturage.sql
@@ -1,0 +1,32 @@
+{{ config(
+    materialized='view',
+    tags=['exposed', 'observatory', 'infra']
+) }}
+
+-- Aires de covoiturage exposées à l'API (remplace la lecture directe de
+-- `observatory.aires_covoiturage` + `geo.perimeters` côté API Deno).
+--
+-- L'API ne lit que la zone exposée. Cette vue :
+--   * ne garde que les aires ouvertes (`ouvert = true`) ;
+--   * reconstruit la géométrie GeoJSON depuis les coordonnées `Xlong`/`Ylat`
+--     (la source ne fournit pas de colonne `geom`) ;
+--   * conserve `insee` pour le filtrage territorial côté API.
+
+SELECT
+  id_lieu,
+  nom_lieu,
+  com_lieu,
+  insee,
+  type,
+  date_maj,
+  nbre_pl,
+  nbre_pmr,
+  duree,
+  horaires,
+  proprio,
+  lumiere,
+  ST_ASGEOJSON(
+    ST_SETSRID(ST_MAKEPOINT("Xlong", "Ylat"), 4326), 6
+  )::json AS geom
+FROM {{ source('raw', 'aires_covoiturage') }}
+WHERE ouvert = true

--- a/datalake/models/exposed/observatory/yml/_aires_covoiturage.yml
+++ b/datalake/models/exposed/observatory/yml/_aires_covoiturage.yml
@@ -1,0 +1,24 @@
+version: 2
+models:
+  - name: aires_covoiturage
+    description: >
+      Aires de covoiturage ouvertes exposées à l'API (remplace la lecture directe de
+      observatory.aires_covoiturage côté API Deno). Ne garde que ouvert=true et
+      reconstruit la géométrie GeoJSON depuis Xlong/Ylat.
+    columns:
+      - name: id_lieu
+        data_type: character varying
+      - name: nom_lieu
+        data_type: character varying
+      - name: com_lieu
+        data_type: character varying
+      - name: insee
+        data_type: character varying
+        description: Code INSEE, utilisé pour le filtrage territorial côté API.
+      - name: type
+        data_type: character varying
+      - name: date_maj
+        data_type: date
+      - name: geom
+        data_type: json
+        description: Géométrie GeoJSON (Point) reconstruite depuis Xlong/Ylat.


### PR DESCRIPTION
## Contexte

Suite de la migration de l'observatoire vers `api-datalake` (après `location`, `campaigns`,
`last-record`). Cette PR porte les **11 endpoints observatoire restants** du service Deno
vers l'API Python, lisant **uniquement `zone_exposed`** (garde-fou testé).

## Endpoints portés (11)

`flux`, `best-flux`, `evol-flux`, `incentive`, `occupation`, `best-territories`,
`evol-occupation`, `journeys-by-hours`, `journeys-by-distances`, `keyfigures`,
`aires-covoiturage`.

## Ce que contient la PR

- **`observatory_sql.py`** — briques partagées : résolution du grain temporel
  (priorité `month > trimester > semester > year`, renommage legacy `trimester` → table
  `quarter`) et expansion de périmètre portée de `geo.perimeters` vers
  `zone_exposed.observatory_perimeters`.
- **`repositories/observatory_aggregated.py`** — builders SQL **purs et testables**, portés
  fidèlement des providers Deno : filtres, jointures périmètre, k-anon flux
  `(distance/journeys) <= 80`, `territory_1 <> territory_2`, tri/limit, casts.
- **`routers/observatory.py`** — 11 routes `GET` publiques, cache Redis gzip (helper commun),
  bornes de validation (`year`, `month`, `trimester`, `semester`, `limit`, `past`,
  `direction`), validation du `code`.
- **Modèle dbt `zone_exposed.aires_covoiturage`** — géométrie GeoJSON reconstruite depuis
  `Xlong`/`Ylat`, filtre `ouvert=true`. SQL validé sur prod (dbt parse + sqlfluff + requête).

## Validation

- **81 tests** (dont un garde-fou : tous les builders ne lisent que `zone_exposed`) — verts.
- **Parité flux** validée à ~**91 %** (région/département) et **100 %** (commune) contre
  l'API en ligne, au grain agrégé (`zone_aggregated.od_*`, dont l'exposé est la projection) ;
  les écarts résiduels sont de la fraîcheur de snapshot (backfill), proportionnels.
- Modèle `aires_covoiturage` : requête compilée exécutée sur prod (GeoJSON Points corrects).

## Limites assumées et documentées

- **`direction`** : les modèles exposés `occupation`/`incentive`/`users` viennent de
  `territory_month_*_both` → **direction `both` uniquement** ; le filtre `direction=from|to`
  legacy est ignoré (émis en dur `both`). `distribution` conserve la dimension direction.
- **`keyfigures`** : recomposé (od + occupation + users) faute de modèle exposé dédié,
  direction `both`.
- **`evol-flux` indic `has_incentive`** : absent d'`od_*` → retombe sur `journeys` (fallback
  legacy).
- **Libellés EPCI/AOM** : forme IGN 2025 abrégée, différente du legacy — décision équipe en
  cours (tâche Notion dédiée).

## Portée & déploiement

PR **data-only** (`api-datalake/**` + `datalake/**`) → **ne déclenche aucune release**
(attendu ; déploiement via l'image `datalake-api`). La validation finale des données se fera
au fil de la matérialisation de la zone exposée en prod (gérée séparément).

## Sécurité (relecture — PASS)

Aucune injection SQL : tous les identifiants interpolés en f-string (`type`, `observe`,
`indic`, suffixe de grain, colonnes) proviennent d'allowlists strictes
(`check_territory_param` → fallback `com`, `_check_indic` → fallback `journeys`,
`resolve_grain` → constantes) ; toutes les valeurs (`year`, `code`, `tval`, `limit`,
`direction`) sont liées `%(...)s`. `code` validé partout (`check_code_param`), bornes sur
`year`/`month`/`trimester`/`semester`/`limit`/`past`. Aucun secret.

Trois constats mineurs **corrigés dans la PR** : `type = observe` désormais **lié**
(`%(observe)s`) au lieu d'interpolé ; `indic` **normalisé** (allowlist) dans la clé de
cache et **borné** (`max_length`), évitant l'amplification de cache Redis.

## CGU (garde-fou — PASS)

Lecture seule sur `zone_exposed`, agrégats territoriaux + lieux publics (aires de
covoiturage). Aucun champ PII (`phone`/`identity_key`/`driver_*`/`passenger_*` absents),
coordonnées = centroïdes de territoires, filtre k-anonymat flux `(distance/journeys) <= 80`
préservé. `proprio` des aires = gestionnaire public (collectivité/opérateur), pas une
personne physique. Aucun secret ni mutation de statut.