### PR TITLE
fix(datalake): rend la requête observatoire location sargable (+ timeout 30s)

### DIFF
--- a/api-datalake/src/api_datalake/config.py
+++ b/api-datalake/src/api_datalake/config.py
@@ -24,7 +24,8 @@ class Settings(BaseSettings):
     dbt_password: str = ""
     dbt_dbname: str = "datalake"
     # Plafond par requête : borne les scans H3 lourds, protège le pool (ms).
-    db_statement_timeout_ms: int = 5000
+    # 30s (stopgap) : location scanne carpools à la volée ; à réduire après pré-agrégation.
+    db_statement_timeout_ms: int = 30000
 
     # Cache
     redis_url: str | None = None

--- a/api-datalake/src/api_datalake/repositories/observatory.py
+++ b/api-datalake/src/api_datalake/repositories/observatory.py
@@ -4,6 +4,8 @@ Porté depuis `api/src/pdc/services/observatory/providers/*`. Toutes les valeurs
 sont liées (paramétrées) ; `type` est en plus validé par allowlist en amont.
 """
 
+from datetime import date
+
 from ..helpers import check_territory_param
 
 # Toutes les sources sont dans la zone exposée : l'API ne lit rien d'autre.
@@ -34,6 +36,28 @@ _PERIM_COL = {
 }
 
 
+def _add_months(year: int, month: int, delta: int) -> date:
+    idx = year * 12 + (month - 1) + delta
+    return date(idx // 12, idx % 12 + 1, 1)
+
+
+def _period_bounds(year: int, month: int | None, trimester: int | None,
+                   semester: int | None) -> tuple[str, str]:
+    """Bornes [début, fin) de la période en dates ISO, pour un filtre sargable
+    sur start_datetime (index start_datetime_tz). Un seul grain à la fois."""
+    if month is not None:
+        start, end = date(year, month, 1), _add_months(year, month, 1)
+    elif trimester is not None:
+        sm = (trimester - 1) * 3 + 1
+        start, end = date(year, sm, 1), _add_months(year, sm, 3)
+    elif semester is not None:
+        sm = 1 if semester == 1 else 7
+        start, end = date(year, sm, 1), _add_months(year, sm, 6)
+    else:
+        start, end = date(year, 1, 1), date(year + 1, 1, 1)
+    return start.isoformat(), end.isoformat()
+
+
 def build_location_query(type_: str, code: str, year: int, n: int,
                          month: int | None = None, trimester: int | None = None,
                          semester: int | None = None) -> tuple[str, dict]:
@@ -46,21 +70,13 @@ def build_location_query(type_: str, code: str, year: int, n: int,
     type_ = check_territory_param(type_)
     col = _PERIM_COL[type_]
 
-    params: dict = {"code": code, "year": year, "n": n}
-    period = ["EXTRACT(YEAR FROM start_datetime) = %(year)s"]
-    if month is not None:
-        period.append("EXTRACT(MONTH FROM start_datetime) = %(month)s")
-        params["month"] = month
-    if trimester is not None:
-        period.append("EXTRACT(QUARTER FROM start_datetime) = %(trimester)s")
-        params["trimester"] = trimester
-    if semester is not None:
-        # Réplique à l'identique la logique de l'API (Q4 -> S2, sinon S1).
-        period.append(
-            "(CASE WHEN EXTRACT(QUARTER FROM start_datetime)::int > 3 THEN 2 ELSE 1 END) = %(semester)s"
-        )
-        params["semester"] = semester
-    period_sql = " AND ".join(period)
+    dt_start, dt_end = _period_bounds(year, month, trimester, semester)
+    params: dict = {"code": code, "year": year, "n": n,
+                    "dt_start": dt_start, "dt_end": dt_end}
+    # Filtre temporel sargable : plage [dt_start, dt_end) sur start_datetime, qui
+    # utilise l'index start_datetime_tz. EXTRACT(...) forçait un Seq Scan de carpools
+    # (~60 s -> statement_timeout). Un seul grain (mois/trimestre/semestre) à la fois.
+    period_sql = "start_datetime >= %(dt_start)s AND start_datetime < %(dt_end)s"
 
     geo = ("(start_geo_code IN (SELECT com FROM perims) "
            "OR end_geo_code IN (SELECT com FROM perims))")

--- a/api-datalake/tests/test_location.py
+++ b/api-datalake/tests/test_location.py
@@ -33,18 +33,20 @@ def test_query_unknown_type_falls_back_to_arr():
 
 
 def test_query_period_filters_by_grain():
-    _, p_month = build_location_query("com", "75056", 2022, 8, month=6)
-    assert p_month["month"] == 6 and "trimester" not in p_month
+    sql_m, p_month = build_location_query("com", "75056", 2022, 8, month=6)
+    assert "start_datetime >= %(dt_start)s AND start_datetime < %(dt_end)s" in sql_m
+    assert p_month["dt_start"] == "2022-06-01" and p_month["dt_end"] == "2022-07-01"
 
-    sql_t, p_tri = build_location_query("com", "75056", 2022, 8, trimester=2)
-    assert "EXTRACT(QUARTER FROM start_datetime) = %(trimester)s" in sql_t
-    assert p_tri["trimester"] == 2
+    _, p_tri = build_location_query("com", "75056", 2022, 8, trimester=2)  # T2 -> avr..juin
+    assert p_tri["dt_start"] == "2022-04-01" and p_tri["dt_end"] == "2022-07-01"
+
+    _, p_year = build_location_query("com", "75056", 2022, 8)  # année pleine
+    assert p_year["dt_start"] == "2022-01-01" and p_year["dt_end"] == "2023-01-01"
 
 
-def test_query_semester_maps_to_quarter_case():
-    sql_s, p_sem = build_location_query("com", "75056", 2022, 8, semester=2)
-    assert "CASE WHEN EXTRACT(QUARTER FROM start_datetime)::int > 3 THEN 2 ELSE 1 END" in sql_s
-    assert p_sem["semester"] == 2
+def test_query_semester_bounds():
+    _, p_sem = build_location_query("com", "75056", 2022, 8, semester=2)  # S2 -> juil..déc
+    assert p_sem["dt_start"] == "2022-07-01" and p_sem["dt_end"] == "2023-01-01"
 
 
 # --- endpoint /observatory/location ---

--- a/docs/superpowers/specs/2026-07-15-observatory-location-preaggregation.md
+++ b/docs/superpowers/specs/2026-07-15-observatory-location-preaggregation.md
@@ -1,0 +1,86 @@
+# Observatoire `location` — pré-agrégation (version robuste)
+
+**Statut** : proposition. Mitigation immédiate déjà livrée (filtre sargable + `statement_timeout` 30 s).
+
+## Problème
+
+L'endpoint `/observatory/location` (heatmap de densité H3) agrège **à la volée**
+`zone_trusted.carpools` : la vue `zone_exposed.location` expose les colonnes brutes et
+`build_location_query` fait le binning `h3_cell_to_parent(start/end_h3index_z8, n)` +
+`GROUP BY` à chaque requête.
+
+- Avant fix : filtre `EXTRACT(YEAR/MONTH FROM start_datetime)` non-sargable → **Seq Scan
+  de ~50 M lignes** → **~60 s** → coupé par `statement_timeout` (5 s) → **500**.
+- Après mitigation (sargable) : Index Scan sur `start_datetime_tz` → **~2,4 s** pour une
+  région-mois. Mais un scope **année** ou **pays** reste lourd (12× à N× plus de lignes),
+  proche/au-delà du timeout, et chaque requête relit `carpools` (coûteux, tient une
+  connexion du pool). Les autres stats (flux, occupation…) lisent des **tables
+  pré-agrégées** et répondent en < 100 ms.
+
+## Objectif
+
+Aligner `location` sur le patron des autres stats : l'API lit une **table pré-agrégée**
+de `zone_exposed`, petite et indexée, au lieu de scanner `carpools`.
+
+## Design proposé
+
+### Modèle dbt agrégé
+
+Nouvelle table matérialisée (grain z8, le plus fin utilisé par le front qui envoie `n=8`) :
+
+```
+zone_aggregated.location_z8 (
+  type            text,        -- grain territoire (com/epci/aom/dep/reg/country)
+  code            text,        -- code du territoire (millésime courant des périmètres)
+  year            int,
+  month           int,         -- + colonnes grain (ou tables _month/_quarter/_semester/_year
+                               --   comme od_*, au choix)
+  h3_z8           h3index,     -- hexagone z8 (départ OU arrivée, dédoublonné par ligne)
+  count           bigint
+)
+```
+
+- Peuplée par un modèle dbt lisant `zone_trusted.carpools` (mêmes filtres :
+  `valid_acquisition_status`, `start_datetime_tz < now()-2j`), croisé avec
+  `zone_trusted.perimeters_agg` pour rattacher chaque trajet à ses territoires
+  (start_geo_code / end_geo_code → type+code), puis `GROUP BY type, code, période, h3_z8`.
+- Projetée en `zone_exposed.location_z8` (contrat public), avec `GRANT SELECT` à
+  `datalake_api_ro` **via `ALTER DEFAULT PRIVILEGES`** (voir « Droits » plus bas).
+
+### Requête API
+
+`build_location_query` lit la table pré-agrégée :
+
+```sql
+SELECT h3_cell_to_parent(h3_z8, %(n)s)::text AS hex, sum(count)::int AS count
+FROM zone_exposed.location_z8
+WHERE type = %(type)s AND code = %(code)s
+  AND <filtre période sargable>
+GROUP BY 1
+```
+
+- Pour `n = 8` : `h3_cell_to_parent(h3_z8, 8) = h3_z8` (no-op) → lecture directe.
+- Pour `n < 8` : agrégation vers l'ancêtre — sur un petit ensemble (un territoire × une
+  période), pas sur `carpools`.
+- Plus de jointure `carpools` ni de résolution de périmètre au runtime (faite en amont).
+
+### Pipeline & droits
+
+- Brancher le modèle dans le pipeline exposé (`pipeline-daily` / `models/exposed`), avec
+  `cache-bump` pour l'invalidation Redis (déjà en place pour les autres agrégés).
+- **Droits** : le bug 500 initial venait aussi de vues recréées perdant leur ACL. Poser
+  un `ALTER DEFAULT PRIVILEGES IN SCHEMA zone_exposed GRANT SELECT ON TABLES TO
+  datalake_api_ro` (et pour les vues) pour que les objets recréés par dbt gardent le grant.
+
+### Suites
+
+- Après passage en pré-agrégé : **rabaisser `db_statement_timeout_ms` à 5 s** (le 30 s
+  n'était qu'un stopgap).
+- Décider du grain exposé (`_month/_quarter/_semester/_year` séparés comme `od_*`, ou une
+  table unique avec colonnes de grain). Cohérence avec `observatory/helpers/tableName.ts`
+  côté front (le front ne fait que passer les params ; pas d'impact).
+
+## Hors-scope
+
+- Seuil de k-anonymat sur la heatmap (`count=1` à n=8 ré-identifiant) — hérité du legacy,
+  à traiter séparément (déjà noté dans GEN-668).


### PR DESCRIPTION
## Problème

`GET /observatory/location` (heatmap de densité) renvoyait **500** en prod. Cause racine confirmée par `EXPLAIN ANALYZE` : la requête agrège `zone_trusted.carpools` à la volée avec un filtre `EXTRACT(YEAR/MONTH FROM start_datetime)` **non-sargable** → **Seq Scan de ~50 M lignes (~60 s)** → coupée par le `statement_timeout` (5 s) → 500. Les autres endpoints lisent des tables pré-agrégées (rapides) → 200.

## Correctif

- **Filtre temporel sargable** : plage de dates `start_datetime >= dt_start AND < dt_end` (bornes calculées depuis `year/month/trimestre/semestre`) → utilise l'index `start_datetime_tz`. Mesuré : **~60 s → ~2,4 s** pour une région-mois (Index Scan au lieu de Seq Scan).
- **`db_statement_timeout_ms` : 5 s → 30 s** (stopgap) pour couvrir les scopes plus larges (année/pays) en attendant la pré-agrégation.
- Tests `build_location_query` adaptés (bornes de date au lieu d'assertions `EXTRACT`).

## Version robuste (préparée, non incluse ici)

Spec ajoutée : `docs/superpowers/specs/2026-07-15-observatory-location-preaggregation.md` — pré-agréger `location` en table matérialisée `zone_exposed` (grain H3 z8 par territoire/période), comme les autres stats, pour lire une petite table au lieu de scanner `carpools`. Permettra de **rabaisser le timeout à 5 s**.

## Déploiement

⚠️ `api-datalake` se déploie via l'**ops** (hors CI mono ; ce PR ne coupe pas de release). Le fix atteindra la prod au **redéploiement du service `api-datalake`** sur `dlk`.

## Validation

- `uv run pytest` : **81 tests passent**.
- `EXPLAIN ANALYZE` sur `datalake_production` : Index Scan, Execution Time ~2,4 s (vs ~60 s).

## Sécurité

**Verdict : PASS** (non bloquant). Pas d'injection : les bornes de date sont dérivées d'entiers via `date(...).isoformat()` et passées en **bind params** (`%(dt_start)s`/`%(dt_end)s`) ; `period_sql` devient une constante littérale. Pas de nouvelle exposition de données.

Point LOW/INFO, tech-debt : le timeout 30 s sur cet endpoint **public non authentifié** allonge la rétention d'une connexion du pool (risque de connection starvation en concurrence sur un scope lourd). Atténué par le filtre sargable (~2,4 s réel). Suivi : rate-limit / plafond de concurrence sur `/observatory/location`, et retour à 5 s dès la pré-agrégation livrée.

## CGU

**Verdict : PASS** (bloquant levé). Aucune règle déclenchée : pas de mutation de statut, pas de changement de rétention, pas d'exposition PII (champs projetés inchangés, agrégation par hexagone). Le point k-anonymat (`count=1` à n=8) est hérité du legacy, non aggravé par cette PR, suivi dans GEN-668.