### PR TITLE
fix(export): rétablit le bouton de téléchargement des exports en succès

### DIFF
--- a/api/src/db/migrations/20260715000000-drop-export-dead-columns.sql
+++ b/api/src/db/migrations/20260715000000-drop-export-dead-columns.sql
@@ -1,0 +1,13 @@
+-- Drop dead columns from export.exports.
+--
+-- download_url / download_url_expire_at: exports are downloaded through
+-- GetDownloadLinkAction, which signs a fresh S3 URL from `filename` on demand.
+-- Neither the datalake export worker nor the legacy command populated these, and
+-- nothing reads them anymore.
+--
+-- stats: never written by any command/action and never exposed by ListAction —
+-- a JSON field designed but never wired since the table was created.
+ALTER TABLE export.exports
+DROP COLUMN download_url,
+DROP COLUMN download_url_expire_at,
+DROP COLUMN stats;

--- a/api/src/db/migrations/20260715000000-drop-export-download-url.sql
+++ b/api/src/db/migrations/20260715000000-drop-export-download-url.sql
@@ -1,6 +1,0 @@
--- Drop the now-unused download_url column: exports are downloaded through
--- GetDownloadLinkAction, which signs a fresh S3 URL from `filename` on demand.
--- The datalake export worker never populated this column, and the frontend no
--- longer reads it.
-ALTER TABLE export.exports
-DROP COLUMN download_url;

--- a/api/src/db/migrations/20260715000000-drop-export-download-url.sql
+++ b/api/src/db/migrations/20260715000000-drop-export-download-url.sql
@@ -1,0 +1,6 @@
+-- Drop the now-unused download_url column: exports are downloaded through
+-- GetDownloadLinkAction, which signs a fresh S3 URL from `filename` on demand.
+-- The datalake export worker never populated this column, and the frontend no
+-- longer reads it.
+ALTER TABLE export.exports
+DROP COLUMN download_url;

