### PR TITLE
fix(datalake): aligne l'export open-data data.gouv sur l'ancien format

### DIFF
--- a/datalake/macros/helpers/iso8601_paris.sql
+++ b/datalake/macros/helpers/iso8601_paris.sql
@@ -1,0 +1,5 @@
+{% macro iso8601_paris(ts) %}
+{#- Horodatage ISO 8601 « yyyy-MM-dd'T'HH:mm:ssXX » : champs locaux bruts + offset UTC d'Europe/Paris (DST, toujours positif UTC+1/+2). Reproduit toTzString de l'ancien export open-data. -#}
+{%- set offset = "(" ~ ts ~ ") - ((" ~ ts ~ ") AT TIME ZONE 'Europe/Paris' AT TIME ZONE 'UTC')" -%}
+to_char({{ ts }}, 'YYYY-MM-DD"T"HH24:MI:SS') || '+' || to_char({{ offset }}, 'HH24MI')
+{% endmacro %}

--- a/datalake/models/exposed/export/export_opendata.sql
+++ b/datalake/models/exposed/export/export_opendata.sql
@@ -17,6 +17,14 @@ WITH latest_perimeters AS (
     END                                                    AS precision
   FROM {{ ref('perimeters') }}
   ORDER BY arr ASC, year DESC
+),
+
+-- Semi-jointure pré-agrégée : trajet rattaché à au moins une campagne validée
+-- (= has_incentive de l'ancien export, indépendant du montant, qui peut être nul).
+incentivised AS (
+  SELECT DISTINCT carpool_v2_id
+  FROM {{ ref('incentives') }}
+  WHERE status = 'validated'
 )
 
 SELECT
@@ -24,12 +32,8 @@ SELECT
     AS journey_id,
   gps.arr
     AS journey_start_insee,
-
-  -- date filtering column (raw DATE in Europe/Paris)
   gps.dep
     AS journey_start_department,
-
-  -- start
   gps.l_arr
     AS journey_start_town,
   gps.l_epci
@@ -48,57 +52,55 @@ SELECT
     AS journey_end_country,
   c.passenger_seats,
   c.operator_class,
-
-  -- end
   c.distance
     AS journey_distance,
-  c.with_incentive
+  -- OUI/NON : rattachement à une campagne validée (cf. CTE incentivised)
+  CASE WHEN inc.carpool_v2_id IS NOT NULL THEN 'OUI' ELSE 'NON' END
     AS has_incentive,
   ts.carpools
     AS start_insee_count,
   te.carpools
     AS end_insee_count,
-  COALESCE(
-    c.operator_trip_id::text, GEN_RANDOM_UUID()::text
+  -- SHA-256 hex de l'operator_trip_id (masque l'id opérateur brut en open-data)
+  encode(
+    sha256(convert_to(
+      COALESCE(c.operator_trip_id::text, GEN_RANDOM_UUID()::text), 'UTF8'
+    )),
+    'hex'
   )                AS trip_id,
   (
     c.start_datetime AT TIME ZONE 'Europe/Paris'
   )::date          AS start_date_filter,
+  {{ iso8601_paris('TS_CEIL(c.start_datetime_tz, 600)') }}
+                   AS journey_start_datetime,
   TO_CHAR(
-    TS_CEIL(c.start_datetime_tz, 600) AT TIME ZONE 'Europe/Paris',
-    'YYYY-MM-DD HH24:MI:SS'
-  )                AS journey_start_datetime,
-  TO_CHAR(
-    TS_CEIL(c.start_datetime_tz, 600) AT TIME ZONE 'Europe/Paris', 'YYYY-MM-DD'
+    TS_CEIL(c.start_datetime_tz, 600), 'YYYY-MM-DD'
   )                AS journey_start_date,
   TO_CHAR(
-    TS_CEIL(c.start_datetime_tz, 600) AT TIME ZONE 'Europe/Paris', 'HH24:MI:SS'
+    TS_CEIL(c.start_datetime_tz, 600), 'HH24:MI:SS'
   )                AS journey_start_time,
   TRUNC(
     ST_X(sc.start_position::geometry)::numeric, gps.precision
-  )                AS journey_start_lon,
+  )::float8        AS journey_start_lon,
 
   TRUNC(
     ST_Y(sc.start_position::geometry)::numeric, gps.precision
-  )                AS journey_start_lat,
+  )::float8        AS journey_start_lat,
+  {{ iso8601_paris('TS_CEIL(c.end_datetime_tz, 600)') }}
+                   AS journey_end_datetime,
   TO_CHAR(
-    TS_CEIL(c.end_datetime_tz, 600) AT TIME ZONE 'Europe/Paris',
-    'YYYY-MM-DD HH24:MI:SS'
-  )                AS journey_end_datetime,
-  TO_CHAR(
-    TS_CEIL(c.end_datetime_tz, 600) AT TIME ZONE 'Europe/Paris', 'YYYY-MM-DD'
+    TS_CEIL(c.end_datetime_tz, 600), 'YYYY-MM-DD'
   )                AS journey_end_date,
   TO_CHAR(
-    TS_CEIL(c.end_datetime_tz, 600) AT TIME ZONE 'Europe/Paris', 'HH24:MI:SS'
+    TS_CEIL(c.end_datetime_tz, 600), 'HH24:MI:SS'
   )                AS journey_end_time,
   TRUNC(
     ST_X(sc.end_position::geometry)::numeric, gpe.precision
-  )                AS journey_end_lon,
+  )::float8        AS journey_end_lon,
 
