### PR TITLE
feat(datalake): sert l'observatoire sous /v3 (version de contrat de l'API)

### DIFF
--- a/api-datalake/README.md
+++ b/api-datalake/README.md
@@ -18,7 +18,7 @@ worker. On la déplace donc là où vivent les données — le datalake — pour
 
 ```
 app-observatory (Next.js)
-      │  GET /observatory/*
+      │  GET /v3/observatory/*
       ▼
 api-datalake (FastAPI)  ──►  Redis (cache gzip, clé versionnée sur la publication)
       │  lecture locale
@@ -32,6 +32,16 @@ datalake_production  ·  zone_exposed.{od,incentive,distribution,occupation,loca
   pipeline dbt incrémente à chaque publication).
 - **Fenêtre de publication** : `APP_OBSERVATORY_PUBLISHED_UNTIL` (borne supérieure
   exclusive, `YYYY-MM-DD`), portée depuis `helpers/publishedDate.ts`.
+
+## Versioning
+
+- **Contrat public = le préfixe d'URL `/v3`** (`API_VERSION` dans `main.py`). Toutes les
+  routes observatoire sont servies sous `/v3/observatory/...`. Les changements **additifs**
+  restent en `/v3` ; un changement **cassant** se fait en ajoutant `/v4` — on ne casse
+  jamais `/v3` en place. Les sondes `/health` et `/health/ready` sont **hors contrat** (ops),
+  non versionnées.
+- **Artefact = tag d'image Docker** `datalake-api:<horodatage>-<sha court>` (build → commit).
+  Pas de semver / release applicative (data-only, hors du gate semantic-release).
 
 ## Modules
 
@@ -63,7 +73,7 @@ just test              # pytest
 
 - [x] Squelette FastAPI + cache + fenêtre de publication
 - [x] Modèles dbt `zone_exposed.{location, observatory_perimeters, campaigns, aires_covoiturage}` — validés sur prod
-- [x] `GET /observatory/location`, `campaigns`, `last-record`
+- [x] `GET /v3/observatory/location`, `campaigns`, `last-record`
 - [x] **Endpoints agrégés** : `flux`, `best-flux`, `evol-flux`, `incentive`,
       `occupation`, `best-territories`, `evol-occupation`, `journeys-by-hours`,
       `journeys-by-distances`, `keyfigures`, `aires-covoiturage`

--- a/api-datalake/src/api_datalake/main.py
+++ b/api-datalake/src/api_datalake/main.py
@@ -16,7 +16,13 @@ from .routers import observatory
 
 logger = logging.getLogger("api_datalake")
 
-# Routes toujours servies, y compris en maintenance (sondes k8s liveness/readiness).
+# Version de contrat de l'API publique : le préfixe d'URL EST la version. Les
+# consommateurs (app-observatoire, réutilisateurs open-data) épinglent `/v3`. Un
+# changement cassant se fait en ajoutant `/v4` — on ne casse jamais `/v3` en place.
+API_VERSION = "v3"
+
+# Routes toujours servies, y compris en maintenance (sondes k8s liveness/readiness,
+# non versionnées : ce sont des sondes d'ops, pas du contrat public).
 HEALTH_PATHS = {"/health"}
 
 
@@ -87,7 +93,8 @@ def create_app() -> FastAPI:
             return JSONResponse({"status": "unavailable"}, status_code=503)
         return {"status": "ready"}
 
-    app.include_router(observatory.router)
+    # Monté sous /v3 : les routes publiques sont /v3/observatory/... (contrat préservé).
+    app.include_router(observatory.router, prefix=f"/{API_VERSION}")
     return app
 
 

--- a/api-datalake/tests/test_aggregated.py
+++ b/api-datalake/tests/test_aggregated.py
@@ -156,7 +156,7 @@ def client(rows):
 def test_flux_endpoint_gzipped_rows():
     rows = [{"ter_1": "Île-de-France", "passengers": 1198}]
     c = client(rows)
-    r = c.get("/observatory/flux", params={"code": "11", "type": "reg", "observe": "reg", "year": 2022, "month": 6})
+    r = c.get("/v3/observatory/flux", params={"code": "11", "type": "reg", "observe": "reg", "year": 2022, "month": 6})
     assert r.status_code == 200
     assert r.headers["content-encoding"] == "gzip"
     assert r.json() == rows
@@ -165,7 +165,7 @@ def test_flux_endpoint_gzipped_rows():
 def test_keyfigures_endpoint():
     rows = [{"code": "11", "journeys": 5, "intra_journeys": 2}]
     c = client(rows)
-    r = c.get("/observatory/keyfigures", params={"code": "11", "type": "reg", "year": 2022, "month": 6})
+    r = c.get("/v3/observatory/keyfigures", params={"code": "11", "type": "reg", "year": 2022, "month": 6})
     assert r.status_code == 200
     assert r.json() == rows
 
@@ -173,18 +173,18 @@ def test_keyfigures_endpoint():
 def test_aires_endpoint_without_code():
     rows = [{"id_lieu": "A1", "nom_lieu": "Aire test", "geom": {"type": "Point"}}]
     c = client(rows)
-    r = c.get("/observatory/aires-covoiturage", params={"type": "com"})
+    r = c.get("/v3/observatory/aires-covoiturage", params={"type": "com"})
     assert r.status_code == 200
     assert r.json() == rows
 
 
 def test_journeys_by_distances_requires_direction():
     c = client([])
-    r = c.get("/observatory/journeys-by-distances", params={"code": "11", "type": "reg", "year": 2022, "month": 6})
+    r = c.get("/v3/observatory/journeys-by-distances", params={"code": "11", "type": "reg", "year": 2022, "month": 6})
     assert r.status_code == 422  # direction manquante
 
 
 def test_invalid_code_returns_422():
     c = client([])
-    r = c.get("/observatory/flux", params={"code": "bad!code", "type": "reg", "observe": "reg", "year": 2022})
+    r = c.get("/v3/observatory/flux", params={"code": "bad!code", "type": "reg", "observe": "reg", "year": 2022})
     assert r.status_code == 422

--- a/api-datalake/tests/test_campaigns.py
+++ b/api-datalake/tests/test_campaigns.py
@@ -88,7 +88,7 @@ def test_campaigns_endpoint_returns_gzipped_list():
     app.dependency_overrides[get_conn] = override_conn
     app.dependency_overrides[get_redis] = lambda: None
     c = TestClient(app)
-    r = c.get("/observatory/campaigns", params={"type": "aom", "code": "217500016", "year": 2024})
+    r = c.get("/v3/observatory/campaigns", params={"type": "aom", "code": "217500016", "year": 2024})
     assert r.status_code == 200
     assert r.headers["content-encoding"] == "gzip"
     assert r.json() == rows

--- a/api-datalake/tests/test_hardening.py
+++ b/api-datalake/tests/test_hardening.py
@@ -68,7 +68,7 @@ def test_openapi_and_docs_are_404():
 
 def test_validation_error_is_terse_and_does_not_echo_input():
     c = client()
-    r = c.get("/observatory/location", params={"code": "75056", "type": "com", "year": 2022, "month": 13, "n": 8})
+    r = c.get("/v3/observatory/location", params={"code": "75056", "type": "com", "year": 2022, "month": 13, "n": 8})
     assert r.status_code == 422
     assert r.json() == {"detail": "invalid request parameters"}
     assert "13" not in r.text  # la valeur invalide ne fuit pas
@@ -96,24 +96,24 @@ def test_campaigns_query_projects_explicit_allowlist():
 
 def test_invalid_code_charset_returns_422():
     c = client()
-    r = c.get("/observatory/location", params={"code": "75%56", "type": "com", "year": 2022, "n": 8})
+    r = c.get("/v3/observatory/location", params={"code": "75%56", "type": "com", "year": 2022, "n": 8})
     assert r.status_code == 422
 
 
 def test_too_long_code_returns_422():
     c = client()
-    r = c.get("/observatory/location", params={"code": "1234567890123456", "type": "com", "year": 2022, "n": 8})
+    r = c.get("/v3/observatory/location", params={"code": "1234567890123456", "type": "com", "year": 2022, "n": 8})
     assert r.status_code == 422
 
 
 def test_valid_corsican_code_accepted():
     # 2A004 (arrondissement corse) : alphanumérique valide, atteint la requête.
     c = client(rows=[{"hex": "abc", "count": 1}])
-    r = c.get("/observatory/location", params={"code": "2A004", "type": "com", "year": 2022, "n": 8})
+    r = c.get("/v3/observatory/location", params={"code": "2A004", "type": "com", "year": 2022, "n": 8})
     assert r.status_code == 200
 
 
 def test_campaigns_invalid_code_returns_422():
     c = client()
-    r = c.get("/observatory/campaigns", params={"code": "bad!", "year": 2024})
+    r = c.get("/v3/observatory/campaigns", params={"code": "bad!", "year": 2024})
     assert r.status_code == 422

--- a/api-datalake/tests/test_location.py
+++ b/api-datalake/tests/test_location.py
@@ -108,7 +108,7 @@ def make_client(rows, redis=None):
 def test_location_returns_gzipped_heatmap():
     rows = [{"hex": "881fb46461fffff", "count": 616}]
     c = TestClient(make_client(rows))
-    r = c.get("/observatory/location", params={"code": "75056", "type": "com", "year": 2022, "month": 6, "n": 8})
+    r = c.get("/v3/observatory/location", params={"code": "75056", "type": "com", "year": 2022, "month": 6, "n": 8})
     assert r.status_code == 200
     assert r.headers["content-encoding"] == "gzip"
     assert r.headers["x-cache"] == "MISS"
@@ -120,12 +120,12 @@ def test_location_cache_hit_served_from_redis():
     cached = [{"hex": "abc", "count": 1}]
     c = TestClient(make_client([], redis=redis))
     # 1er appel : MISS, remplit le cache (data = [] côté DB)
-    first = c.get("/observatory/location", params={"code": "75056", "type": "com", "year": 2022, "n": 8})
+    first = c.get("/v3/observatory/location", params={"code": "75056", "type": "com", "year": 2022, "n": 8})
     assert first.headers["x-cache"] == "MISS"
     # on force une entrée pré-existante et on rappelle : HIT
     (only_key,) = redis.store.keys()
     redis.store[only_key] = gzip.compress(json.dumps(cached).encode())
-    second = c.get("/observatory/location", params={"code": "75056", "type": "com", "year": 2022, "n": 8})
+    second = c.get("/v3/observatory/location", params={"code": "75056", "type": "com", "year": 2022, "n": 8})
     assert second.headers["x-cache"] == "HIT"
     assert second.json() == cached
 
@@ -134,7 +134,7 @@ def test_location_redis_failure_degrades_to_pg_not_500():
     # Redis en panne (TLS/réseau) : on sert depuis PG en 200, X-Cache BYPASS, jamais 500.
     rows = [{"hex": "881fb46461fffff", "count": 616}]
     c = TestClient(make_client(rows, redis=RaisingRedis()))
-    r = c.get("/observatory/location", params={"code": "75056", "type": "com", "year": 2022, "month": 6, "n": 8})
+    r = c.get("/v3/observatory/location", params={"code": "75056", "type": "com", "year": 2022, "month": 6, "n": 8})
     assert r.status_code == 200
     assert r.headers["x-cache"] == "BYPASS"
     assert r.json() == rows
@@ -143,19 +143,19 @@ def test_location_redis_failure_degrades_to_pg_not_500():
 def test_location_out_of_range_params_return_422_not_500():
     c = TestClient(make_client([]))
     # month=13 est hors bornes -> 422 de validation, pas un 500 (ValueError sur date())
-    r = c.get("/observatory/location", params={"code": "75056", "type": "com", "year": 2022, "month": 13, "n": 8})
+    r = c.get("/v3/observatory/location", params={"code": "75056", "type": "com", "year": 2022, "month": 13, "n": 8})
     assert r.status_code == 422
 
 
 def test_location_rejects_malformed_code_with_422():
     c = TestClient(make_client([]))
     # Code hors charset/longueur : rejeté avant tout accès PG (anti cache-flooding).
-    r = c.get("/observatory/location", params={"code": "75'; DROP--", "type": "com", "year": 2022, "n": 8})
+    r = c.get("/v3/observatory/location", params={"code": "75'; DROP--", "type": "com", "year": 2022, "n": 8})
     assert r.status_code == 422
-    r_long = c.get("/observatory/location", params={"code": "x" * 20, "type": "com", "year": 2022, "n": 8})
+    r_long = c.get("/v3/observatory/location", params={"code": "x" * 20, "type": "com", "year": 2022, "n": 8})
     assert r_long.status_code == 422
     # `$` laisserait passer un newline final ; `fullmatch` le rejette.
-    r_nl = c.get("/observatory/location", params={"code": "75056\n", "type": "com", "year": 2022, "n": 8})
+    r_nl = c.get("/v3/observatory/location", params={"code": "75056\n", "type": "com", "year": 2022, "n": 8})
     assert r_nl.status_code == 422
 
 
@@ -163,7 +163,7 @@ def test_location_unpublished_period_is_bypassed_and_empty():
     c = TestClient(make_client([{"hex": "x", "count": 9}]))
     settings.app_observatory_published_until = "2022-01-01"
     try:
-        r = c.get("/observatory/location", params={"code": "75056", "type": "com", "year": 2022, "month": 6, "n": 8})
+        r = c.get("/v3/observatory/location", params={"code": "75056", "type": "com", "year": 2022, "month": 6, "n": 8})
         assert r.headers["x-cache"] == "BYPASS"
         assert r.json() == []
     finally:

--- a/api-datalake/tests/test_maintenance.py
+++ b/api-datalake/tests/test_maintenance.py
@@ -42,12 +42,12 @@ def test_off_serves_routes_normally():
     # /health (exempt) + une vraie route observatoire servie depuis une DB factice.
     c = app_with_maintenance(False, fake_db=True)
     assert c.get("/health").status_code == 200
-    assert c.get("/observatory/campaigns", params={"year": 2024}).status_code == 200
+    assert c.get("/v3/observatory/campaigns", params={"year": 2024}).status_code == 200
 
 
 def test_on_returns_503_with_retry_after_and_body():
     c = app_with_maintenance(True)
-    r = c.get("/observatory/campaigns", params={"year": 2024})
+    r = c.get("/v3/observatory/campaigns", params={"year": 2024})
     assert r.status_code == 503
     assert r.headers["Retry-After"] == "3600"
     assert r.json() == {"status": "maintenance"}
@@ -57,7 +57,7 @@ def test_on_short_circuits_observatory_before_db():
     # Aucune dépendance DB surchargée : si la route s'exécutait, elle ouvrirait le pool.
     # Le 503 prouve le court-circuit avant tout accès PG/Redis.
     c = app_with_maintenance(True)
-    r = c.get("/observatory/campaigns", params={"year": 2024})
+    r = c.get("/v3/observatory/campaigns", params={"year": 2024})
     assert r.status_code == 503
 
 

--- a/api-datalake/tests/test_observatory.py
+++ b/api-datalake/tests/test_observatory.py
@@ -42,14 +42,14 @@ def client_with_row(row):
 
 def test_last_record_returns_year_month():
     c = client_with_row({"year": 2026, "month": 2})
-    r = c.get("/observatory/last-record", params={"code": "75", "type": "reg"})
+    r = c.get("/v3/observatory/last-record", params={"code": "75", "type": "reg"})
     assert r.status_code == 200
     assert r.json() == {"year": 2026, "month": 2}
 
 
 def test_last_record_returns_null_when_no_data():
     c = client_with_row(None)
-    r = c.get("/observatory/last-record", params={"code": "00000", "type": "com"})
+    r = c.get("/v3/observatory/last-record", params={"code": "00000", "type": "com"})
     assert r.status_code == 200
     assert r.json() is None
 

--- a/api-datalake/tests/test_versioning.py
+++ b/api-datalake/tests/test_versioning.py
@@ -1,0 +1,60 @@
+"""Le préfixe d'URL /v3 EST la version de contrat de l'API publique."""
+
+from fastapi.testclient import TestClient
+
+from api_datalake.cache import get_redis
+from api_datalake.main import API_VERSION, create_app
+from api_datalake.routers.observatory import get_conn
+
+
+class _FakeCursor:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def execute(self, sql, params):
+        pass
+
+    async def fetchone(self):
+        return {"year": 2026, "month": 2}
+
+
+class _FakeConn:
+    def cursor(self):
+        return _FakeCursor()
+
+
+def _client():
+    app = create_app()
+
+    async def override():
+        yield _FakeConn()
+
+    app.dependency_overrides[get_conn] = override
+    app.dependency_overrides[get_redis] = lambda: None
+    return TestClient(app)
+
+
+def test_version_is_v3():
+    assert API_VERSION == "v3"
+
+
+def test_observatory_served_under_v3():
+    c = _client()
+    r = c.get("/v3/observatory/last-record", params={"code": "11", "type": "reg"})
+    assert r.status_code == 200
+
+
+def test_unversioned_observatory_is_404():
+    # ne jamais servir hors /v3 : casserait le namespace de contrat
+    c = _client()
+    assert c.get("/observatory/last-record", params={"code": "11", "type": "reg"}).status_code == 404
+
+
+def test_health_stays_unversioned():
+    # sondes d'ops : hors du contrat public, non versionnées
+    c = _client()
+    assert c.get("/health").status_code == 200
+    assert c.get("/v3/health").status_code == 404


### PR DESCRIPTION
## Contexte

Le préfixe d'URL **`/v3`** est la **version de contrat** de l'API observatoire publique :
`app-observatoire` (et d'éventuels réutilisateurs open-data) appellent
`https://api.covoiturage.beta.gouv.fr/v3/observatory/...`. Jusqu'ici `api-datalake` montait
le router sous `/observatory` — le `/v3` venait **implicitement de l'ingress**. On le rend
**explicite et possédé par le service** : la version de contrat vit dans le code, pas dans
une réécriture d'ingress invisible.

