### PR TITLE
fix(datalake): réintègre les trajets tardifs dans les agrégats coarse (lookback semester/year)

### DIFF
--- a/datalake/macros/models/aggregated/fraud/fraud_model.sql
+++ b/datalake/macros/models/aggregated/fraud/fraud_model.sql
@@ -7,8 +7,8 @@
     'day':      {'nb': 3, 'unit': 'day'},
     'month':    {'nb': 1, 'unit': 'month'},
     'quarter':  {'nb': 1, 'unit': 'quarter'},
-    'semester': {'nb': 0, 'unit': 'semester'},
-    'year':     {'nb': 0, 'unit': 'year'}
+    'semester': {'nb': 1, 'unit': 'semester'},
+    'year':     {'nb': 1, 'unit': 'year'}
   } %}
 
   {% if grain not in lookbacks %}

--- a/datalake/macros/models/aggregated/location/location_model.sql
+++ b/datalake/macros/models/aggregated/location/location_model.sql
@@ -10,8 +10,8 @@
     'day':      {'nb': 3, 'unit': 'day'},
     'month':    {'nb': 1, 'unit': 'month'},
     'quarter':  {'nb': 1, 'unit': 'quarter'},
-    'semester': {'nb': 0, 'unit': 'semester'},
-    'year':     {'nb': 0, 'unit': 'year'}
+    'semester': {'nb': 1, 'unit': 'semester'},
+    'year':     {'nb': 1, 'unit': 'year'}
   } %}
 
   {% if grain not in lookbacks %}

--- a/datalake/macros/models/aggregated/od/od_model.sql
+++ b/datalake/macros/models/aggregated/od/od_model.sql
@@ -7,8 +7,8 @@
     'day':      {'nb': 3, 'unit': 'day'},
     'month':    {'nb': 1, 'unit': 'month'},
     'quarter':  {'nb': 1, 'unit': 'quarter'},
-    'semester': {'nb': 0, 'unit': 'semester'},
-    'year':     {'nb': 0, 'unit': 'year'}
+    'semester': {'nb': 1, 'unit': 'semester'},
+    'year':     {'nb': 1, 'unit': 'year'}
   } %}
 
   {% if grain not in lookbacks %}

--- a/datalake/macros/models/aggregated/operators/operators_model.sql
+++ b/datalake/macros/models/aggregated/operators/operators_model.sql
@@ -7,8 +7,8 @@
     'day':      {'nb': 3, 'unit': 'day'},
     'month':    {'nb': 1, 'unit': 'month'},
     'quarter':  {'nb': 1, 'unit': 'quarter'},
-    'semester': {'nb': 0, 'unit': 'semester'},
-    'year':     {'nb': 0, 'unit': 'year'}
+    'semester': {'nb': 1, 'unit': 'semester'},
+    'year':     {'nb': 1, 'unit': 'year'}
   } %}
 
   {% if grain not in lookbacks %}

--- a/datalake/macros/models/aggregated/territory/territory_model.sql
+++ b/datalake/macros/models/aggregated/territory/territory_model.sql
@@ -7,8 +7,8 @@
     'day':      {'nb': 3, 'unit': 'day'},
     'month':    {'nb': 1, 'unit': 'month'},
     'quarter':  {'nb': 1, 'unit': 'quarter'},
-    'semester': {'nb': 0, 'unit': 'semester'},
-    'year':     {'nb': 0, 'unit': 'year'}
+    'semester': {'nb': 1, 'unit': 'semester'},
+    'year':     {'nb': 1, 'unit': 'year'}
   } %}
 
   {% if grain not in lookbacks %}


### PR DESCRIPTION
## Contexte
GEN-681 : les agrégats observatoire aux grains **semestre / année** figent la dernière période affichée. Le `GROUP BY` par période est correct ; le bug vient du **fenêtrage incrémental**.

## Problème
Le lookback quotidien vaut `nb=0` pour `semester` et `year` : le run incrémental ne relit que la période **en cours**, jamais la précédente. Une période close ne réintègre donc plus les trajets arrivés en retard (transmissions tardives, reprocessing validité/fraude) → sa dernière barre dérive à la baisse dans le temps.

## Correctif
Passe le lookback à `nb=1` pour `semester` et `year`, aligné sur `month=1` / `quarter=1`. Appliqué aux 5 modèles agrégés partageant le même patron : `territory`, `od`, `fraud`, `operators`, `location`.

Chaque période close est ré-agrégée un cycle de plus, le temps que les données tardives atterrissent, puis se fige (les retards au-delà d'une période sont rattrapés par le backfill périodique).

## Impact / coût
Le run quotidien reprocesse désormais la période précédente complète : pour `year`, ~2 ans de `carpools` ré-agrégés par jour (vs ~6 mois pour `quarter`). Prix de la cohérence, ajustable si le runtime pose problème.

## Suite (ops, cf. runbook)
Le correctif code ne réécrit pas l'historique : après merge, backfill des grains coarse en **fenêtres période-complète** puis `--full-refresh` des exposés `zone_exposed.*`, et parité vs `observatory.monthly_*`. Détaillé dans `~/shared/backfill-location-preagg.md` et GEN-681.

Ref: GEN-681