-  -- INSEE occurrence counts (for filtering by API)
   TRUNC(
     ST_Y(sc.end_position::geometry)::numeric, gpe.precision
-  )                AS journey_end_lat,
+  )::float8        AS journey_end_lat,
   ROUND(
     c.duration / 60.0
   )                AS journey_duration
@@ -107,6 +109,7 @@ FROM {{ ref('carpools') }} AS c
 LEFT JOIN
   {{ source('dlk_import', 'carpool_v2_carpools') }} AS sc
   ON c._id = sc._id
+LEFT JOIN incentivised AS inc ON inc.carpool_v2_id = c._id
 LEFT JOIN
   {{ ref('territory_month_arr_from') }} AS ts
   ON

--- a/datalake/models/exposed/export/export_opendata.sql
+++ b/datalake/models/exposed/export/export_opendata.sql
@@ -19,8 +19,8 @@ WITH latest_perimeters AS (
   ORDER BY arr ASC, year DESC
 ),
 
--- Semi-jointure pré-agrégée : trajet rattaché à au moins une campagne validée
--- (= has_incentive de l'ancien export, indépendant du montant, qui peut être nul).
+-- Semi-jointure : trajet rattaché à une campagne validée (= has_incentive de
+-- l'ancien export, indépendant du montant, qui peut être nul).
 incentivised AS (
   SELECT DISTINCT carpool_v2_id
   FROM {{ ref('incentives') }}
@@ -55,71 +55,81 @@ SELECT
   c.distance
     AS journey_distance,
   -- OUI/NON : rattachement à une campagne validée (cf. CTE incentivised)
-  CASE WHEN inc.carpool_v2_id IS NOT NULL THEN 'OUI' ELSE 'NON' END
-    AS has_incentive,
   ts.carpools
     AS start_insee_count,
   te.carpools
     AS end_insee_count,
+  CASE WHEN inc.carpool_v2_id IS NOT NULL THEN 'OUI' ELSE 'NON' END
+    AS has_incentive,
   -- SHA-256 hex de l'operator_trip_id (masque l'id opérateur brut en open-data)
   encode(
     sha256(convert_to(
-      COALESCE(c.operator_trip_id::text, GEN_RANDOM_UUID()::text), 'UTF8'
+      coalesce(c.operator_trip_id::text, gen_random_uuid()::text), 'UTF8'
     )),
     'hex'
-  )                AS trip_id,
+  )                                                                 AS trip_id,
   (
     c.start_datetime AT TIME ZONE 'Europe/Paris'
-  )::date          AS start_date_filter,
-  {{ iso8601_paris('TS_CEIL(c.start_datetime_tz, 600)') }}
-                   AS journey_start_datetime,
-  TO_CHAR(
-    TS_CEIL(c.start_datetime_tz, 600), 'YYYY-MM-DD'
-  )                AS journey_start_date,
-  TO_CHAR(
-    TS_CEIL(c.start_datetime_tz, 600), 'HH24:MI:SS'
-  )                AS journey_start_time,
-  TRUNC(
-    ST_X(sc.start_position::geometry)::numeric, gps.precision
-  )::float8        AS journey_start_lon,
+  )::date
+    AS start_date_filter,
+  {{ iso8601_paris('ts_ceil(c.start_datetime_tz, 600)') }}
+    AS journey_start_datetime,
+  to_char(
+    ts_ceil(c.start_datetime_tz, 600), 'YYYY-MM-DD'
+  )
+    AS journey_start_date,
+  to_char(
+    ts_ceil(c.start_datetime_tz, 600), 'HH24:MI:SS'
+  )
+    AS journey_start_time,
+  trunc(
+    st_x(sc.start_position::geometry)::numeric, gps.precision
+  )::float8
+    AS journey_start_lon,
 
