### PR TITLE
perf(datalake): réordonne l'index composite OD avec (start_code, end_code) en tête

### DIFF
--- a/datalake/models/aggregated/operators/operators_od_day.sql
+++ b/datalake/models/aggregated/operators/operators_od_day.sql
@@ -1,7 +1,11 @@
 {#
-  Index composite = clé du delete+insert. Sans lui, le DELETE incrémental (semi-jointure
-  sur les 4 colonnes) balaie toute la table (~12 M lignes) => très lent. operator_id seul
-  est peu sélectif ; le composite le remplace et couvre les lookups par operator_id (préfixe).
+  Composite réordonné, (start_code, end_code) en tête = clé du delete+insert. Sinon le
+  planificateur choisit l'index ['start_code', 'end_code'] seul, peu sélectif (une paire
+  origine-destination revient sur des milliers de lignes) : le DELETE incrémental balaie
+  cet index et devient catastrophique (> 1 h par fenêtre). Avec (start_code, end_code) en
+  tête, le composite sert le DELETE (sonde par ligne sur les 4 colonnes) ET les lookups par
+  (start_code, end_code) via son préfixe gauche ; l'index ['start_code', 'end_code'] seul
+  devient redondant et est retiré.
 #}
 {{
   config(
@@ -9,9 +13,8 @@
     incremental_strategy='delete+insert',
     unique_key=['operator_id', 'incremental_date', 'start_code', 'end_code'],
     indexes=[
-      { 'columns': ['operator_id', 'incremental_date', 'start_code', 'end_code'] },
-      { 'columns': ['incremental_date'] },
-      { 'columns': ['start_code', 'end_code'] }
+      { 'columns': ['start_code', 'end_code', 'operator_id', 'incremental_date'] },
+      { 'columns': ['incremental_date'] }
     ],
     tags=['aggregated', 'operators', 'od', 'daily']
   )

--- a/datalake/models/aggregated/operators/operators_od_month.sql
+++ b/datalake/models/aggregated/operators/operators_od_month.sql
@@ -1,8 +1,11 @@
 {#
-  Index composite = clé du delete+insert. Sans lui, le DELETE incrémental (semi-jointure
-  sur les 4 colonnes) balaie toute la table (~2,9 M lignes) => très lent. operator_id seul
-  est peu sélectif ; le composite le remplace et couvre les lookups par operator_id (préfixe).
-  Même correctif que operators_od_day (#3272).
+  Composite réordonné, (start_code, end_code) en tête = clé du delete+insert. Sinon le
+  planificateur choisit l'index ['start_code', 'end_code'] seul, peu sélectif (une paire
+  origine-destination revient sur des milliers de lignes) : le DELETE incrémental balaie
+  cet index et devient catastrophique (> 1 h par fenêtre). Avec (start_code, end_code) en
+  tête, le composite sert le DELETE (sonde par ligne sur les 4 colonnes) ET les lookups par
+  (start_code, end_code) via son préfixe gauche ; l'index ['start_code', 'end_code'] seul
+  devient redondant et est retiré.
 #}
 {{
   config(
@@ -10,9 +13,8 @@
     incremental_strategy='delete+insert',
     unique_key=['operator_id', 'incremental_date', 'start_code', 'end_code'],
     indexes=[
-      { 'columns': ['operator_id', 'incremental_date', 'start_code', 'end_code'] },
-      { 'columns': ['incremental_date'] },
-      { 'columns': ['start_code', 'end_code'] }
+      { 'columns': ['start_code', 'end_code', 'operator_id', 'incremental_date'] },
+      { 'columns': ['incremental_date'] }
     ],
     tags=['aggregated', 'operators', 'od', 'daily']
   )

--- a/datalake/models/aggregated/users/user_od_day.sql
+++ b/datalake/models/aggregated/users/user_od_day.sql
@@ -1,7 +1,11 @@
 {#
-  Index composite = clé du delete+insert. Sans lui, le DELETE incrémental (semi-jointure
-  sur les 5 colonnes) balaie toute la table (~57 M lignes) => très lent. Il sert aussi les
-  lookups par user_id (préfixe gauche) et remplace donc l'index ['user_id'] seul.
+  Composite réordonné, (start_code, end_code) en tête = clé du delete+insert. Sinon le
+  planificateur choisit l'index ['start_code', 'end_code'] seul, peu sélectif (une paire
+  origine-destination revient sur des milliers de lignes) : le DELETE incrémental balaie
+  cet index et devient catastrophique (> 1 h par fenêtre). Avec (start_code, end_code) en
+  tête, le composite sert le DELETE (sonde par ligne sur les 5 colonnes) ET les lookups par
+  (start_code, end_code) via son préfixe gauche ; l'index ['start_code', 'end_code'] seul
+  devient redondant et est retiré.
 #}
 {{
   config(
@@ -9,9 +13,8 @@
     incremental_strategy='delete+insert',
     unique_key=['user_id', 'incremental_date', 'role', 'start_code', 'end_code'],
     indexes=[
-      { 'columns': ['user_id', 'incremental_date', 'role', 'start_code', 'end_code'] },
-      { 'columns': ['incremental_date'] },
-      { 'columns': ['start_code', 'end_code'] }
+      { 'columns': ['start_code', 'end_code', 'user_id', 'incremental_date', 'role'] },
+      { 'columns': ['incremental_date'] }
     ],
     tags=['aggregated', 'users', 'od', 'daily']
   )

--- a/datalake/models/aggregated/users/user_od_month.sql
+++ b/datalake/models/aggregated/users/user_od_month.sql
@@ -1,7 +1,11 @@
 {#
-  Index composite = clé du delete+insert. Sans lui, le DELETE incrémental (semi-jointure
-  sur les 5 colonnes) balaie toute la table (~23 M lignes) => très lent. Il sert aussi les
-  lookups par user_id (préfixe gauche) et remplace donc l'index ['user_id'] seul.
+  Composite réordonné, (start_code, end_code) en tête = clé du delete+insert. Sinon le
+  planificateur choisit l'index ['start_code', 'end_code'] seul, peu sélectif (une paire
+  origine-destination revient sur des milliers de lignes) : le DELETE incrémental balaie
+  cet index et devient catastrophique (> 1 h par fenêtre). Avec (start_code, end_code) en
+  tête, le composite sert le DELETE (sonde par ligne sur les 5 colonnes) ET les lookups par
+  (start_code, end_code) via son préfixe gauche ; l'index ['start_code', 'end_code'] seul
+  devient redondant et est retiré.
 #}
 {{
   config(
@@ -9,9 +13,8 @@
     incremental_strategy='delete+insert',
     unique_key=['user_id', 'incremental_date', 'role', 'start_code', 'end_code'],
     indexes=[
-      { 'columns': ['user_id', 'incremental_date', 'role', 'start_code', 'end_code'] },
-      { 'columns': ['incremental_date'] },
-      { 'columns': ['start_code', 'end_code'] }
+      { 'columns': ['start_code', 'end_code', 'user_id', 'incremental_date', 'role'] },
+      { 'columns': ['incremental_date'] }
     ],
     tags=['aggregated', 'users', 'od', 'monthly']
   )


### PR DESCRIPTION
## Contexte

Sur les modèles OD en `delete+insert`, le `DELETE` incrémental supprime par semi-jointure sur toute la clé unique. Le planificateur choisissait l'index `['start_code', 'end_code']` seul — peu sélectif, car une paire origine-destination revient sur des milliers de lignes (toutes les personnes / tous les mois). Chaque fenêtre dense balayait donc cet index et le `DELETE` dépassait **1 heure**, dominant tout le backfill.

## Changement

Réordonne le composite pour placer `(start_code, end_code)` en tête :

- `user_od_day` / `user_od_month` : `(start_code, end_code, user_id, incremental_date, role)`
- `operators_od_day` / `operators_od_month` : `(start_code, end_code, operator_id, incremental_date)`

Le composite sert alors le `DELETE` (sonde par ligne sur la clé complète) **et** les lookups par `(start_code, end_code)` via son préfixe gauche. L'index `['start_code', 'end_code']` seul devient redondant et est retiré.

## Vérification

- `dbt parse` OK.
- `EXPLAIN` du `DELETE` en base : passe de `Index Scan` sur `(start_code, end_code)` (des milliers de lignes par sonde) à `Index Scan` sur le composite réordonné (une ligne par sonde).
- Benchmark isolé (copie de `user_od_month`, fenêtre dense ~1,5 M lignes) : `DELETE` **> 1 h → 25 s**.
- Rappel : dbt ne construit les index qu'au `full-refresh`. Sur les tables existantes, ils ont été recréés hors bande via `CREATE INDEX CONCURRENTLY`.
