### PR TITLE
fix(datalake): l'export-worker gère la file vide sans planter

### DIFF
--- a/datalake/pipelines/helpers/api_client.py
+++ b/datalake/pipelines/helpers/api_client.py
@@ -60,7 +60,9 @@ class ApiClient:
 
     def claim(self, targets):
         r = self._post("/exports/claim", {"targets": targets})
-        if r.status_code == 204:
+        # Empty queue: the API returns 200 with an empty body (null result ->
+        # res.end()), so an empty body means "no task", not decodable JSON.
+        if r.status_code == 204 or not r.content:
             return None
         return r.json()
 

--- a/datalake/tests/test_api_client.py
+++ b/datalake/tests/test_api_client.py
@@ -42,3 +42,16 @@ def test_claim_targets_versioned_path(rq):
     ]
     _client().claim(["operator"])
     assert rq.post.call_args_list[1].args[0] == "https://api.test/v3/exports/claim"
+
+
+# Empty queue: the API returns 200 with an empty body (null result -> res.end()),
+# not 204, so claim must treat an empty body as "no task" rather than r.json().
+@patch("pipelines.helpers.api_client.requests")
+def test_claim_returns_none_on_empty_200_body(rq):
+    empty = MagicMock(status_code=200, content=b"")
+    empty.json.side_effect = ValueError("Expecting value: line 1 column 1 (char 0)")
+    rq.post.side_effect = [
+        MagicMock(status_code=201, json=lambda: {"access_token": "t"}),  # token
+        empty,                                                           # empty claim
+    ]
+    assert _client().claim(["operator"]) is None


### PR DESCRIPTION
## Contexte

Suite du correctif `/v3` (#3288). Le worker authentifie et appelle désormais `/v3/exports/claim`, mais plante sur une file vide :

```
api_client.py:65 in claim -> return r.json()
JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

## Cause

Quand aucune tâche n'est disponible, `ClaimAction` renvoie `null`. Le handler générique (`registerExpressRoute`) fait alors `res.status(200)` puis `res.end()` : **HTTP 200 avec un corps vide**, pas 204. Le client ne gérait que le cas 204 et tentait `r.json()` sur un corps vide.

Conséquence : chaque exécution plante dès que la file se vide (y compris après avoir traité des exports), et un worker sur file vide remonte un échec au lieu d'un `0 traité`.

## Correctif

`claim()` traite un corps vide (`not r.content`) comme l'absence de tâche, en plus du 204 déjà géré.

## Tests

Test ajouté : `claim` renvoie `None` sur un 200 à corps vide. Suite datalake : 79 passés, 2 ignorés.