-  TRUNC(
-    ST_Y(sc.start_position::geometry)::numeric, gps.precision
-  )::float8        AS journey_start_lat,
-  {{ iso8601_paris('TS_CEIL(c.end_datetime_tz, 600)') }}
-                   AS journey_end_datetime,
-  TO_CHAR(
-    TS_CEIL(c.end_datetime_tz, 600), 'YYYY-MM-DD'
-  )                AS journey_end_date,
-  TO_CHAR(
-    TS_CEIL(c.end_datetime_tz, 600), 'HH24:MI:SS'
-  )                AS journey_end_time,
-  TRUNC(
-    ST_X(sc.end_position::geometry)::numeric, gpe.precision
-  )::float8        AS journey_end_lon,
+  trunc(
+    st_y(sc.start_position::geometry)::numeric, gps.precision
+  )::float8
+    AS journey_start_lat,
+  {{ iso8601_paris('ts_ceil(c.end_datetime_tz, 600)') }}
+    AS journey_end_datetime,
+  to_char(
+    ts_ceil(c.end_datetime_tz, 600), 'YYYY-MM-DD'
+  )
+    AS journey_end_date,
+  to_char(
+    ts_ceil(c.end_datetime_tz, 600), 'HH24:MI:SS'
+  )
+    AS journey_end_time,
+  trunc(
+    st_x(sc.end_position::geometry)::numeric, gpe.precision
+  )::float8
+    AS journey_end_lon,
 
-  TRUNC(
-    ST_Y(sc.end_position::geometry)::numeric, gpe.precision
-  )::float8        AS journey_end_lat,
-  ROUND(
+  trunc(
+    st_y(sc.end_position::geometry)::numeric, gpe.precision
+  )::float8
+    AS journey_end_lat,
+  round(
     c.duration / 60.0
-  )                AS journey_duration
+  )
+    AS journey_duration
 
 FROM {{ ref('carpools') }} AS c
 LEFT JOIN
   {{ source('dlk_import', 'carpool_v2_carpools') }} AS sc
   ON c._id = sc._id
-LEFT JOIN incentivised AS inc ON inc.carpool_v2_id = c._id
+LEFT JOIN incentivised AS inc ON c._id = inc.carpool_v2_id
 LEFT JOIN
   {{ ref('territory_month_arr_from') }} AS ts
   ON
     c.start_geo_code = ts.code
-    AND DATE_TRUNC('month', c.start_datetime) = ts.incremental_date
+    AND date_trunc('month', c.start_datetime) = ts.incremental_date
 LEFT JOIN
   {{ ref('territory_month_arr_to') }} AS te
   ON
     c.end_geo_code = te.code
-    AND DATE_TRUNC('month', c.start_datetime) = te.incremental_date
+    AND date_trunc('month', c.start_datetime) = te.incremental_date
 LEFT JOIN latest_perimeters AS gps ON c.start_geo_code = gps.arr
 LEFT JOIN latest_perimeters AS gpe ON c.end_geo_code = gpe.arr
 

--- a/datalake/models/exposed/export/yml/_export_opendata.yml
+++ b/datalake/models/exposed/export/yml/_export_opendata.yml
@@ -15,9 +15,9 @@ models:
       - name: journey_start_time
         data_type: text
       - name: journey_start_lon
-        data_type: numeric
+        data_type: double precision
       - name: journey_start_lat
-        data_type: numeric
+        data_type: double precision
       - name: journey_start_insee
         data_type: character varying
       - name: journey_start_department
@@ -35,9 +35,9 @@ models:
       - name: journey_end_time
         data_type: text
       - name: journey_end_lon
-        data_type: numeric
+        data_type: double precision
       - name: journey_end_lat
-        data_type: numeric
+        data_type: double precision
       - name: journey_end_insee
         data_type: character varying
       - name: journey_end_department
@@ -57,7 +57,7 @@ models:
       - name: journey_duration
         data_type: numeric
       - name: has_incentive
