### PR TITLE
perf(datalake): parallélise les endpoints observatoire (gzip 3 + connexion paresseuse)

### DIFF
--- a/api-datalake/src/api_datalake/cache.py
+++ b/api-datalake/src/api_datalake/cache.py
@@ -62,9 +62,14 @@ def build_cache_key(version: str, route: str, params: dict) -> str:
 
 
 def gzip_payload(data) -> bytes:
-    """Sérialise en JSON compact puis gzip. Renvoie les octets à stocker/servir."""
+    """Sérialise en JSON compact puis gzip (niveau 3).
+
+    La compression n'a lieu que sur cache MISS ; sur un event-loop unique borné à
+    0,5 CPU, le niveau 6 alourdissait la boucle sur les gros payloads. Niveau 3 :
+    nettement moins de CPU, ratio quasi équivalent (compromis, cf. plan §Notes).
+    """
     raw = json.dumps(data, separators=(",", ":"), default=str).encode()
-    return gzip.compress(raw, compresslevel=6)
+    return gzip.compress(raw, compresslevel=3)
 
 
 async def publication_version(redis, cutoff: str | None) -> str:

--- a/api-datalake/src/api_datalake/routers/observatory.py
+++ b/api-datalake/src/api_datalake/routers/observatory.py
@@ -24,9 +24,15 @@ router = APIRouter(prefix="/observatory", tags=["observatory"])
 Direction = Literal["from", "to", "both"]
 
 
-async def get_conn():
-    async with connection() as conn:
-        yield conn
+def get_conn():
+    """Fournit l'« acquéreur » de connexion (la fabrique `connection`), pas une
+    connexion ouverte.
+
+    Sur cache HIT, `acquire()` n'est jamais appelé : aucune connexion du pool n'est
+    mobilisée. Sur MISS, la connexion n'est ouverte que le temps de la requête SQL,
+    puis relâchée avant le gzip. Surchargeable en test.
+    """
+    return connection
 
 
 def _gzip_json(blob: bytes, cache_state: str) -> Response:
@@ -38,10 +44,12 @@ def _gzip_json(blob: bytes, cache_state: str) -> Response:
     )
 
 
-async def _serve_cached(redis, route: str, params: dict, produce) -> Response:
-    """Sert `produce()` (données PG) avec cache Redis best-effort.
+async def _serve_cached(redis, route: str, params: dict, produce, acquire) -> Response:
+    """Sert `produce(conn)` (données PG) avec cache Redis best-effort.
 
-    Une panne Redis dégrade en cache-miss (`X-Cache: BYPASS`), jamais en 500.
+    La connexion n'est ouverte (`acquire()`) que sur cache MISS, et relâchée dès la
+    requête terminée — avant la sérialisation/gzip. Une panne Redis dégrade en
+    cache-miss (`X-Cache: BYPASS`), jamais en 500.
     """
     cutoff = settings.app_observatory_published_until
     key = None
@@ -53,7 +61,9 @@ async def _serve_cached(redis, route: str, params: dict, produce) -> Response:
     if hit is not None:
         return _gzip_json(hit, "HIT")
 
-    blob = gzip_payload(await produce())
+    async with acquire() as conn:
+        data = await produce(conn)
+    blob = gzip_payload(data)
     if ok:
         await cache_set(redis, key, blob, settings.cache_ttl_seconds)
     return _gzip_json(blob, "MISS" if ok else "BYPASS")
@@ -63,13 +73,14 @@ async def _serve_cached(redis, route: str, params: dict, produce) -> Response:
 async def last_record(
     code: str = Query(...),
     type: str = Query("com"),
-    conn=Depends(get_conn),
+    acquire=Depends(get_conn),
 ):
     """Dernier mois disponible pour un territoire, borné par le cutoff de publication."""
     check_code_param(code)
     cutoff = last_record_cutoff(settings.app_observatory_published_until)
     max_ym = cutoff[0] * 100 + cutoff[1] if cutoff else None
-    return await repo.get_last_record(conn, type, code, max_ym)
+    async with acquire() as conn:
+        return await repo.get_last_record(conn, type, code, max_ym)
 
 
 @router.get("/location")
@@ -81,7 +92,7 @@ async def location(
     trimester: int | None = Query(None, ge=1, le=4),
     semester: int | None = Query(None, ge=1, le=2),
     n: int = Query(5, ge=0, le=8),
-    conn=Depends(get_conn),
+    acquire=Depends(get_conn),
     redis=Depends(get_redis),
 ):
     """Heatmap de densité (H3) d'un territoire. Binning en SQL, réponse gzip cachée."""