C'est le point **(b)** de la discussion sur le versioning (le **(a)**, SHA dans le tag
d'image, est la PR #3280).

## Changement

- `main.py` : `API_VERSION = "v3"`, router monté sous `/{API_VERSION}` → routes publiques
  **`/v3/observatory/*`**. `/health` et `/health/ready` restent **hors contrat** (sondes
  d'ops, non versionnées).
- **Discipline** documentée : changement **additif** → reste `/v3` ; changement **cassant**
  → `/v4`, on ne casse **jamais** `/v3` en place.
- Tests : chemins HTTP passés sous `/v3` ; nouveau `test_versioning` qui fige le contrat
  (`/v3` sert, hors `/v3` = 404, `/health` non versionné). README : section **Versioning**.

## Validation

85 tests verts. Le changement de montage est au niveau app (indépendant des endpoints).

## Coordination

**PR empilée sur #3279** (les 14 endpoints observatoire) pour que tous les tests soient
cohérents sous `/v3`. À **merger après #3279** ; le diff se réduira alors au seul delta `/v3`.

## Portée

PR **data-only** (`api-datalake/**`) → **aucune release**. Point de vigilance pour le
repointage `app-observatory` (tâche #2) : le front doit cibler `/v3/observatory/...` (déjà
le cas de l'URL publique) et l'ingress router `/v3` en pass-through (plus de réécriture).