### PR TITLE
feat(export): réactive l'interface de création d'exports à la demande

### DIFF
--- a/app-partners/src/app/activite/export/page.tsx
+++ b/app-partners/src/app/activite/export/page.tsx
@@ -17,11 +17,6 @@ import dayjs, { type Dayjs } from "dayjs";
 import "dayjs/locale/fr";
 import { useEffect, useRef, useState } from "react";
 
-// Désactive la création d'exports le temps de la migration vers le datalake.
-// Repasser à true (ou supprimer le garde-fou) une fois le worker déployé et le
-// cutover effectué. Les exports déjà générés restent téléchargeables.
-const EXPORT_CREATION_ENABLED = false;
-
 export default function TabExport() {
   const { user, simulate, simulatedRole } = useAuth();
   const [territoryId, setTerritoryId] = useState(user?.territory_id);
@@ -54,28 +49,6 @@ export default function TabExport() {
       scrollRef.current?.scrollIntoView({ behavior: "smooth" });
     }
   }, [error]);
-
-  // Feature temporairement désactivée : on affiche une note de maintenance et on
-  // conserve la liste des exports déjà produits (toujours téléchargeables).
-  if (!EXPORT_CREATION_ENABLED) {
-    return (
-      <>
-        <Alert
-          title="Génération d'exports momentanément indisponible"
-          severity="info"
-          description={
-            <>
-              La création d'exports est temporairement désactivée le temps d'une mise à jour technique. Pour obtenir un
-              export pendant cette période, écrivez à{" "}
-              <a href="mailto:technique@covoiturage.beta.gouv.fr">technique@covoiturage.beta.gouv.fr</a> en précisant le
-              périmètre et la période souhaités. Le service sera rétabli sous quelques jours.
-            </>
-          }
-        />
-        <ExportList refreshTrigger={refreshTrigger} days={30} pageSize={10} />
-      </>
-    );
-  }
 
   const handleExport = async () => {
     void sendEvent({


### PR DESCRIPTION
## Contexte

La création d'exports à la demande dans le tableau de bord partenaires avait été désactivée le temps de la migration du worker d'export vers le datalake (#3253), via un garde-fou temporaire `EXPORT_CREATION_ENABLED = false` affichant une note de maintenance à la place du formulaire.

Le worker d'export datalake est désormais déployé et opérationnel (voir #3288, #3289 et f7dea4f2), le cutover est effectué : on peut rétablir l'interface.

## Changement

- Suppression du garde-fou `EXPORT_CREATION_ENABLED` et de son commentaire.
- Suppression du court-circuit qui affichait l'`Alert` de maintenance (« Génération d'exports momentanément indisponible ») à la place du formulaire.
- Le formulaire de création d'exports (sélecteurs de périmètre géographique/campagne, plages de dates, bouton *Exporter* → `useExportCreate`) redevient disponible.

Le diff est un retrait exact des 27 lignes introduites par #3253 : aucune logique nouvelle, restauration de la page d'export telle qu'avant la migration. La liste des exports déjà produits (`ExportList`) restait affichée pendant la désactivation et n'est pas modifiée.

`app-partners/src/app/activite/export/page.tsx` — 27 suppressions, 0 ajout.

## Contrôles

### CGU

**PASS.** Changement purement présentationnel côté `app-partners`. Aucune mutation de statut de trajet, aucune règle de conservation touchée, aucun champ exposé élargi : la composition des exports (Annexe 2) est inchangée par cette PR.

### Sécurité

**PASS — risque faible.** Le garde-fou retiré était un simple interrupteur fonctionnel côté front, pas un contrôle de sécurité : le contrôle d'accès effectif à la création d'export reste appliqué côté API (permissions). Aucune injection, aucune exposition de données, aucune dépendance ni secret introduits. Imports `Alert` et `ExportList` toujours utilisés (pas de lint mort).