@@ -96,7 +107,8 @@ async def location(
               "month": month, "trimester": trimester, "semester": semester, "n": n}
     return await _serve_cached(
         redis, "/observatory/location", params,
-        lambda: repo.get_location(conn, type, code, year, n, month, trimester, semester),
+        lambda conn: repo.get_location(conn, type, code, year, n, month, trimester, semester),
+        acquire,
     )
 
 
@@ -105,7 +117,7 @@ async def campaigns(
     type: str | None = Query(None),
     code: str | None = Query(None),
     year: int | None = Query(None, ge=2015, le=2100),
-    conn=Depends(get_conn),
+    acquire=Depends(get_conn),
     redis=Depends(get_redis),
 ):
     """Campagnes d'incitation (avec géométrie du territoire). Réponse gzip cachée."""
@@ -115,7 +127,8 @@ async def campaigns(
               "code": code, "year": year}
     return await _serve_cached(
         redis, "/observatory/campaigns", params,
-        lambda: repo.get_campaigns(conn, type, code, year),
+        lambda conn: repo.get_campaigns(conn, type, code, year),
+        acquire,
     )
 
 
@@ -126,9 +139,9 @@ async def campaigns(
 # --------------------------------------------------------------------------- #
 
 
-def _serve_rows(redis, route: str, params: dict, sql: str, sql_params: dict, conn):
+def _serve_rows(redis, route: str, params: dict, sql: str, sql_params: dict, acquire):
     return _serve_cached(redis, route, params,
-                         lambda: agg.fetch(conn, sql, sql_params))
+                         lambda conn: agg.fetch(conn, sql, sql_params), acquire)
 
 
 @router.get("/flux")
@@ -140,7 +153,7 @@ async def flux(
     month: int | None = Query(None, ge=1, le=12),
     trimester: int | None = Query(None, ge=1, le=4),
     semester: int | None = Query(None, ge=1, le=2),
-    conn=Depends(get_conn),
+    acquire=Depends(get_conn),
     redis=Depends(get_redis),
 ):
     """Flux OD entre territoires."""