-        data_type: boolean
+        data_type: character varying
       - name: start_insee_count
         data_type: bigint
       - name: end_insee_count


### PR DESCRIPTION
## Contexte

La vérification de parité de la bascule legacy → datalake a montré que les fichiers **open-data
data.gouv** produits par le nouveau pipeline n'étaient **pas ISO** avec ceux publiés
aujourd'hui. L'ancienne chaîne appliquait des transformations dans son `CSVWriter` (processeurs
`computed`) ; le nouveau job data.gouv fait un `COPY` brut de la vue `export_opendata`, donc ces
transformations manquaient et cassaient le contrat des fichiers publiés.

*(La bascule des exports territoire/opérateur, elle, est déjà ISO — corrigée par les PR
antérieures. Cette PR ne concerne que l'open-data.)*

## Ce que contient la PR

Correctifs sur la vue `datalake/models/exposed/export/export_opendata.sql` (+ son `.yml`) pour
reproduire exactement le format de l'ancien export :

- **`has_incentive`** — passe de `t`/`f` (booléen `with_incentive`) à **`OUI`/`NON`**, avec la
  sémantique de l'ancien export : « trajet rattaché à une **campagne validée** » (semi-jointure
  `incentivised` sur `incentives WHERE status = 'validated'`), indépendante du montant (qui peut
  être nul). Aucun montant n'est exposé.
- **`trip_id`** — haché en **SHA-256 hex** (`encode(sha256(convert_to(...)), 'hex')`) au lieu de
  publier l'`operator_trip_id` **en clair**. Reproduit `createHash` de l'ancienne chaîne et
  **masque l'identifiant opérateur** en open-data.
- **`journey_start/end_datetime`** — format **ISO 8601 `yyyy-MM-dd'T'HH:mm:ssXX`** avec offset
  Europe/Paris (DST), via le nouveau macro `iso8601_paris`. L'arrondi 10 min (`TS_CEIL`) est
  préservé. `journey_end_datetime` porte enfin la **vraie heure d'arrivée** (l'ancien recopiait
  par erreur l'heure de départ — décision : garder la correction).
- **`lat`/`lon`** — cast en **float** (retire les zéros de fin), comme `export_partners`. La
  troncature de précision géographique (`TRUNC(..., precision)`) est **inchangée**.

Nouveau macro `datalake/macros/helpers/iso8601_paris.sql` : horodatage ISO local + offset
Europe/Paris (toujours positif, UTC+1/+2).

## Validation

- **`dbt compile`** du modèle : OK (macro et refs résolus).
- **Test bout-en-bout** sur Postgres 17 + PostGIS (table stub + ligne synthétique parisienne) :
  sortie conforme au format legacy — `has_incentive=OUI`, `trip_id` = SHA-256 attendu,
  `journey_start_datetime=2026-05-01T15:20:00+0200`, offset d'hiver `+0100` vérifié, lat/lon en
  float sans zéros de fin.
- `sqlfluff` : les seuls avertissements restants (fonctions en majuscules, alignement, ordre de
  join) sont **préexistants** au fichier et le job est non bloquant ; aucune nouvelle catégorie
  introduite.

## Portée & déploiement

PR **data-only** (`datalake/**`, dbt) → type `fix`, scope `datalake` : **ne déclenche aucune
release** applicative (attendu — le datalake se déploie hors du pipeline `release`).

## Sécurité (relecture — PASS, risque faible)

Aucun secret introduit. Le SQL de la vue et du macro est **statique**, résolu à la compilation
dbt : les seuls appels du macro passent des fragments SQL constants écrits par les développeurs
(`TS_CEIL(c.start_datetime_tz, 600)`), jamais une entrée runtime → **aucun vecteur d'injection**.
Le hachage SHA-256 du `trip_id` est un **durcissement** (l'identifiant opérateur n'est plus
publié en clair). La semi-jointure `incentivised` ne divulgue ni montant ni identifiant de
campagne. Cast `::float8` appliqué **après** la troncature de précision → surface de données
inchangée.

## CGU (garde-fou — PASS)

Aucune règle enfreinte. Vue en **lecture seule** : aucune écriture ni mutation de statut
(CGU-1), aucune modification de rétention (CGU-2). **Aucune donnée nouvelle exposée** et **aucune
dé-anonymisation** (CGU-3) — au contraire, le hachage du `trip_id` **renforce** l'anonymat, et
l'arrondi temporel 10 min comme la précision géographique tronquée sont préservés.