--- a/api/src/pdc/services/export/actions/ListAction.ts
+++ b/api/src/pdc/services/export/actions/ListAction.ts
@@ -42,7 +42,6 @@ export class listAction extends AbstractAction {
         start_date: exp.params.get().start_at,
         end_date: exp.params.get().end_at,
         geo_selector: await this.territoryService.getTerritoryNames(exp.params.get().geo_selector),
-        download_url: exp.download_url,
         filename: exp.filename,
         file_size: exp.file_size,
         status: exp.status,

--- a/api/src/pdc/services/export/contracts/list.contract.ts
+++ b/api/src/pdc/services/export/contracts/list.contract.ts
@@ -6,7 +6,6 @@ export type ResultItemInterface = {
   start_date: Date;
   end_date: Date;
   geo_selector: string[];
-  download_url: string;
   filename: string;
   file_size: number;
   status: string;

--- a/api/src/pdc/services/export/models/Export.ts
+++ b/api/src/pdc/services/export/models/Export.ts
@@ -17,7 +17,6 @@ export enum ExportTarget {
 }
 
 export type ExportError = string;
-export type ExportStats = string;
 
 export class Export {
   public _id: number;
@@ -25,12 +24,10 @@ export class Export {
   public target: ExportTarget;
   public status: ExportStatus;
   public created_by: number;
-  public download_url_expire_at: Date;
   public filename: string;
   public file_size: number;
   public params: ExportParams;
   public error: ExportError; // JSON object
-  public stats: ExportStats; // JSON object
 
   public static fromJSON(data: any): Export {
     const export_ = new Export();
@@ -39,12 +36,10 @@ export class Export {
     export_.target = data.target;
     export_.status = data.status;
     export_.created_by = data.created_by;
-    export_.download_url_expire_at = data.download_url_expire_at;
     export_.filename = data.filename;
     export_.file_size = Number(data.file_size) || 0;
     export_.params = new ExportParams(data.params);
     export_.error = data.error;
-    export_.stats = data.stats;
     return export_;
   }
 
@@ -55,12 +50,10 @@ export class Export {
       target: export_.target,
       status: export_.status,
       created_by: export_.created_by,
-      download_url_expire_at: export_.download_url_expire_at,
       filename: export_.filename,
       file_size: export_.file_size,
       params: ExportParams.toJSON(export_.params),
       error: export_.error,
-      stats: export_.stats,
     };
   }
 

--- a/api/src/pdc/services/export/models/Export.ts
+++ b/api/src/pdc/services/export/models/Export.ts
@@ -26,7 +26,6 @@ export class Export {
   public status: ExportStatus;
   public created_by: number;
   public download_url_expire_at: Date;
-  public download_url: string;
   public filename: string;
   public file_size: number;
   public params: ExportParams;
@@ -41,7 +40,6 @@ export class Export {
     export_.status = data.status;
     export_.created_by = data.created_by;
     export_.download_url_expire_at = data.download_url_expire_at;
-    export_.download_url = data.download_url;
     export_.filename = data.filename;
     export_.file_size = Number(data.file_size) || 0;
     export_.params = new ExportParams(data.params);
@@ -58,7 +56,6 @@ export class Export {
       status: export_.status,
       created_by: export_.created_by,
       download_url_expire_at: export_.download_url_expire_at,
-      download_url: export_.download_url,
       filename: export_.filename,
       file_size: export_.file_size,
       params: ExportParams.toJSON(export_.params),

--- a/api/src/pdc/services/export/repositories/ExportRepository.ts
+++ b/api/src/pdc/services/export/repositories/ExportRepository.ts
@@ -7,7 +7,7 @@ import { LogServiceInterfaceResolver } from "../services/LogService.ts";
 
 export type ExportCreateData = Pick<Export, "created_by" | "target" | "params">;
 export type ExportUpdateData = Partial<
-  Pick<Export, "status" | "filename" | "file_size" | "error" | "stats">
+  Pick<Export, "status" | "filename" | "file_size" | "error">
 >;
 
 export abstract class ExportRepositoryInterfaceResolver {
@@ -179,7 +179,7 @@ export class ExportRepository {
   }
 
   private static readonly UPDATABLE_COLUMNS: ReadonlySet<string> = new Set([
-    "status", "filename", "file_size", "error", "stats",
+    "status", "filename", "file_size", "error",
   ]);
 
   public async update(id: number, data: ExportUpdateData): Promise<void> {

--- a/api/src/pdc/services/export/repositories/ExportRepository.ts
+++ b/api/src/pdc/services/export/repositories/ExportRepository.ts
@@ -7,7 +7,7 @@ import { LogServiceInterfaceResolver } from "../services/LogService.ts";
 
 export type ExportCreateData = Pick<Export, "created_by" | "target" | "params">;
 export type ExportUpdateData = Partial<
-  Pick<Export, "status" | "download_url" | "filename" | "file_size" | "error" | "stats">
+  Pick<Export, "status" | "filename" | "file_size" | "error" | "stats">
 >;
 
 export abstract class ExportRepositoryInterfaceResolver {
@@ -179,7 +179,7 @@ export class ExportRepository {
   }
 
   private static readonly UPDATABLE_COLUMNS: ReadonlySet<string> = new Set([
-    "status", "download_url", "filename", "file_size", "error", "stats",
+    "status", "filename", "file_size", "error", "stats",
   ]);
 
   public async update(id: number, data: ExportUpdateData): Promise<void> {

--- a/app-partners/src/components/export/ExportList.tsx
+++ b/app-partners/src/components/export/ExportList.tsx
@@ -13,7 +13,6 @@ interface ExportListItemInterface {
   start_date: Date;
   end_date: Date;
   geo_selector: string[];
-  download_url: string;
   filename: string;
   file_size: number;
   status: string;
@@ -92,7 +91,7 @@ export default function ExportList({ refreshTrigger, days = 30, pageSize = 25 }:
         formatBoundStart(d.start_date),
         formatBoundEnd(d.end_date),
         d.geo_selector?.length > 0 ? d.geo_selector.join(", ") : "-",
-        d.download_url && d.filename ? (
+        d.status === "success" && d.filename ? (
           <Download
             label={d.filename}
             details={`${d.filename.split(".").pop()?.toUpperCase()} • ${formatFileSize(d.file_size)}`}

--- a/app-partners/src/hooks/api/useExportsList.ts
+++ b/app-partners/src/hooks/api/useExportsList.ts
@@ -5,7 +5,6 @@ interface ExportRecord {
   start_date: Date;
   end_date: Date;
   geo_selector: string[];
-  download_url: string;
   filename: string;
   file_size: number;
   status: string;


### PR DESCRIPTION
## Contexte

Depuis la bascule des exports à la demande vers le worker datalake, le bouton de téléchargement a disparu du tableau « Historique des exports » d'app-partners pour les exports en succès (GEN-677).

**Cause** : le worker datalake complète l'export via `CompleteAction` en renseignant `filename` + `file_size` mais **pas** `download_url`. Or la cellule « Fichier » conditionnait l'affichage du bouton sur `download_url`. Résultat : seul le badge « Succès » s'affichait, sans bouton.

## Changements

### Correctif du bouton (GEN-677)

- `app-partners/.../ExportList.tsx` : la condition d'affichage passe de `download_url && filename` à `status === "success" && filename`. Le bouton réapparaît quel que soit le chemin de complétion (worker CLI historique ou worker datalake).
- Le téléchargement lui-même est inchangé : au clic, une URL S3 signée fraîche (60 s) est régénérée à la volée via `GET /exports/download-link/:id` (qui signe à partir de `filename`), déjà en place.

### Suppression de colonnes mortes de `export.exports`

Migration `DROP COLUMN` + purge du modèle `Export`, du contrat de liste, du dépôt et des interfaces frontend :

- **`download_url`** / **`download_url_expire_at`** : le téléchargement s'appuie sur `filename` (URL signée à la volée), l'e-mail sur une URL calculée à la volée. Plus rien ne les lit ; le worker datalake ne les écrit pas.
- **`stats`** (json) : jamais écrite par aucune commande/action, jamais exposée par `ListAction` — champ jamais câblé depuis la création de la table.

Aucun lecteur externe de ces colonnes (datalake / sqlmesh / metabase) — vérifié. `progress` et `recipients` avaient déjà été droppées ; `error` (écrite par `FailAction`) et le journal `export.logs` sont conservés.

## Hors périmètre

- La suppression du code de production CSV migré vers le datalake (`ProcessCommand`, DataGouv, machinerie CSV) fait l'objet de la **PR #3277** (draft, bloquée jusqu'à la bascule complète). Cette PR-ci modifie seulement `ProcessCommand.ts` (retrait de l'écriture de `download_url`) : léger conflit à prévoir au rebase si #3277 est mergée d'abord (elle supprime le fichier).

## Sécurité

**PASS** — risque FAIBLE (revue sur le diff initial).

- La bascule du garde-fou frontend (`ExportList.tsx`) est purement présentationnelle : le contrôle d'accès réel reste serveur. `GetDownloadLinkAction` conserve le scoping utilisateur via `exportRepository.get(id, userId)` (`AND created_by = ${userId}`) — pas d'accès inter-comptes.
- URL S3 signée à partir de `filename` (valeur serveur, TTL 60 s), jamais fournie par le client au téléchargement : pas de path traversal. Suppression de la persistance d'une URL signée longue durée : gain de sécurité.
- Migration : `DROP COLUMN` irréversible mais colonnes inutilisées. Requêtes SQL paramétrées, `id` validé en `format: uuid`. Aucun secret ni dépendance ajoutés.
- Remarque mineure hors périmètre : dans `GetDownloadLinkAction`, si `userId` était `undefined` le scoping `created_by` serait ignoré — préexistant, garanti en pratique par l'auth + `common.export.list`.

## CGU

**PASS** — aucun constat.

- CGU-1 (finalité 48h) : non concernée (le `status` est celui de l'export, pas `acquisition_status`/`fraud_status`).
- CGU-2 (rétention) : favorable — on supprime des données stockées (URL signée + son expiration), aucune rétention étendue.
- CGU-3 (minimisation / PII) : non concernée — colonnes non identifiantes ; leur suppression réduit la surface exposée par l'API de liste. Périmètre des fichiers d'export inchangé.

## Release

`fix(export)` + diff sur `api/**` et `app-partners/**` → déclenche une release **patch** et le déploiement (API + partners). C'est voulu : le correctif du bouton doit partir en prod.