### PR TITLE
fix(datalake): préfixe /v3 sur les appels API de l'export-worker

### DIFF
--- a/datalake/pipelines/helpers/api_client.py
+++ b/datalake/pipelines/helpers/api_client.py
@@ -16,7 +16,10 @@ import requests
 
 class ApiClient:
     def __init__(self, base_url, access_key, secret_key):
-        self.base_url = base_url.rstrip("/")
+        # The API mounts apiRoute handlers under a /:api_version/ prefix
+        # (registerExpressRoute), so every path must carry /v3 — the bare root
+        # 404s. v3 satisfies the supported range (3.3.0–3.4.0).
+        self.base_url = f"{base_url.rstrip('/')}/v3"
         self.access_key = access_key
         self.secret_key = secret_key
         self._token = None

--- a/datalake/tests/test_api_client.py
+++ b/datalake/tests/test_api_client.py
@@ -23,3 +23,22 @@ def test_claim_returns_payload_on_200(rq):
         MagicMock(status_code=200, json=lambda: {"uuid": "u", "target": "operator", "params": {}}),
     ]
     assert _client().claim(["operator"])["uuid"] == "u"
+
+
+# The mono API mounts apiRoute handlers under a /:api_version/ prefix, so calls
+# must target /v3/... — hitting the bare root returns 404.
+@patch("pipelines.helpers.api_client.requests")
+def test_auth_targets_versioned_path(rq):
+    rq.post.return_value = MagicMock(status_code=201, json=lambda: {"access_token": "t"})
+    _client()._auth()
+    assert rq.post.call_args.args[0] == "https://api.test/v3/auth/access_token"
+
+
+@patch("pipelines.helpers.api_client.requests")
+def test_claim_targets_versioned_path(rq):
+    rq.post.side_effect = [
+        MagicMock(status_code=201, json=lambda: {"access_token": "t"}),
+        MagicMock(status_code=204),
+    ]
+    _client().claim(["operator"])
+    assert rq.post.call_args_list[1].args[0] == "https://api.test/v3/exports/claim"


### PR DESCRIPTION
## Contexte

L'`export-worker` du datalake échoue à chaque exécution :

```
HTTPError: 404 Client Error: Not Found for url:
https://api.covoiturage.beta.gouv.fr/auth/access_token
```

## Cause

Le proxy monte les handlers `apiRoute` sous un préfixe `/:api_version/` (`registerExpressRoute.ts`). Les routes réelles sont donc `/v3/auth/access_token`, `/v3/exports/claim`, etc. Le client Python (`api_client.py`) visait la racine, sans version → 404.

Vérifié en production :

| chemin | code |
|---|---|
| `POST /auth/access_token` | 404 |
| `POST /v3/auth/access_token` | 400 (route présente, corps vide) |
| `POST /v3/exports/claim` | 403 (route présente, token requis) |

## Correctif

Le client préfixe désormais `base_url` avec `/v3` (satisfait la plage supportée `3.3.0–3.4.0`). `API_URL` reste inchangé côté infra.

## Tests

Deux tests ajoutés (URL versionnée pour `auth` et `claim`). Suite datalake : 78 passés, 2 ignorés.