### PR TITLE
feat(datalake): pré-agrège la heatmap observatoire (location) — modèles

### DIFF
--- a/datalake/analyses/location_parity.py
+++ b/datalake/analyses/location_parity.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""Harnais de parité heatmap `location` : ancienne requête à la volée vs pré-agrégat.
+
+Compare, hexagone par hexagone, la sortie de l'ANCIENNE requête
+`build_location_query` (scan de `zone_exposed.location` + `observatory_perimeters`)
+à la NOUVELLE lecture du pré-agrégat `zone_exposed.location_<grain>` (PR #3293).
+
+À lancer APRÈS `dbt build` des modèles `location_*` sur un backfill scopé, avant
+de faire confiance à la publication. Les deux côtés lisent la même base : tout
+écart résiduel = bug de logique d'agrégation (et non une différence de source).
+
+    DBT_HOST=... DBT_PORT=... DBT_USER=... DBT_PASSWORD=... DBT_DBNAME=datalake \
+        python analyses/location_parity.py
+
+Sortie : une ligne par scope (PASS / DIVERGE attendu / FAIL), code retour != 0
+si un seul FAIL. La matrice couvre chaque branche de la sémantique (intra/inter,
+NULL/cross-border, PLM, résolution de périmètre au millésime, aom vs aomreg).
+"""
+
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass
+
+from pipelines.helpers.pg import pg_connect
+
+# Binning de comparaison : un zoom « moyen ». La parité doit tenir à tout n<=8 ;
+# n=6 suffit à détecter tout écart de comptage (le binning est déterministe).
+N_ZOOM = 6
+
+# com -> arr : même mapping que l'ancienne API (SELECT arr AS com ...).
+_PERIM_COL = {"com": "arr", "epci": "epci", "aom": "aom",
+              "dep": "dep", "reg": "reg", "country": "country"}
+
+# Communes PLM : l'ancienne requête (WHERE arr = code) renvoyait un heatmap VIDE ;
+# le nouveau pré-agrégat renvoie des données (fix voulu). Écart ATTENDU, pas un échec.
+PLM_COM_CODES = {"75056", "69123", "13055"}
+
+
+@dataclass(frozen=True)
+class Scope:
+    type_: str
+    code: str
+    grain: str            # month | quarter | semester | year
+    year: int
+    period: int | None    # mois 1-12 / trimestre 1-4 / semestre 1-2 / None pour year
+    note: str = ""
+
+
+# Matrice : chaque ligne exerce une branche distincte. Codes réels (INSEE COG) ;
+# `XXXXX` = code pays France. Vérifier que chaque scope a du volume dans sa période
+# (un territoire vide rend le test vacant).
+SCOPES: list[Scope] = [
+    Scope("com", "31555", "month", 2024, 6, "commune ordinaire (intra + inter)"),
+    Scope("com", "75056", "year", 2024, None, "commune PLM -> DIVERGENCE attendue"),
+    Scope("reg", "76", "month", 2024, 6, "région (résolution périmètre au millésime)"),
+    Scope("reg", "11", "year", 2024, None, "région dense, grain année"),
+    Scope("dep", "31", "quarter", 2024, 2, "département, grain trimestre"),
+    Scope("aom", "217500016", "semester", 2024, 1, "aom réelle, grain semestre"),
+    Scope("country", "XXXXX", "year", 2024, None, "pays entier, pire cas dense"),
+]
+
+
+def _period_bounds(s: Scope) -> tuple[str, str]:
+    """Bornes [début, fin) ISO pour le filtre temporel de l'ancienne requête."""
+    y = s.year
+    if s.grain == "month":
+        m = s.period
+        end = (f"{y + 1}-01-01" if m == 12 else f"{y}-{m + 1:02d}-01")
+        return f"{y}-{m:02d}-01", end
+    if s.grain == "quarter":
+        sm = (s.period - 1) * 3 + 1
+        end = (f"{y + 1}-01-01" if sm + 3 > 12 else f"{y}-{sm + 3:02d}-01")
+        return f"{y}-{sm:02d}-01", end
+    if s.grain == "semester":
+        sm = 1 if s.period == 1 else 7
+        end = (f"{y + 1}-01-01" if sm == 7 else f"{y}-07-01")
+        return f"{y}-{sm:02d}-01", end
+    return f"{y}-01-01", f"{y + 1}-01-01"
+
+
+def _old_new_sql(s: Scope, n: int) -> tuple[str, dict]:
+    """Une seule requête : ancienne sémantique (CTE `old`) vs lecture du pré-agrégat
+    (CTE `new`), jointure externe par hex, renvoie les stats d'écart + 5 échantillons."""
+    col = _PERIM_COL[s.type_]
+    dt_start, dt_end = _period_bounds(s)
+    params: dict = {"code": s.code, "year": s.year, "n": n,
+                    "dt_start": dt_start, "dt_end": dt_end}
+
+    # Filtre de grain côté nouvelle table exposée.
+    grain_pred = ""
+    if s.grain != "year":
+        gcol = {"month": "month", "quarter": "quarter", "semester": "semester"}[s.grain]
+        grain_pred = f"AND {gcol} = %(period)s"
+        params["period"] = s.period
+
+    sql = f"""
+    WITH
+    millesime AS (
+        SELECT year FROM (
+            SELECT max(year) AS year FROM zone_exposed.observatory_perimeters WHERE year = %(year)s
+            UNION ALL
+            SELECT max(year) AS year FROM zone_exposed.observatory_perimeters
+            ORDER BY year LIMIT 1
+        ) m
+    ),
+    perims AS (
+        SELECT arr AS com FROM zone_exposed.observatory_perimeters
+        WHERE year = (SELECT year FROM millesime) AND {col} = %(code)s
+    ),
+    pts AS (
+        SELECT h3_cell_to_parent(start_h3index_z8, %(n)s) AS hex
+        FROM zone_exposed.location
+        WHERE start_datetime >= %(dt_start)s AND start_datetime < %(dt_end)s
+          AND (start_geo_code IN (SELECT com FROM perims) OR end_geo_code IN (SELECT com FROM perims))
+        UNION ALL
+        SELECT h3_cell_to_parent(end_h3index_z8, %(n)s)
+        FROM zone_exposed.location
+        WHERE start_datetime >= %(dt_start)s AND start_datetime < %(dt_end)s
+          AND (start_geo_code IN (SELECT com FROM perims) OR end_geo_code IN (SELECT com FROM perims))
+    ),
+    old AS (
+        SELECT hex::text AS hex, count(*)::int AS cnt FROM pts GROUP BY hex
+    ),
+    new AS (
+        SELECT h3_cell_to_parent(hex_z8, %(n)s)::text AS hex, sum(count)::int AS cnt
+        FROM zone_exposed.location_{s.grain}
+        WHERE type = %(type)s AND code = %(code)s AND year = %(year)s {grain_pred}
+        GROUP BY 1
+    ),
+    diff AS (
+        SELECT coalesce(o.hex, n.hex) AS hex, o.cnt AS old_cnt, n.cnt AS new_cnt
+        FROM old o FULL JOIN new n USING (hex)
+        WHERE o.cnt IS DISTINCT FROM n.cnt
+    )
+    SELECT
+        (SELECT count(*) FROM old)                       AS old_hexes,
+        (SELECT count(*) FROM new)                       AS new_hexes,
+        (SELECT coalesce(sum(cnt),0) FROM old)           AS old_total,
+        (SELECT coalesce(sum(cnt),0) FROM new)           AS new_total,
+        (SELECT count(*) FROM diff)                      AS mismatched_hexes,
+        (SELECT json_agg(d) FROM (SELECT * FROM diff LIMIT 5) d) AS sample
+    """
+    params["type"] = s.type_
+    return sql, params
+
+
+def main() -> int:
+    conn = pg_connect()
+    failures = 0
+    print(f"{'scope':<34} {'old→new hex':>14} {'old→new tot':>18} {'écart':>8}  verdict")
+    print("-" * 92)
+    for s in SCOPES:
+        sql, params = _old_new_sql(s, N_ZOOM)
+        row = conn.execute(sql, params).fetchone()
+        old_h, new_h, old_t, new_t, mism, sample = row
+        expected = s.code in PLM_COM_CODES and s.type_ == "com"
+        if mism == 0:
+            verdict = "PASS"
+        elif expected:
+            verdict = "DIVERGE (attendu)"
+        else:
+            verdict = "FAIL"
+            failures += 1
+        label = f"{s.type_}/{s.code}/{s.grain}{'' if s.period is None else '/' + str(s.period)}"
+        print(f"{label:<34} {f'{old_h}→{new_h}':>14} {f'{old_t}→{new_t}':>18} {mism:>8}  {verdict}")
+        if verdict == "FAIL" and sample:
+            print(f"    échantillons: {sample}")
+    print("-" * 92)
+    print(f"{'OK' if failures == 0 else 'ÉCHEC'} — {failures} scope(s) en FAIL")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/datalake/analyses/location_quality.py
+++ b/datalake/analyses/location_quality.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Contrôles qualité de la heatmap `location` pré-agrégée (PR modèles).
+
+À lancer APRÈS le backfill des modèles `location_*`, avant la bascule de l'API.
+Complète le harnais de parité (`location_parity.py`, qui compare à l'ancienne
+requête) par des invariants internes qui ne dépendent PAS de l'ancienne vue —
+donc encore valables après sa suppression.
+
+Contrôle central : **cohérence des grains grossiers vs mois**. Les agrégats
+`*_{quarter,semester,year}` sont construits en `delete+insert` sur un bucket de
+période ; un backfill mené mois par mois peut ne laisser que le dernier mois dans
+le bucket (bug connu, cf. suivi Data). Ce script le détecte : la somme d'une
+période doit égaler la somme de ses mois constitutifs.
+
+    DBT_HOST=... DBT_PORT=... DBT_USER=... DBT_PASSWORD=... DBT_DBNAME=datalake \
+        python analyses/location_quality.py
+
+Code retour != 0 si un contrôle échoue.
+"""
+
+from __future__ import annotations
+
+import sys
+
+from pipelines.helpers.pg import pg_connect
+
+# Échantillon (type, code, année) : un fin, un moyen, un dense. À adapter au backfill.
+SAMPLE = [
+    ("com", "31555", 2024),
+    ("reg", "11", 2024),
+    ("country", "XXXXX", 2024),  # France (cf. suivi Data : XXXXX = code pays France)
+]
+
+
+def _sum(conn, table: str, where: str, params: dict) -> int:
+    row = conn.execute(f"SELECT coalesce(sum(count), 0) FROM zone_exposed.{table} WHERE {where}",
+                       params).fetchone()
+    return int(row[0])
+
+
+def _neg_counts(conn, table: str) -> int:
+    return int(conn.execute(f"SELECT count(*) FROM zone_exposed.{table} WHERE count < 0").fetchone()[0])
+
+
+def check_scope(conn, type_: str, code: str, year: int) -> list[tuple[str, bool, str]]:
+    """Renvoie une liste de (libellé, ok, détail) pour un scope."""
+    base = {"type": type_, "code": code, "year": year}
+    w = "type = %(type)s AND code = %(code)s AND year = %(year)s"
+    out: list[tuple[str, bool, str]] = []
+
+    months = _sum(conn, "location_month", w, base)
+
+    # 1. année == somme des mois de l'année
+    y = _sum(conn, "location_year", w, base)
+    out.append((f"year == Σmois", y == months, f"year={y} vs Σmois={months}"))
+
+    # 2. chaque trimestre == somme de ses 3 mois
+    for q in (1, 2, 3, 4):
+        m0 = (q - 1) * 3 + 1
+        qsum = _sum(conn, "location_quarter", w + " AND quarter = %(q)s", {**base, "q": q})
+        msum = _sum(conn, "location_month",
+                    w + " AND month BETWEEN %(a)s AND %(b)s", {**base, "a": m0, "b": m0 + 2})
+        out.append((f"Q{q} == ΣmoisQ{q}", qsum == msum, f"q={qsum} vs Σmois={msum}"))
+
+    # 3. chaque semestre == somme de ses 6 mois
+    for s, (a, b) in ((1, (1, 6)), (2, (7, 12))):
+        ssum = _sum(conn, "location_semester", w + " AND semester = %(s)s", {**base, "s": s})
+        msum = _sum(conn, "location_month",
+                    w + " AND month BETWEEN %(a)s AND %(b)s", {**base, "a": a, "b": b})
+        out.append((f"S{s} == ΣmoisS{s}", ssum == msum, f"s={ssum} vs Σmois={msum}"))
+
+    return out
+
+
+def main() -> int:
+    conn = pg_connect()
+    failures = 0
+
+    # Sanité structurelle globale : aucun count négatif.
+    for grain in ("month", "quarter", "semester", "year"):
+        n = _neg_counts(conn, f"location_{grain}")
+        status = "OK" if n == 0 else "FAIL"
+        if n:
+            failures += 1
+        print(f"[structure] location_{grain} counts<0 : {n}  {status}")
+
+    print("-" * 78)
+    for type_, code, year in SAMPLE:
+        print(f"### {type_}/{code}/{year}")
+        for label, ok, detail in check_scope(conn, type_, code, year):
+            verdict = "OK" if ok else "FAIL"
+            if not ok:
+                failures += 1
+            print(f"  {label:<16} {verdict:<5} {detail}")
+    print("-" * 78)
+    print(f"{'OK' if failures == 0 else 'ÉCHEC'} — {failures} contrôle(s) en FAIL")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/datalake/macros/filters/filtered_carpools.sql
+++ b/datalake/macros/filters/filtered_carpools.sql
@@ -138,6 +138,8 @@ SELECT
   c.distance,
   c.duration,
   c.dist_class,
+  c.start_h3index_z8,
+  c.end_h3index_z8,
   {{ cfg.start_col }} AS start_code,
   {{ cfg.end_col }} AS end_code,
   -- Nouveaux utilisateurs

--- a/datalake/macros/models/aggregated/location/location_model.sql
+++ b/datalake/macros/models/aggregated/location/location_model.sql
@@ -1,0 +1,82 @@
+{% macro location_model(perim, grain) %}
+
+  {# Histogramme H3 (heatmap de densité) pré-agrégé par territoire touché et période.
+     Réplique la sémantique de l'ancienne requête à la volée de l'API : pour chaque
+     territoire T où un trajet a un point (start_code = T OU end_code = T), on compte
+     SES DEUX extrémités (start_h3index_z8 et end_h3index_z8). Le garde-fou
+     `end_code IS DISTINCT FROM start_code` évite le double comptage des intra-T. #}
+
+  {% set lookbacks = {
+    'day':      {'nb': 3, 'unit': 'day'},
+    'month':    {'nb': 1, 'unit': 'month'},
+    'quarter':  {'nb': 1, 'unit': 'quarter'},
+    'semester': {'nb': 0, 'unit': 'semester'},
+    'year':     {'nb': 0, 'unit': 'year'}
+  } %}
+
+  {% if grain not in lookbacks %}
+    {{ exceptions.raise_compiler_error("Invalid grain: " ~ grain) }}
+  {% endif %}
+
+  {% set lb = lookbacks[grain] %}
+
+{% if perim == 'com' %}
+
+{{ config(
+  materialized='view',
+  tags=['aggregated', 'location', grain, 'com']
+) }}
+
+SELECT * FROM {{ ref('location_' ~ grain ~ '_arr') }}
+UNION ALL
+SELECT * FROM {{ ref('location_' ~ grain ~ '_plm') }}
+
+{% else %}
+
+{{ config(
+  materialized='incremental',
+  incremental_strategy='delete+insert',
+  unique_key=['territory', 'incremental_date', 'hex_z8'],
+  indexes=[
+    {'columns': ['territory', 'incremental_date']}
+  ],
+  tags=['aggregated', 'location', grain, perim, 'daily']
+) }}
+
+{% set plm_filter = "IN ('75056', '69123', '13055')" if perim == 'plm' else '' %}
+
+WITH filtered_carpools AS (
+  {{ filtered_carpools(perim, lookback_nb=lb.nb, lookback_unit=lb.unit) }}
+),
+
+-- Parité vue legacy : exclut les 2 derniers jours (données incomplètes).
+recent AS (
+  SELECT * FROM filtered_carpools WHERE carpool_datetime < now() - INTERVAL '2 day'
+),
+
+exploded AS (
+  -- trajet rattaché par son départ au territoire start_code : ses 2 hexagones
+  SELECT start_code AS territory, carpool_datetime, start_h3index_z8 AS hex_z8
+  FROM recent WHERE start_code IS NOT NULL {% if plm_filter %}AND start_code {{ plm_filter }}{% endif %}
+  UNION ALL
+  SELECT start_code, carpool_datetime, end_h3index_z8
+  FROM recent WHERE start_code IS NOT NULL {% if plm_filter %}AND start_code {{ plm_filter }}{% endif %}
+  UNION ALL
+  -- trajet rattaché par son arrivée à un territoire distinct : ses 2 hexagones
+  SELECT end_code, carpool_datetime, start_h3index_z8
+  FROM recent WHERE end_code IS NOT NULL AND end_code IS DISTINCT FROM start_code {% if plm_filter %}AND end_code {{ plm_filter }}{% endif %}
+  UNION ALL
+  SELECT end_code, carpool_datetime, end_h3index_z8
+  FROM recent WHERE end_code IS NOT NULL AND end_code IS DISTINCT FROM start_code {% if plm_filter %}AND end_code {{ plm_filter }}{% endif %}
+)
+
+SELECT
+  territory,
+  {{ incremental_columns('carpool_datetime', grain) }},
+  hex_z8,
+  count(*)::bigint AS count
+FROM exploded
+GROUP BY 1, {{ group_by_grain(grain, 2) }}, hex_z8
+
+{% endif %}
+{% endmacro %}

--- a/datalake/macros/models/exposed/observatory/location_exposed.sql
+++ b/datalake/macros/models/exposed/observatory/location_exposed.sql
@@ -1,0 +1,66 @@
+{% macro location_exposed(grain) %}
+
+  {# Projection exposée de la heatmap H3 pré-agrégée : union des types de territoire
+     (colonne `type`), lue par api-datalake sur (type, code, période). Remplace la
+     vue brute `location` qui scannait `carpools` à la volée. #}
+
+  {% set grain_cols = {
+    'month':    ['year', 'month'],
+    'quarter':  ['year', 'quarter'],
+    'semester': ['year', 'semester'],
+    'year':     ['year']
+  } %}
+
+  {% if grain not in grain_cols %}
+    {{ exceptions.raise_compiler_error("Invalid grain: " ~ grain) }}
+  {% endif %}
+
+  {% set gcols = grain_cols[grain] %}
+
+  {% set type_map = [
+    ('com',    'com'),
+    ('epci',   'epci'),
+    ('aom',    'aom'),
+    ('aomreg', 'aom'),
+    ('dep',    'dep'),
+    ('reg',    'reg'),
+    ('country','country')
+  ] %}
+
+  {# Clé de tri de période, pour un lookback incrémental (comme od_month). #}
+  {% set period_key = {
+    'month':    'year * 100 + month',
+    'quarter':  'year * 10 + quarter',
+    'semester': 'year * 10 + semester',
+    'year':     'year'
+  }[grain] %}
+
+{{ config(
+  materialized='incremental',
+  incremental_strategy='delete+insert',
+  unique_key=['type', 'code'] + grain_cols[grain] + ['hex_z8'],
+  indexes=[
+    {'columns': ['type', 'code'] + grain_cols[grain]}
+  ],
+  tags=['exposed', 'observatory', 'location']
+) }}
+
+{% if is_incremental() %}
+WITH lookback AS (
+  SELECT max({{ period_key }}) - 1 AS min_key FROM {{ this }}
+)
+{% endif %}
+
+{% for model_type, exposed_type in type_map %}
+SELECT
+  '{{ exposed_type }}'::text AS type,
+  territory AS code,
+  {% for c in gcols %}{{ c }},
+  {% endfor %}hex_z8,
+  count
+FROM {{ ref('location_' ~ grain ~ '_' ~ model_type) }}
+{% if is_incremental() %}WHERE {{ period_key }} >= (SELECT min_key FROM lookback){% endif %}
+{% if not loop.last %}UNION ALL{% endif %}
+{% endfor %}
+
+{% endmacro %}

--- a/datalake/models/aggregated/location/month/location_month_aom.sql
+++ b/datalake/models/aggregated/location/month/location_month_aom.sql
@@ -1,0 +1,1 @@
+{{ location_model('aom', 'month') }}

--- a/datalake/models/aggregated/location/month/location_month_aomreg.sql
+++ b/datalake/models/aggregated/location/month/location_month_aomreg.sql
@@ -1,0 +1,1 @@
+{{ location_model('aomreg', 'month') }}

--- a/datalake/models/aggregated/location/month/location_month_arr.sql
+++ b/datalake/models/aggregated/location/month/location_month_arr.sql
@@ -1,0 +1,1 @@
+{{ location_model('arr', 'month') }}

--- a/datalake/models/aggregated/location/month/location_month_com.sql
+++ b/datalake/models/aggregated/location/month/location_month_com.sql
@@ -1,0 +1,1 @@
+{{ location_model('com', 'month') }}

--- a/datalake/models/aggregated/location/month/location_month_country.sql
+++ b/datalake/models/aggregated/location/month/location_month_country.sql
@@ -1,0 +1,1 @@
+{{ location_model('country', 'month') }}

--- a/datalake/models/aggregated/location/month/location_month_dep.sql
+++ b/datalake/models/aggregated/location/month/location_month_dep.sql
@@ -1,0 +1,1 @@
+{{ location_model('dep', 'month') }}

--- a/datalake/models/aggregated/location/month/location_month_epci.sql
+++ b/datalake/models/aggregated/location/month/location_month_epci.sql
@@ -1,0 +1,1 @@
+{{ location_model('epci', 'month') }}

--- a/datalake/models/aggregated/location/month/location_month_plm.sql
+++ b/datalake/models/aggregated/location/month/location_month_plm.sql
@@ -1,0 +1,1 @@
+{{ location_model('plm', 'month') }}

--- a/datalake/models/aggregated/location/month/location_month_reg.sql
+++ b/datalake/models/aggregated/location/month/location_month_reg.sql
@@ -1,0 +1,1 @@
+{{ location_model('reg', 'month') }}

--- a/datalake/models/aggregated/location/quarter/location_quarter_aom.sql
+++ b/datalake/models/aggregated/location/quarter/location_quarter_aom.sql
@@ -1,0 +1,1 @@
+{{ location_model('aom', 'quarter') }}

--- a/datalake/models/aggregated/location/quarter/location_quarter_aomreg.sql
+++ b/datalake/models/aggregated/location/quarter/location_quarter_aomreg.sql
@@ -1,0 +1,1 @@
+{{ location_model('aomreg', 'quarter') }}

--- a/datalake/models/aggregated/location/quarter/location_quarter_arr.sql
+++ b/datalake/models/aggregated/location/quarter/location_quarter_arr.sql
@@ -1,0 +1,1 @@
+{{ location_model('arr', 'quarter') }}

--- a/datalake/models/aggregated/location/quarter/location_quarter_com.sql
+++ b/datalake/models/aggregated/location/quarter/location_quarter_com.sql
@@ -1,0 +1,1 @@
+{{ location_model('com', 'quarter') }}

--- a/datalake/models/aggregated/location/quarter/location_quarter_country.sql
+++ b/datalake/models/aggregated/location/quarter/location_quarter_country.sql
@@ -1,0 +1,1 @@
+{{ location_model('country', 'quarter') }}

--- a/datalake/models/aggregated/location/quarter/location_quarter_dep.sql
+++ b/datalake/models/aggregated/location/quarter/location_quarter_dep.sql
@@ -1,0 +1,1 @@
+{{ location_model('dep', 'quarter') }}

--- a/datalake/models/aggregated/location/quarter/location_quarter_epci.sql
+++ b/datalake/models/aggregated/location/quarter/location_quarter_epci.sql
@@ -1,0 +1,1 @@
+{{ location_model('epci', 'quarter') }}

--- a/datalake/models/aggregated/location/quarter/location_quarter_plm.sql
+++ b/datalake/models/aggregated/location/quarter/location_quarter_plm.sql
@@ -1,0 +1,1 @@
+{{ location_model('plm', 'quarter') }}

--- a/datalake/models/aggregated/location/quarter/location_quarter_reg.sql
+++ b/datalake/models/aggregated/location/quarter/location_quarter_reg.sql
@@ -1,0 +1,1 @@
+{{ location_model('reg', 'quarter') }}

--- a/datalake/models/aggregated/location/semester/location_semester_aom.sql
+++ b/datalake/models/aggregated/location/semester/location_semester_aom.sql
@@ -1,0 +1,1 @@
+{{ location_model('aom', 'semester') }}

--- a/datalake/models/aggregated/location/semester/location_semester_aomreg.sql
+++ b/datalake/models/aggregated/location/semester/location_semester_aomreg.sql
@@ -1,0 +1,1 @@
+{{ location_model('aomreg', 'semester') }}

--- a/datalake/models/aggregated/location/semester/location_semester_arr.sql
+++ b/datalake/models/aggregated/location/semester/location_semester_arr.sql
@@ -1,0 +1,1 @@
+{{ location_model('arr', 'semester') }}

--- a/datalake/models/aggregated/location/semester/location_semester_com.sql
+++ b/datalake/models/aggregated/location/semester/location_semester_com.sql
@@ -1,0 +1,1 @@
+{{ location_model('com', 'semester') }}

--- a/datalake/models/aggregated/location/semester/location_semester_country.sql
+++ b/datalake/models/aggregated/location/semester/location_semester_country.sql
@@ -1,0 +1,1 @@
+{{ location_model('country', 'semester') }}

--- a/datalake/models/aggregated/location/semester/location_semester_dep.sql
+++ b/datalake/models/aggregated/location/semester/location_semester_dep.sql
@@ -1,0 +1,1 @@
+{{ location_model('dep', 'semester') }}

--- a/datalake/models/aggregated/location/semester/location_semester_epci.sql
+++ b/datalake/models/aggregated/location/semester/location_semester_epci.sql
@@ -1,0 +1,1 @@
+{{ location_model('epci', 'semester') }}

--- a/datalake/models/aggregated/location/semester/location_semester_plm.sql
+++ b/datalake/models/aggregated/location/semester/location_semester_plm.sql
@@ -1,0 +1,1 @@
+{{ location_model('plm', 'semester') }}

--- a/datalake/models/aggregated/location/semester/location_semester_reg.sql
+++ b/datalake/models/aggregated/location/semester/location_semester_reg.sql
@@ -1,0 +1,1 @@
+{{ location_model('reg', 'semester') }}

--- a/datalake/models/aggregated/location/year/location_year_aom.sql
+++ b/datalake/models/aggregated/location/year/location_year_aom.sql
@@ -1,0 +1,1 @@
+{{ location_model('aom', 'year') }}

--- a/datalake/models/aggregated/location/year/location_year_aomreg.sql
+++ b/datalake/models/aggregated/location/year/location_year_aomreg.sql
@@ -1,0 +1,1 @@
+{{ location_model('aomreg', 'year') }}

--- a/datalake/models/aggregated/location/year/location_year_arr.sql
+++ b/datalake/models/aggregated/location/year/location_year_arr.sql
@@ -1,0 +1,1 @@
+{{ location_model('arr', 'year') }}

--- a/datalake/models/aggregated/location/year/location_year_com.sql
+++ b/datalake/models/aggregated/location/year/location_year_com.sql
@@ -1,0 +1,1 @@
+{{ location_model('com', 'year') }}

--- a/datalake/models/aggregated/location/year/location_year_country.sql
+++ b/datalake/models/aggregated/location/year/location_year_country.sql
@@ -1,0 +1,1 @@
+{{ location_model('country', 'year') }}

--- a/datalake/models/aggregated/location/year/location_year_dep.sql
+++ b/datalake/models/aggregated/location/year/location_year_dep.sql
@@ -1,0 +1,1 @@
+{{ location_model('dep', 'year') }}

--- a/datalake/models/aggregated/location/year/location_year_epci.sql
+++ b/datalake/models/aggregated/location/year/location_year_epci.sql
@@ -1,0 +1,1 @@
+{{ location_model('epci', 'year') }}

--- a/datalake/models/aggregated/location/year/location_year_plm.sql
+++ b/datalake/models/aggregated/location/year/location_year_plm.sql
@@ -1,0 +1,1 @@
+{{ location_model('plm', 'year') }}

--- a/datalake/models/aggregated/location/year/location_year_reg.sql
+++ b/datalake/models/aggregated/location/year/location_year_reg.sql
@@ -1,0 +1,1 @@
+{{ location_model('reg', 'year') }}

--- a/datalake/models/exposed/observatory/location_month.sql
+++ b/datalake/models/exposed/observatory/location_month.sql
@@ -1,0 +1,1 @@
+{{ location_exposed('month') }}

--- a/datalake/models/exposed/observatory/location_quarter.sql
+++ b/datalake/models/exposed/observatory/location_quarter.sql
@@ -1,0 +1,1 @@
+{{ location_exposed('quarter') }}

--- a/datalake/models/exposed/observatory/location_semester.sql
+++ b/datalake/models/exposed/observatory/location_semester.sql
@@ -1,0 +1,1 @@
+{{ location_exposed('semester') }}

--- a/datalake/models/exposed/observatory/location_year.sql
+++ b/datalake/models/exposed/observatory/location_year.sql
@@ -1,0 +1,1 @@
+{{ location_exposed('year') }}

--- a/datalake/models/exposed/observatory/yml/_location.yml
+++ b/datalake/models/exposed/observatory/yml/_location.yml
@@ -1,21 +1,64 @@
 version: 2
 models:
-  - name: location
+  - name: location_month
     description: >
-      Trajets pour la heatmap de densité de l'observatoire (remplace la vue legacy
-      observatoire_stats.view_location). Expose les index H3 résolution 8 pour un
-      binning en SQL côté api-datalake ; parité H3 exacte pour un zoom <= 8.
+      Heatmap de densité pré-agrégée (histogramme H3 résolution 8) par territoire et
+      par mois. Remplace la vue brute `location` qui scannait `carpools` à la volée.
+      Lue par api-datalake sur (type, code, year, month) ; binning au zoom via
+      h3_cell_to_parent(hex_z8, n).
     columns:
-      - name: carpool_id
+      - name: type
+        data_type: text
+      - name: code
+        data_type: text
+      - name: year
         data_type: integer
-      - name: start_geo_code
-        data_type: character varying
-      - name: end_geo_code
-        data_type: character varying
-      - name: start_datetime
-        data_type: timestamp without time zone
-        description: Datetime de départ en heure locale (timezoned_ts), stocké naïf.
-      - name: start_h3index_z8
+      - name: month
+        data_type: integer
+      - name: hex_z8
         data_type: h3index
-      - name: end_h3index_z8
+      - name: count
+        data_type: bigint
+  - name: location_quarter
+    description: Heatmap de densité pré-agrégée (H3 z8) par territoire et par trimestre.
+    columns:
+      - name: type
+        data_type: text
+      - name: code
+        data_type: text
+      - name: year
+        data_type: integer
+      - name: quarter
+        data_type: integer
+      - name: hex_z8
         data_type: h3index
+      - name: count
+        data_type: bigint
+  - name: location_semester
+    description: Heatmap de densité pré-agrégée (H3 z8) par territoire et par semestre.
+    columns:
+      - name: type
+        data_type: text
+      - name: code
+        data_type: text
+      - name: year
+        data_type: integer
+      - name: semester
+        data_type: integer
+      - name: hex_z8
+        data_type: h3index
+      - name: count
+        data_type: bigint
+  - name: location_year
+    description: Heatmap de densité pré-agrégée (H3 z8) par territoire et par année.
+    columns:
+      - name: type
+        data_type: text
+      - name: code
+        data_type: text
+      - name: year
+        data_type: integer
+      - name: hex_z8
+        data_type: h3index
+      - name: count
+        data_type: bigint


### PR DESCRIPTION
## Contexte

Découpe de #3293 en **2 PR** pour respecter le déploiement **automatique** d'`api-datalake` (déclenché sur push `main` touchant `api-datalake/**`). Un PR unique basculerait l'API sur des tables qui n'existent pas encore au merge → 500.

Cette PR = **modèles datalake uniquement** → ne touche pas `api-datalake/`, donc **ne déclenche aucun déploiement**. L'ancienne API continue de lire la vue legacy `location`, conservée ici.

Rebasée sur `main` courant (le #3293 d'origine était très en retard : décommission du service observatoire Deno depuis, d'où le diff pollué).

## Contenu

- **`location_model`** : histogramme H3 z8 incrémental par territoire touché et période ; compte les 2 extrémités (garde-fou intra `end_code IS DISTINCT FROM start_code`) ; **exclut les 2 derniers jours** (parité avec l'ancienne vue).
- **`location_exposed`** : projection `(type, code, période)` en **incrémental `delete+insert` indexée** (patron `od_month`), lue par api-datalake.
- **`filtered_carpools`** : expose `start/end_h3index_z8` (passthrough).
- **Vue legacy `location` conservée** le temps de la bascule (drop en PR de suivi).

### Correctifs par rapport à #3293
- Régression du cutoff 2 jours restaurée.
- Exposé en `incremental` au lieu de `table` (le `table` réécrivait tout l'historique chaque run ; bench : lecture pire cas ~128 ms en index-exact).
- Vue legacy conservée (la supprimer du dépôt ne drope pas la relation ; fait en suivi).

### Outils de validation (`datalake/analyses/`)
- `location_parity.py` : parité par hexagone vs l'ancienne requête (à lancer post-backfill).
- `location_quality.py` : cohérence des grains grossiers vs mois (garde-fou du bug bucket `delete+insert` connu sur `*_{quarter,semester,year}`).

## Séquencement (⚠️ impératif)

1. Merge **cette PR**.
2. `dbt build` + **backfill** des `location_*` — ⚠️ grains grossiers : reprocesser la **période complète** (pas mois par mois), sinon le bucket ne garde que le dernier mois. Voir le runbook ops.
3. Lancer `location_parity.py` + `location_quality.py` (vert attendu).
4. Merger la **PR api-datalake** → bascule + déploiement auto.
5. PR de suivi : `DROP VIEW` de la vue legacy `location`.

Runbook ops de backfill fourni séparément à l'équipe infra.