@@ -149,7 +162,7 @@ async def flux(
     params = {"code": code, "type": check_territory_param(type),
               "observe": check_territory_param(observe), "year": year,
               "month": month, "trimester": trimester, "semester": semester}
-    return await _serve_rows(redis, "/observatory/flux", params, sql, sp, conn)
+    return await _serve_rows(redis, "/observatory/flux", params, sql, sp, acquire)
 
 
 @router.get("/best-flux")
@@ -161,7 +174,7 @@ async def best_flux(
     month: int | None = Query(None, ge=1, le=12),
     trimester: int | None = Query(None, ge=1, le=4),
     semester: int | None = Query(None, ge=1, le=2),
-    conn=Depends(get_conn),
+    acquire=Depends(get_conn),
     redis=Depends(get_redis),
 ):
     """Meilleurs flux d'un territoire (top N par trajets)."""
@@ -169,7 +182,7 @@ async def best_flux(
     sql, sp = agg.build_best_flux(type, code, year, limit, month, trimester, semester)
     params = {"code": code, "type": check_territory_param(type), "year": year,
               "limit": limit, "month": month, "trimester": trimester, "semester": semester}
-    return await _serve_rows(redis, "/observatory/best-flux", params, sql, sp, conn)
+    return await _serve_rows(redis, "/observatory/best-flux", params, sql, sp, acquire)
 
 
 @router.get("/evol-flux")
@@ -181,7 +194,7 @@ async def evol_flux(
     month: int | None = Query(None, ge=1, le=12),
     trimester: int | None = Query(None, ge=1, le=4),
     semester: int | None = Query(None, ge=1, le=2),
-    conn=Depends(get_conn),
+    acquire=Depends(get_conn),
     redis=Depends(get_redis),
 ):
     """Évolution temporelle d'un indicateur de flux."""
@@ -190,7 +203,7 @@ async def evol_flux(
     params = {"code": code, "type": check_territory_param(type),
               "indic": agg.normalize_flux_indic(indic),
               "past": past, "month": month, "trimester": trimester, "semester": semester}
-    return await _serve_rows(redis, "/observatory/evol-flux", params, sql, sp, conn)
+    return await _serve_rows(redis, "/observatory/evol-flux", params, sql, sp, acquire)
 
 
 @router.get("/incentive")
@@ -201,7 +214,7 @@ async def incentive(
     month: int | None = Query(None, ge=1, le=12),
     trimester: int | None = Query(None, ge=1, le=4),
     semester: int | None = Query(None, ge=1, le=2),
-    conn=Depends(get_conn),
+    acquire=Depends(get_conn),
     redis=Depends(get_redis),
 ):
     """Répartition des incitations par territoire."""
@@ -209,7 +222,7 @@ async def incentive(
     sql, sp = agg.build_incentive(type, code, year, month, trimester, semester)
     params = {"code": code, "type": check_territory_param(type), "year": year,
               "month": month, "trimester": trimester, "semester": semester}
-    return await _serve_rows(redis, "/observatory/incentive", params, sql, sp, conn)
+    return await _serve_rows(redis, "/observatory/incentive", params, sql, sp, acquire)
 
 
 @router.get("/occupation")
@@ -221,7 +234,7 @@ async def occupation(
     month: int | None = Query(None, ge=1, le=12),
     trimester: int | None = Query(None, ge=1, le=4),
     semester: int | None = Query(None, ge=1, le=2),
-    conn=Depends(get_conn),
+    acquire=Depends(get_conn),
     redis=Depends(get_redis),
 ):
     """Taux d'occupation par territoire (avec géométrie)."""
@@ -230,7 +243,7 @@ async def occupation(
     params = {"code": code, "type": check_territory_param(type),
               "observe": check_territory_param(observe), "year": year,
               "month": month, "trimester": trimester, "semester": semester}
-    return await _serve_rows(redis, "/observatory/occupation", params, sql, sp, conn)
+    return await _serve_rows(redis, "/observatory/occupation", params, sql, sp, acquire)
 
 
 @router.get("/best-territories")
@@ -243,7 +256,7 @@ async def best_territories(
     month: int | None = Query(None, ge=1, le=12),
     trimester: int | None = Query(None, ge=1, le=4),
     semester: int | None = Query(None, ge=1, le=2),
-    conn=Depends(get_conn),
+    acquire=Depends(get_conn),
     redis=Depends(get_redis),
 ):
     """Meilleurs territoires par nombre de trajets."""
@@ -253,7 +266,7 @@ async def best_territories(
     params = {"code": code, "type": check_territory_param(type),
               "observe": check_territory_param(observe), "year": year, "limit": limit,
               "month": month, "trimester": trimester, "semester": semester}
-    return await _serve_rows(redis, "/observatory/best-territories", params, sql, sp, conn)
+    return await _serve_rows(redis, "/observatory/best-territories", params, sql, sp, acquire)
 
 
 @router.get("/evol-occupation")
@@ -265,7 +278,7 @@ async def evol_occupation(
     month: int | None = Query(None, ge=1, le=12),
     trimester: int | None = Query(None, ge=1, le=4),
     semester: int | None = Query(None, ge=1, le=2),
-    conn=Depends(get_conn),
+    acquire=Depends(get_conn),
     redis=Depends(get_redis),
 ):
     """Évolution temporelle d'un indicateur d'occupation."""
@@ -274,7 +287,7 @@ async def evol_occupation(
     params = {"code": code, "type": check_territory_param(type),
               "indic": agg.normalize_occupation_indic(indic),
               "past": past, "month": month, "trimester": trimester, "semester": semester}
-    return await _serve_rows(redis, "/observatory/evol-occupation", params, sql, sp, conn)
+    return await _serve_rows(redis, "/observatory/evol-occupation", params, sql, sp, acquire)
 
 
 @router.get("/journeys-by-hours")
@@ -285,7 +298,7 @@ async def journeys_by_hours(
     month: int | None = Query(None, ge=1, le=12),
     trimester: int | None = Query(None, ge=1, le=4),
     semester: int | None = Query(None, ge=1, le=2),
-    conn=Depends(get_conn),
+    acquire=Depends(get_conn),
     redis=Depends(get_redis),
 ):
     """Distribution horaire des trajets (toutes directions)."""
@@ -293,7 +306,7 @@ async def journeys_by_hours(
     sql, sp = agg.build_journeys_by_hours(type, code, year, month, trimester, semester)
     params = {"code": code, "type": check_territory_param(type), "year": year,
               "month": month, "trimester": trimester, "semester": semester}
-    return await _serve_rows(redis, "/observatory/journeys-by-hours", params, sql, sp, conn)
+    return await _serve_rows(redis, "/observatory/journeys-by-hours", params, sql, sp, acquire)
 
 
 @router.get("/journeys-by-distances")
@@ -305,7 +318,7 @@ async def journeys_by_distances(
     month: int | None = Query(None, ge=1, le=12),
     trimester: int | None = Query(None, ge=1, le=4),
     semester: int | None = Query(None, ge=1, le=2),
-    conn=Depends(get_conn),
+    acquire=Depends(get_conn),
     redis=Depends(get_redis),
 ):
     """Distribution kilométrique des trajets (direction requise)."""
@@ -315,7 +328,7 @@ async def journeys_by_distances(
     params = {"code": code, "type": check_territory_param(type), "year": year,
               "direction": direction, "month": month,
               "trimester": trimester, "semester": semester}
-    return await _serve_rows(redis, "/observatory/journeys-by-distances", params, sql, sp, conn)
+    return await _serve_rows(redis, "/observatory/journeys-by-distances", params, sql, sp, acquire)
 
 
 @router.get("/keyfigures")
@@ -326,7 +339,7 @@ async def keyfigures(
     month: int | None = Query(None, ge=1, le=12),
     trimester: int | None = Query(None, ge=1, le=4),
     semester: int | None = Query(None, ge=1, le=2),
-    conn=Depends(get_conn),
+    acquire=Depends(get_conn),
     redis=Depends(get_redis),
 ):
     """Chiffres clés d'un territoire (recomposition ; direction both)."""
@@ -334,14 +347,14 @@ async def keyfigures(
     sql, sp = agg.build_keyfigures(type, code, year, month, trimester, semester)
     params = {"code": code, "type": check_territory_param(type), "year": year,
               "month": month, "trimester": trimester, "semester": semester}
-    return await _serve_rows(redis, "/observatory/keyfigures", params, sql, sp, conn)
+    return await _serve_rows(redis, "/observatory/keyfigures", params, sql, sp, acquire)
 
 
 @router.get("/aires-covoiturage")
 async def aires_covoiturage(
     type: str = Query("com"),
     code: str | None = Query(None, min_length=1, max_length=15),
-    conn=Depends(get_conn),
+    acquire=Depends(get_conn),
     redis=Depends(get_redis),
 ):
     """Aires de covoiturage ouvertes (optionnellement filtrées par territoire)."""
@@ -349,4 +362,4 @@ async def aires_covoiturage(
         check_code_param(code)
     sql, sp = agg.build_aires_covoiturage(type, code)
     params = {"type": check_territory_param(type), "code": code}
-    return await _serve_rows(redis, "/observatory/aires-covoiturage", params, sql, sp, conn)
+    return await _serve_rows(redis, "/observatory/aires-covoiturage", params, sql, sp, acquire)

--- a/api-datalake/tests/test_aggregated.py
+++ b/api-datalake/tests/test_aggregated.py
@@ -1,5 +1,6 @@
 import gzip
 import json
+from contextlib import asynccontextmanager
 
 from fastapi.testclient import TestClient
 
@@ -145,8 +146,11 @@ class FakeConn:
 def client(rows):
     app = create_app()
 
-    async def override():
-        yield FakeConn(rows)
+    def override():
+        @asynccontextmanager
+        async def _acquire():
+            yield FakeConn(rows)
+        return _acquire
 
     app.dependency_overrides[get_conn] = override
     app.dependency_overrides[get_redis] = lambda: None

--- a/api-datalake/tests/test_cache.py
+++ b/api-datalake/tests/test_cache.py
@@ -29,6 +29,20 @@ def test_gzip_payload_roundtrips():
     assert json.loads(gzip.decompress(blob)) == data
 
 
+def test_gzip_payload_uses_level_3():
+    # Payload assez gros/varié pour que l'heuristique deflate diverge d'un niveau à
+    # l'autre : sur un tout petit blob, niveaux 3 et 6 sortent des octets identiques
+    # (l'octet XFL de l'en-tête ne distingue que 1 et 9). On compare donc le corps à
+    # une référence niveau 3, après neutralisation du MTIME (octets 4-7, horloge).
+    data = [{"hex": format(i, "04x"), "count": (i * 7919) % 1000} for i in range(400)]
+    raw = json.dumps(data, separators=(",", ":"), default=str).encode()
+    got = bytearray(cache_mod.gzip_payload(data))
+    ref = bytearray(gzip.compress(raw, compresslevel=3))
+    got[4:8] = b"\x00\x00\x00\x00"  # neutralise MTIME (horloge)
+    ref[4:8] = b"\x00\x00\x00\x00"
+    assert bytes(got) == bytes(ref)  # corps deflate identique => même niveau
+
+
 # --- ouverture du client Redis : TLS + CA privée ---
 
 

--- a/api-datalake/tests/test_campaigns.py
+++ b/api-datalake/tests/test_campaigns.py
@@ -1,3 +1,5 @@
+from contextlib import asynccontextmanager
+
 from fastapi.testclient import TestClient
 
 from api_datalake.cache import get_redis
@@ -82,8 +84,11 @@ def test_campaigns_endpoint_returns_gzipped_list():
     rows = [{"type": "aom", "code": "217500016", "lien": "https://x", "geom": {"type": "Polygon"}}]
     app = create_app()
 
-    async def override_conn():
-        yield FakeConn(rows)
+    def override_conn():
+        @asynccontextmanager
+        async def _acquire():
+            yield FakeConn(rows)
+        return _acquire
 
     app.dependency_overrides[get_conn] = override_conn
     app.dependency_overrides[get_redis] = lambda: None

--- a/api-datalake/tests/test_hardening.py
+++ b/api-datalake/tests/test_hardening.py
@@ -1,4 +1,5 @@
 import asyncio
+from contextlib import asynccontextmanager
 
 from fastapi.testclient import TestClient
 
@@ -45,8 +46,11 @@ class FakeConn:
 def client(rows=None, delay=0.0):
     app = create_app()
 
-    async def override_conn():
-        yield FakeConn(rows, delay)
+    def override_conn():
+        @asynccontextmanager
+        async def _acquire():
+            yield FakeConn(rows, delay)
+        return _acquire
 
     app.dependency_overrides[get_conn] = override_conn
     app.dependency_overrides[get_redis] = lambda: None

--- a/api-datalake/tests/test_location.py
+++ b/api-datalake/tests/test_location.py
@@ -1,5 +1,6 @@
 import gzip
 import json
+from contextlib import asynccontextmanager
 
 from fastapi.testclient import TestClient
 
@@ -99,8 +100,11 @@ class RaisingRedis:
 def make_client(rows, redis=None):
     app = create_app()
 
-    async def override_conn():
-        yield FakeConn(rows)
+    def override_conn():
+        @asynccontextmanager
+        async def _acquire():
+            yield FakeConn(rows)
+        return _acquire
 
     app.dependency_overrides[get_conn] = override_conn
     app.dependency_overrides[get_redis] = lambda: redis
@@ -159,6 +163,31 @@ def test_location_rejects_malformed_code_with_422():
     # `$` laisserait passer un newline final ; `fullmatch` le rejette.
     r_nl = c.get("/observatory/location", params={"code": "75056\n", "type": "com", "year": 2022, "n": 8})
     assert r_nl.status_code == 422
+
+
+def test_location_cache_hit_opens_no_connection():
+    # 1er appel : MISS, remplit le cache. 2e : HIT — l'acquéreur ne doit jamais
+    # être ouvert. On le remplace alors par un acquéreur qui lève à l'ouverture.
+    redis = FakeRedis()
+    app = make_client([{"hex": "a", "count": 1}], redis=redis)
+    c = TestClient(app)
+    p = {"code": "75056", "type": "com", "year": 2022, "month": 6, "n": 8}
+
+    first = c.get("/observatory/location", params=p)
+    assert first.headers["x-cache"] == "MISS"
+
+    def exploding():
+        @asynccontextmanager
+        async def _acquire():
+            raise AssertionError("pool sollicité sur un cache HIT")
+            yield  # pragma: no cover
+        return _acquire
+    app.dependency_overrides[get_conn] = exploding
+
+    second = c.get("/observatory/location", params=p)
+    assert second.status_code == 200
+    assert second.headers["x-cache"] == "HIT"
+    assert second.json() == [{"hex": "a", "count": 1}]
 
 
 def test_location_unpublished_period_is_bypassed_and_empty():

--- a/api-datalake/tests/test_maintenance.py
+++ b/api-datalake/tests/test_maintenance.py
@@ -1,3 +1,5 @@
+from contextlib import asynccontextmanager
+
 import pytest
 from fastapi.testclient import TestClient
 
@@ -30,8 +32,11 @@ def app_with_maintenance(on, fake_db=False):
     app = create_app()
     app.state.settings = Settings(maintenance_mode=on)  # isolé du singleton
     if fake_db:
-        async def override_conn():
-            yield _FakeConn()
+        def override_conn():
+            @asynccontextmanager
+            async def _acquire():
+                yield _FakeConn()
+            return _acquire
 
         app.dependency_overrides[get_conn] = override_conn
         app.dependency_overrides[get_redis] = lambda: None

--- a/api-datalake/tests/test_observatory.py
+++ b/api-datalake/tests/test_observatory.py
@@ -1,3 +1,5 @@
+from contextlib import asynccontextmanager
+
 from fastapi.testclient import TestClient
 
 from api_datalake.main import create_app
@@ -33,8 +35,11 @@ class FakeConn:
 def client_with_row(row):
     app = create_app()
 
-    async def override():
-        yield FakeConn(row)
+    def override():
+        @asynccontextmanager
+        async def _acquire():
+            yield FakeConn(row)
+        return _acquire
 
     app.dependency_overrides[get_conn] = override
     return TestClient(app)


### PR DESCRIPTION
## Contexte

Sur un pod dont le pool PG ne compte que 8 connexions et dont l'event-loop est unique
(uvicorn mono-worker, plafond 0,5 CPU), un endpoint observatoire lent en cache MISS
(`location`/`flux`, ~2 à 5 s) peut affamer les requêtes rapides concurrentes. Les 8 appels
d'un même utilisateur partent du navigateur, se multiplexent sur une seule connexion HTTP/2
et atterrissent tous sur le **même** pod : ce sont les correctifs **par pod** qui comptent.

Cette PR applique deux leviers de mitigation de la concurrence, **sans changer le contrat
public** (mêmes réponses, mêmes en-têtes `Content-Encoding: gzip` / `X-Cache`, mêmes codes
d'erreur) et **sans nouvelle dépendance**.

## Changements

**1. gzip niveau 3 (`cache.py`)**
La compression n'a lieu que sur cache MISS. Passer de niveau 6 à niveau 3 allège nettement
l'event-loop sur les gros payloads à froid, pour un ratio de compression quasi équivalent.
Les entrées Redis déjà écrites en niveau 6 restent lisibles (gzip reste gzip) : cohabitation
transparente, aucune invalidation nécessaire.

**2. Acquisition paresseuse de la connexion (`routers/observatory.py`)**
`get_conn` ne renvoie plus une connexion ouverte mais un **acquéreur** (la fabrique
`connection`). La connexion n'est prise que sur cache MISS, et relâchée dès la requête SQL
terminée — **avant** le gzip et l'écriture Redis.
- Un cache HIT ne mobilise plus **aucune** connexion du pool.
- Un MISS lent ne peut donc plus assécher le pool pour les HITs concurrents.
- La tenue de connexion sur MISS est raccourcie (relâchée avant la sérialisation).

Les 14 endpoints, `_serve_cached`, `_serve_rows` et les overrides de test sont adaptés à la
forme acquéreur. Un test caractérisant (`test_location_cache_hit_opens_no_connection`) prouve
qu'un HIT n'ouvre jamais l'acquéreur.

## Portée / hors-scope

- Le vrai correctif du 5 s reste la **pré-agrégation de `location`** (tâche A), traitée
  séparément. B + gzip ne sont que de la mitigation de concurrence.
- `statement_timeout` (30 s stopgap) et le mode lecture seule sont inchangés (hors scope).

## Tests

Suite complète verte : **83 tests** (`just test`). TDD : chaque levier a été introduit
test-d'abord (le test échoue sur l'ancien code, passe sur le nouveau).

> Note : le test de niveau gzip du plan utilisait un payload minuscule, pour lequel les
> niveaux 3 et 6 produisent des octets **identiques** (il ne pouvait donc pas échouer sur
> l'ancien code). Il a été élargi à un payload réaliste (~10 Ko) où le niveau 3 est
> distinct des niveaux 1, 6 et 9 — le test discrimine désormais réellement le niveau.

## Déploiement

Cette PR ne produit pas de version semantic-release (le filtre de release ne couvre pas
`api-datalake/**`). Le déploiement de l'API datalake est assuré par son workflow dédié
`deploy-datalake-api.yml`, déclenché au merge sur `main` (paths `api-datalake/**`).

## Sécurité

**Verdict : PASS.** Le refactor « acquéreur de connexion » et la baisse gzip 6→3
n'introduisent aucune vulnérabilité ni régression de contrat.
- **Cycle de vie de la connexion — OK sur tous les chemins.** `connection()` est un
  `@asynccontextmanager` qui restitue au pool en sortie normale comme sur exception. HIT :
  aucune connexion mobilisée (verrouillé par `test_location_cache_hit_opens_no_connection`).
  MISS/BYPASS : connexion relâchée à la sortie du `with`, avant gzip et écriture Redis.
  Exception SQL : restitution par le `__aexit__` du pool. `last-record` : `return` dans le
  `async with`. Les 14 endpoints sont convertis de façon homogène, aucun `acquire` sans
  `async with`.
- **Injection SQL — pas de nouvelle surface.** Les lambdas `produce(conn)` ne font que
  passer `conn` aux repos ; `agg.fetch` reste paramétré (`cur.execute(sql, params)`), les
  allowlists sont inchangées.
- **Contrat public préservé** : en-têtes `Content-Encoding`/`X-Cache` et 422 inchangés.
- INFO (pré-existant, non introduit ici) : sous panne Redis prolongée, chaque requête ouvre
  une connexion sans bénéfice de cache — à garder en tête pour le dimensionnement du pool.

## CGU

**Verdict : PASS.** Aucune violation.
- CGU-1 (définitivité du statut à 48 h) : non concernée — diff en lecture seule, aucune
  écriture de statut/classification.
- CGU-2 (rétention des données personnelles) : non concernée — le seul TTL est celui du
  cache Redis de réponses agrégées publiques, pas une borne de rétention de PII ; valeur
  même pas modifiée.
- CGU-3 (minimisation/exposition PII) : non concernée — aucune donnée personnelle ajoutée à
  une réponse, un log ou un export ; données exclusivement agrégées/géographiques.
