### PR TITLE
fix(datalake): raccroche l'observatoire OD au refresh quotidien

### DIFF
--- a/datalake/justfile
+++ b/datalake/justfile
@@ -123,15 +123,17 @@ pipeline-raw *args:
 pipeline-trusted-geo *args:
   just dbt run --select "tag:trusted,tag:geo" {{args}}
 
-# Pipeline 3 : daily update:
+# Pipeline 3 : daily update (agrégés taggés daily + zone exposée + invalidation du cache).
+# Un seul `dbt run` sur l'union => dbt ordonne le DAG (agrégés frais avant l'exposé).
 pipeline-daily *args:
-  just dbt run --select "tag:daily" {{args}}
+  just dbt run --select "tag:daily" "models/exposed" {{args}}
+  just cache-bump
 
 # Invalide le cache de l'API observatoire (INCR obs:cache:version). No-op sans REDIS_URL.
 cache-bump:
   python -m pipelines.cmd.cache_bump
 
-# Pipeline 4 : zone exposée + invalidation du cache observatoire (appel unique côté ops).
+# Zone exposée seule + invalidation du cache (usage manuel/backfill ; le cron ops appelle pipeline-daily).
 pipeline-exposed *args:
   just dbt run --select "models/exposed" {{args}}
   just cache-bump

--- a/datalake/macros/models/aggregated/od/od_model.sql
+++ b/datalake/macros/models/aggregated/od/od_model.sql
@@ -24,7 +24,7 @@
 
 {{ config(
   materialized='view',
-  tags=['aggregated', 'od', grain, 'com', 'daily']
+  tags=['aggregated', 'od', grain, 'com']
 ) }}
 
 SELECT * FROM {{ ref('od_' ~ grain ~ '_arr') }}
@@ -40,7 +40,7 @@ SELECT * FROM {{ ref('od_' ~ grain ~ '_plm') }}
   indexes=[
     {'columns': ['territory_1', 'territory_2', 'incremental_date'], 'unique': true}
   ],
-  tags=['aggregated', 'od', grain, perim]
+  tags=['aggregated', 'od', grain, perim, 'daily']
 ) }}
 
 WITH filtered_carpools AS (


### PR DESCRIPTION
## Résumé

Corrige un **bug de production** : l'observatoire OD (flux origine-destination de la carte publique) servait des données **périmées**. Les agrégés `od_*` n'étaient jamais reconstruits par le pipeline quotidien — seulement en `backfill` — à cause d'une asymétrie de tags dans la macro génératrice. Cette PR raccroche l'OD au refresh quotidien et fait en sorte que le run quotidien reconstruise aussi la zone exposée et invalide le cache observatoire.

## Ce qui change

### 1. `macros/models/aggregated/od/od_model.sql` — asymétrie de tags

Le tag de cadence `daily` était posé sur la **vue** `od_{grain}_com` (un `CREATE OR REPLACE VIEW`, donc un no-op côté données) et **manquait** sur les tables incrémentales réelles (`od_{grain}_{arr,plm,aom,aomreg,dep,epci,reg,country}`). Résultat : `dbt run --select tag:daily` ne sélectionnait que des vues et **jamais** les tables qui portent la donnée.

On inverse le placement pour coller **exactement** aux familles sœurs `territory_model` / `fraud_model` / `operators_model` (vue `com` sans `daily`, incrémentaux avec `daily`).

### 2. `justfile` — fusion `pipeline-exposed` dans `pipeline-daily`

`pipeline-daily` ne construisait que `tag:daily` : la zone exposée et l'invalidation du cache (`cache-bump`) ne tournaient pas dans le run quotidien. On fusionne :

```
pipeline-daily *args:
  just dbt run --select "tag:daily" "models/exposed" {{args}}
  just cache-bump
```

Un **seul** `dbt run` sur l'union → dbt ordonne le DAG (agrégés OD frais **avant** l'exposé OD), puis invalide le cache. `pipeline-exposed` reste dispo pour un usage manuel/backfill. Le cron ops garde son unique appel `just pipeline-daily`.

## Pourquoi (impact prod)

Sans ce correctif, la famille OD de l'observatoire n'était rafraîchie qu'aux backfills manuels : le mois en cours et les corrections amont (fraude/géo, arrivant à J-3) n'apparaissaient jamais dans les flux OD publics. Les familles sœurs (distribution / occupation / incentive / users) étaient, elles, déjà à J-1.

## Vérification (`dbt ls`)

- `tag:daily,tag:od` liste désormais les **40 incrémentaux OD** (arr/plm/aom/aomreg/dep/epci/reg/country × 5 grains) — **0** avant le fix.
- Les vues `od_{grain}_com` **sortent** de `tag:daily` (elles restent des vues, reflétant live les tables fraîches).
- La nouvelle union `pipeline-daily` sélectionne **453 modèles**, dont les exposés OD (`od_month/quarter/semester/year`, `distribution_month`, `location`) **et** leurs agrégés amont (`od_month_epci/aom`).

## Sécurité

**PASS** (non bloquant). Aucun risque introduit : pas d'injection, pas de secret, pas d'exposition de données nouvelle. `models/exposed` était déjà matérialisé par `pipeline-exposed` ; la PR ne fait que fusionner l'ordonnancement. Le `{{args}}` et l'appel `cache-bump` (INCR Redis, sans paramètre variable) sont inchangés.

## CGU

**PASS** (bloquant levé). Deux fichiers datalake (tags de cadence + recettes de pipeline), sans aucune donnée personnelle ni valeur métier. Aucune règle CGU (statut définitif, rétention, minimisation PII) concernée.

## Release

**Data-only (`datalake/`) → aucune release, aucun déploiement applicatif** — attendu. Le datalake se déploie via build d'image, pas via semantic-release ; le scope `datalake` supprime de toute façon la release. Le nouveau comportement prend effet au prochain run du cron ops.

## Suivi

- Tâche liée (projet Datalake V1) : nettoyage de `user_od_month` — agrégé orphelin repéré pendant l'audit des tags (tag `monthly` mort, aucun consommateur), gardé en l'état pour l'instant.