### PR TITLE
fix(export): retire le lien de téléchargement de l'email d'export

### DIFF
--- a/api/src/pdc/services/export/actions/CompleteAction.integration.spec.ts
+++ b/api/src/pdc/services/export/actions/CompleteAction.integration.spec.ts
@@ -13,7 +13,6 @@ import {
 import { ExportServiceProvider as ExportSP } from "@/pdc/services/export/ExportServiceProvider.ts";
 import { Export } from "@/pdc/services/export/models/Export.ts";
 import { NotificationService } from "@/pdc/services/export/services/NotificationService.ts";
-import { StorageService } from "@/pdc/services/export/services/StorageService.ts";
 import { handlerConfig, ResultInterface } from "../contracts/complete.contract.ts";
 
 const { before: kernelBefore, after: kernelAfter } = makeKernelBeforeAfter(ExportSP);
@@ -23,7 +22,7 @@ describe("CompleteAction", () => {
   let db: DenoDbContext;
   let kc: KernelContext;
 
-  const successCalls: Array<{ exp: Export; url: string }> = [];
+  const successCalls: Array<{ exp: Export }> = [];
 
   const workerContext: ContextType = {
     call: { user: { permissions: ["datalake.export.process"] } },
@@ -74,16 +73,13 @@ describe("CompleteAction", () => {
       .rebind(LegacyPostgresConnection)
       .toConstantValue(new LegacyPostgresConnection({ connectionString }));
 
-    // spy the notification + storage so we exercise the transition, not real S3/email
+    // spy the notification so we exercise the transition, not real email
     forceBind(NotificationService, {
-      success: async (exp: Export, url: string) => {
-        successCalls.push({ exp, url });
+      success: async (exp: Export) => {
+        successCalls.push({ exp });
       },
       error: async () => {},
       support: async () => {},
-    });
-    forceBind(StorageService, {
-      getPublicUrl: async (filename: string) => `https://example.test/${filename}`,
     });
   });
 
@@ -109,7 +105,7 @@ describe("CompleteAction", () => {
         assertEquals(Number(row.file_size), 4096);
 
         assertEquals(successCalls.length, 1);
-        assertEquals(successCalls[0].url, `https://example.test/${uuid}.csv.zip`);
+        assertEquals(successCalls[0].exp.uuid, uuid);
       },
     );
 

--- a/api/src/pdc/services/export/actions/CompleteAction.ts
+++ b/api/src/pdc/services/export/actions/CompleteAction.ts
@@ -8,7 +8,6 @@ import { alias } from "../contracts/complete.schema.ts";
 import { ExportStatus } from "../models/Export.ts";
 import { ExportRepositoryInterfaceResolver } from "../repositories/ExportRepository.ts";
 import { NotificationService } from "../services/NotificationService.ts";
-import { StorageService } from "../services/StorageService.ts";
 
 @handler({
   ...handlerConfig,
@@ -22,7 +21,6 @@ export class CompleteAction extends AbstractAction {
   constructor(
     protected exportRepository: ExportRepositoryInterfaceResolver,
     protected notification: NotificationService,
-    protected storage: StorageService,
   ) {
     super();
   }
@@ -40,11 +38,10 @@ export class CompleteAction extends AbstractAction {
     await this.exportRepository.update(exp._id, { filename, file_size: params.file_size });
     await this.exportRepository.status(exp._id, ExportStatus.SUCCESS);
 
-    // email the export creator with the download link — best-effort: the file exists
-    // and the row is SUCCESS, so a missing creator must not block/undo completion
+    // notify the export creator it is ready — best-effort: the file exists and the
+    // row is SUCCESS, so a missing creator must not block/undo completion
     try {
-      const url = await this.storage.getPublicUrl(filename);
-      await this.notification.success(exp, url);
+      await this.notification.success(exp);
     } catch (e) {
       logger.error(`Export ${exp.uuid} completed but notification failed: ${(e as Error).message}`);
     }

--- a/api/src/pdc/services/export/notifications/ExportCSVNotification.ts
+++ b/api/src/pdc/services/export/notifications/ExportCSVNotification.ts
@@ -1,29 +1,32 @@
 import { DefaultNotification, DefaultTemplateData } from "@/pdc/providers/notification/index.ts";
 import { Export } from "../models/Export.ts";
 
-export interface ExportCSVErrorTemplateData extends Pick<Export, "_id" | "uuid" | "target" | "status"> {
+export interface ExportCSVTemplateData extends Pick<Export, "_id" | "uuid" | "target" | "status"> {
   fullname: string;
-  action_href: string;
 }
+
+const exportsUrl = "https://partenaire.covoiturage.beta.gouv.fr/activite/export/";
 
 const defaultData: Partial<DefaultTemplateData> = {
   hero_alt: "Export des données",
   hero_image_src: "https://x0zwu.mjt.lu/tplimg/x0zwu/b/x5zwm/vkxn4.png",
-  action_message: "Télécharger le fichier",
+  action_message: "Voir mes exports",
+  action_href: exportsUrl,
   title: "Export des données",
   preview: "Votre export des trajets est disponible.",
   message_html: `
 <p>
 Votre export des trajets est disponible.
-Vous pouvez le télécharger en cliquant sur le bouton ci-dessous.
-</p>      
+Retrouvez-le dans la liste de vos exports en cliquant sur le bouton ci-dessous.
+</p>
 <p>
 Les données sont au format CSV compressé dans un fichier ZIP.
-</p>      
+</p>
     `,
   message_text: `
 Votre export des trajets est disponible.
-Vous pouvez le télécharger en cliquant sur le bouton ci-dessous.
+Retrouvez-le dans la liste de vos exports à l'adresse suivante :
+${exportsUrl}
 
 Les données sont au format CSV compressé dans un fichier ZIP.
     `,
@@ -31,7 +34,7 @@ Les données sont au format CSV compressé dans un fichier ZIP.
 
 export class ExportCSVNotification extends DefaultNotification {
   static override readonly subject = "Export des données";
-  constructor(to: string, data: Partial<ExportCSVErrorTemplateData>) {
+  constructor(to: string, data: Partial<ExportCSVTemplateData>) {
     super(to, { ...defaultData, ...data });
   }
 }

--- a/api/src/pdc/services/export/services/NotificationService.integration.spec.ts
+++ b/api/src/pdc/services/export/services/NotificationService.integration.spec.ts
@@ -44,7 +44,7 @@ describe("NotificationService", () => {
     const sent: { to: string }[] = [];
     const service = makeService(sent);
 
-    await service.success(makeExport(), "http://example.test/download");
+    await service.success(makeExport());
 
     assertEquals(sent.length, 1);
     assertEquals(sent[0].to, "U Ser <u@test.fr>");

--- a/api/src/pdc/services/export/services/NotificationService.ts
+++ b/api/src/pdc/services/export/services/NotificationService.ts
@@ -12,13 +12,13 @@ import { ExportCSVNotification } from "../notifications/ExportCSVNotification.ts
 import { ExportCSVSupportNotification } from "../notifications/ExportCSVSupportNotification.ts";
 
 export type NotificationProvider = {
-  success(exp: Export, url: string): Promise<void>;
+  success(exp: Export): Promise<void>;
   error(exp: Export): Promise<void>;
   support(exp: Export): Promise<void>;
 };
 
 export abstract class NotificationProviderResolver implements NotificationProvider {
-  public async success(_exp: Export, _url: string): Promise<void> {
+  public async success(_exp: Export): Promise<void> {
     throw new Error("Not implemented");
   }
   public async error(_exp: Export): Promise<void> {
@@ -45,13 +45,13 @@ export class NotificationService {
   ) {}
 
   /**
-   * Send the download link to the export creator
+   * Tell the export creator their export is ready (listed on the partner space)
    */
-  public async success(exp: Export, url: string): Promise<void> {
+  public async success(exp: Export): Promise<void> {
     const { email, fullname } = await this.creator(exp);
     const notification = new ExportCSVNotification(
       `${fullname} <${email}>`,
-      { fullname, action_href: url },
+      { fullname },
     );
     await this.emailer.send(notification);
   }

--- a/api/src/pdc/services/export/services/StorageService.ts
+++ b/api/src/pdc/services/export/services/StorageService.ts
@@ -12,9 +12,6 @@ export abstract class StorageServiceInterfaceResolver {
   public async upload(filepath: string): Promise<string> {
     throw new Error("Not implemented");
   }
-  public async getPublicUrl(filename: string): Promise<string> {
-    throw new Error("Not implemented");
-  }
   public async cleanup(filepath: string): Promise<void> {
     throw new Error("Not implemented");
   }
@@ -41,10 +38,6 @@ export class StorageService {
 
   public async upload(filepath: string): Promise<string> {
     return await this.s3StorageProvider.upload(this.bucket, filepath);
-  }
-
-  public async getPublicUrl(filename: string): Promise<string> {
-    return await this.s3StorageProvider.getPublicUrl(this.bucket, filename);
   }
 
   public async getOneTimeSignedUrl(filename: string): Promise<string> {


### PR DESCRIPTION
## Contexte

L'email « Export des données » envoyé quand un export est prêt contenait un
lien de téléchargement direct : une URL S3 **publique et non expirante**,
accessible sans authentification par quiconque possédait le lien.

On le retire au profit d'un renvoi vers la page qui liste les exports du
partenaire (`/activite/export/`), où le téléchargement passe par un lien signé
à usage unique (60 s, `getOneTimeSignedUrl`).

## Modifications

- **Email** (`ExportCSVNotification.ts`) : le bouton devient « Voir mes exports »
  et pointe vers `https://partenaire.covoiturage.beta.gouv.fr/activite/export/`.
  Le corps du message est réécrit en conséquence. L'interface est renommée
  (`ExportCSVTemplateData`) et le champ `action_href` n'est plus attendu de
  l'appelant : il est fixé statiquement.
- **Nettoyage de bout en bout** de l'URL de téléchargement, désormais inutile :
  - `NotificationService.success(exp)` — le paramètre `url` est retiré du
    contrat, du resolver et de la méthode.
  - `CompleteAction` — plus d'appel à `getPublicUrl` ; l'injection
    `StorageService` (devenue inutile) est supprimée.
  - `StorageService.getPublicUrl` — supprimée (morte). `getOneTimeSignedUrl`,
    utilisée par le chemin de téléchargement authentifié, est conservée.
- Tests d'intégration mis à jour (`CompleteAction`, `NotificationService`).

## Aperçu du nouvel email

> **Export des données**
>
> Bonjour {prénom},
>
> Votre export des trajets est disponible. Retrouvez-le dans la liste de vos
> exports en cliquant sur le bouton ci-dessous.
>
> Les données sont au format CSV compressé dans un fichier ZIP.
>
> **[ Voir mes exports ]** → `https://partenaire.covoiturage.beta.gouv.fr/activite/export/`

## Sécurité

**Verdict : PASS — risque FAIBLE (amélioration de la posture).**

Suppression d'une URL S3 publique persistante qui exposait des données de
trajets (PII) sans authentification ni expiration. Le nouveau chemin
(`GetDownloadLinkAction`, protégé par `hasPermissionMiddleware` + contrôle de
propriété sur l'utilisateur appelant) délivre une URL signée à usage unique
expirant en 60 s. Aucune référence résiduelle à l'URL publique, aucune
régression du flux de notification (le try/catch best-effort est conservé).

_Note (hors périmètre) :_ la méthode bas-niveau `S3StorageProvider.getPublicUrl`
n'a plus aucun appelant dans le repo après ce changement. Suppression à
envisager dans un nettoyage ultérieur du provider partagé.

## CGU

**Verdict : PASS — aucune violation.**

Aucune mutation de statut de trajet, aucune modification de rétention/TTL,
aucune donnée identifiante brute journalisée ou exposée. Le changement va au
contraire dans le sens de la minimisation : l'email ne transporte plus d'URL
publique de téléchargement.
