### PR TITLE
fix(datalake): réduit le centroïde communal à un POINT dans perimeters_agg

### DIFF
--- a/datalake/models/trusted/perimeters_agg.sql
+++ b/datalake/models/trusted/perimeters_agg.sql
@@ -14,7 +14,9 @@ SELECT
   'com'       AS type,  -- noqa: RF04
   l_arr       AS libelle,
   geom_simple AS geom,
-  centroid
+  -- le centroïde communal source est un MULTIPOINT ; on le réduit à un POINT unique
+  -- pour que st_x/st_y (exposed observatory od_*) fonctionnent (ST_X exige un POINT)
+  ST_CENTROID(centroid) AS centroid
 FROM {{ ref('perimeters') }}
 WHERE com IS NOT NULL
 UNION ALL


### PR DESCRIPTION
## Contexte

La reprise complète de la couche `exposed` a échoué sur les modèles
`observatory.od_month` / `od_quarter` / `od_semester` / `od_year` :

> Database Error ... Argument to ST_X() must have type POINT

## Cause

`perimeters_agg` construit `centroid` de deux façons :

- niveaux agrégés (`epci`, `aom`, `dep`, `reg`, `country`) : `ST_POINTONSURFACE(...)` → POINT ;
- niveau communal (`com`) : le centroïde source de `perimeters` est transmis tel quel, or il s'agit d'un MULTIPOINT.

Répartition en production : MULTIPOINT 244 924, POINT 15 576, NULL 6. Les modèles
`od_*` appellent `st_x` / `st_y(centroid)` ; `ST_X` n'accepte qu'un POINT, d'où
l'échec systématique sur toutes les communes (2019-2025).

## Correctif

`ST_CENTROID(centroid)` sur le bras `com`, pour homogénéiser la colonne en POINT.

## Validation (production, lecture seule)

- `st_x(centroid)` actuel : reproduit l'erreur ;
- `ST_CENTROID(centroid)` : 260 500 lignes → POINT (6 NULL inchangés), longitudes
  et latitudes cohérentes (métropole, outre-mer, TAAF), aucune valeur nulle nouvelle.
