### PR TITLE
fix(datalake): tague les vues d'union _com en daily

### DIFF
--- a/datalake/macros/models/aggregated/fraud/fraud_model.sql
+++ b/datalake/macros/models/aggregated/fraud/fraud_model.sql
@@ -28,7 +28,7 @@
 
 {{ config(
   materialized='view',
-  tags=['aggregated', 'fraud', grain, 'com', direction]
+  tags=['aggregated', 'fraud', grain, 'com', direction, 'daily']
 ) }}
 
 SELECT * FROM {{ ref('fraud_' ~ grain ~ '_arr_' ~ direction) }}

--- a/datalake/macros/models/aggregated/location/location_model.sql
+++ b/datalake/macros/models/aggregated/location/location_model.sql
@@ -24,7 +24,7 @@
 
 {{ config(
   materialized='view',
-  tags=['aggregated', 'location', grain, 'com']
+  tags=['aggregated', 'location', grain, 'com', 'daily']
 ) }}
 
 SELECT * FROM {{ ref('location_' ~ grain ~ '_arr') }}

--- a/datalake/macros/models/aggregated/od/od_model.sql
+++ b/datalake/macros/models/aggregated/od/od_model.sql
@@ -24,7 +24,7 @@
 
 {{ config(
   materialized='view',
-  tags=['aggregated', 'od', grain, 'com']
+  tags=['aggregated', 'od', grain, 'com', 'daily']
 ) }}
 
 SELECT * FROM {{ ref('od_' ~ grain ~ '_arr') }}

--- a/datalake/macros/models/aggregated/operators/operators_model.sql
+++ b/datalake/macros/models/aggregated/operators/operators_model.sql
@@ -28,7 +28,7 @@
 
 {{ config(
   materialized='view',
-  tags=['aggregated', 'operators', grain, 'com', direction]
+  tags=['aggregated', 'operators', grain, 'com', direction, 'daily']
 ) }}
 
 SELECT * FROM {{ ref('operators_' ~ grain ~ '_arr_' ~ direction) }}

--- a/datalake/macros/models/aggregated/territory/territory_model.sql
+++ b/datalake/macros/models/aggregated/territory/territory_model.sql
@@ -28,7 +28,7 @@
 
 {{ config(
   materialized='view',
-  tags=['aggregated', 'territory', grain, 'com', direction]
+  tags=['aggregated', 'territory', grain, 'com', direction, 'daily']
 ) }}
 
 SELECT * FROM {{ ref('territory_' ~ grain ~ '_arr_' ~ direction) }}


### PR DESCRIPTION
## Contexte

Le cron `pipeline-daily` (datalake, tous les jours à 3h14 CEST) échouait chaque nuit depuis la mise en production de la heatmap `location` (#3298) :

```
Database Error in model location_month
  relation "zone_aggregated.location_month_com" does not exist
```

## Cause

Chaque macro d'agrégat définit, pour `perim == 'com'`, une **vue** `UNION ALL` des feuilles `arr` + `plm`. Cette vue n'était **pas taggée `daily`**, alors que le cron sélectionne `--select "tag:daily" "models/exposed"`. Les feuilles (taggées `daily`) étaient bien construites, mais jamais la vue `_com` — que lisent pourtant les modèles exposés `zone_aggregated.<fam>_<grain>_com`.

Pour les familles préexistantes (`territory`, `od`…), les vues `_com` avaient été créées par d'anciens backfills manuels, ce qui masquait le bug. Pour une famille neuve (`location`), elles n'existaient pas → l'exposé plante et fait échouer tout le run.

## Correctif

Ajout de `'daily'` aux tags de la config `_com` dans les 5 macros d'agrégat (`location`, `territory`, `od`, `fraud`, `operators`, en conservant `direction` là où il existe). La vue est reconstruite par `CREATE OR REPLACE VIEW` (coût quasi nul) ; dbt ordonne le DAG pour bâtir les feuilles `arr`/`plm` avant la vue. Le pipeline quotidien devient **auto-réparant** : si une vue `_com` manque (famille neuve, environnement vierge), le run la (re)crée.

## Vérification (manifest dbt)

Analyse de la fermeture de dépendances de la sélection `pipeline-daily` sur le manifest compilé (572 modèles) : après correctif, **aucune dépendance dynamique** (données de trajets) n'échappe plus au cron. Ne restent hors sélection que les 3 tables **geo** (`perimeters`, `perimeters_agg`, `com_evolution`), bâties par `pipeline-trusted-geo` — comportement voulu. Contrôle : `dbt ls --select tag:daily` liste désormais les `*_com`.

## Portée

- **Aucun changement de données** : les vues lisent les feuilles existantes, pas de migration.
- Prod `location` déjà débloquée côté infra ce matin (backfill par chemin) ; ce correctif **prévient la récidive** pour la prochaine famille neuve.
- PR **data-only** (`datalake/`) : ne déclenche pas de release applicative, comportement attendu.

## CGU

**Verdict : PASS** (check bloquant). Le diff n'ajoute qu'un tag d'orchestration dbt ; aucun statut `carpool_v2`, durée de conservation ou colonne PII touchés.

## Sécurité

**Verdict : PASS.** Ajout du littéral `'daily'` dans des listes `tags` de config dbt uniquement. Aucune requête SQL modifiée, aucune surface d'injection, aucun secret, aucune dépendance.
