### PR TITLE
ci(datalake): ajoute le SHA court au tag de l'image datalake-api

### DIFF
--- a/.github/workflows/deploy-datalake-api.yml
+++ b/.github/workflows/deploy-datalake-api.yml
@@ -30,7 +30,10 @@ jobs:
     steps:
       - id: set_tag
         shell: bash
-        run: echo "value=$(date +'%F.%H%M')" >> $GITHUB_OUTPUT
+        # Tag = horodatage (ordre lisible) + SHA court (traçabilité build -> commit).
+        # GITHUB_SHA est une variable d'environnement intégrée (40 hex), non
+        # interpolée depuis le contexte : pas de surface d'injection.
+        run: echo "value=$(date +'%F.%H%M')-${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
 
   build:
     name: Build and Push Datalake API Docker Image


### PR DESCRIPTION
## Contexte

`api-datalake` n'a pas de semver (data-only, hors du gate `app` de semantic-release). Sa
« version » de fait est le **tag de l'image Docker**, aujourd'hui un simple horodatage
(`2026-07-12.1618`) — impossible d'en retrouver le commit d'origine.

## Changement

Le tag de l'image `datalake-api` devient **horodatage + SHA court** :

```
2026-07-12.1618-e3cab88
```

- horodatage → ordre lisible des builds ;
- SHA court → **traçabilité build → commit**.

Une seule ligne modifiée dans `set_tag` (`deploy-datalake-api.yml`) ; l'action partagée
`build-image` n'est pas touchée.

## Sécurité

`GITHUB_SHA` est une **variable d'environnement intégrée** (40 hex, non attaquable), pas une
interpolation `${{ github.* }}` → aucune surface d'injection. `zizmor` : aucune alerte.

## Portée

`.github/**` uniquement → **aucune release**, aucun impact applicatif. Premier pas de
traçabilité de version pour `api-datalake` (le versioning de contrat reste porté par `/v3`).