### PR TITLE
ci: suffixe le tag des images datées du SHA court du commit

### DIFF
--- a/.github/workflows/deploy-cms.yml
+++ b/.github/workflows/deploy-cms.yml
@@ -27,7 +27,10 @@ jobs:
     steps:
       - id: set_tag
         shell: bash
-        run: echo "value=$(date +'%F.%H%M')" >> $GITHUB_OUTPUT
+        # Tag = horodatage (ordre lisible) + SHA court (traçabilité build -> commit).
+        # GITHUB_SHA est une variable d'environnement intégrée (40 hex), non
+        # interpolée depuis le contexte : pas de surface d'injection.
+        run: echo "value=$(date +'%F.%H%M')-${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
 
   build:
     name: Build and Push CMS Docker Image

--- a/.github/workflows/deploy-data.yml
+++ b/.github/workflows/deploy-data.yml
@@ -28,7 +28,10 @@ jobs:
     steps:
       - id: set_tag
         shell: bash
-        run: echo "value=$(date +'%F.%H%M')" >> $GITHUB_OUTPUT
+        # Tag = horodatage (ordre lisible) + SHA court (traçabilité build -> commit).
+        # GITHUB_SHA est une variable d'environnement intégrée (40 hex), non
+        # interpolée depuis le contexte : pas de surface d'injection.
+        run: echo "value=$(date +'%F.%H%M')-${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
   build:
     name: Build and Push DATA Docker Image
     needs: tag

--- a/.github/workflows/deploy-datalake.yml
+++ b/.github/workflows/deploy-datalake.yml
@@ -30,7 +30,10 @@ jobs:
     steps:
       - id: set_tag
         shell: bash
-        run: echo "value=$(date +'%F.%H%M')" >> $GITHUB_OUTPUT
+        # Tag = horodatage (ordre lisible) + SHA court (traçabilité build -> commit).
+        # GITHUB_SHA est une variable d'environnement intégrée (40 hex), non
+        # interpolée depuis le contexte : pas de surface d'injection.
+        run: echo "value=$(date +'%F.%H%M')-${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
 
   build:
     name: Build and Push Datalake Docker Image

--- a/.github/workflows/deploy-dbt.yml
+++ b/.github/workflows/deploy-dbt.yml
@@ -27,7 +27,10 @@ jobs:
     steps:
       - id: set_tag
         shell: bash
-        run: echo "value=$(date +'%F.%H%M')" >> $GITHUB_OUTPUT
+        # Tag = horodatage (ordre lisible) + SHA court (traçabilité build -> commit).
+        # GITHUB_SHA est une variable d'environnement intégrée (40 hex), non
+        # interpolée depuis le contexte : pas de surface d'injection.
+        run: echo "value=$(date +'%F.%H%M')-${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
 
   build:
     name: Build and Push DBT Docker Image

--- a/.github/workflows/deploy-sqlmesh.yml
+++ b/.github/workflows/deploy-sqlmesh.yml
@@ -27,7 +27,10 @@ jobs:
     steps:
       - id: set_tag
         shell: bash
-        run: echo "value=$(date +'%F.%H%M')" >> $GITHUB_OUTPUT
+        # Tag = horodatage (ordre lisible) + SHA court (traçabilité build -> commit).
+        # GITHUB_SHA est une variable d'environnement intégrée (40 hex), non
+        # interpolée depuis le contexte : pas de surface d'injection.
+        run: echo "value=$(date +'%F.%H%M')-${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
 
   build:
     name: Build and Push SQLMesh Docker Image


### PR DESCRIPTION
## Contexte

L'image `datalake-api` est buildée avec un tag daté suffixé du SHA court du commit
(`%F.%H%M-<sha7>`). Les autres images à tag daté n'avaient que l'horodatage à la minute :
pas de traçabilité vers le commit, et collision de tag possible entre deux builds de la
même minute.

## Changements

Généralisation du schéma de tag de `datalake-api` aux autres images à tag daté :

| Workflow | Image | Tag avant | Tag après |
| --- | --- | --- | --- |
| `deploy-datalake.yml` | `datalake` | `%F.%H%M` | `%F.%H%M-<sha7>` |
| `deploy-cms.yml` | `cms` | `%F.%H%M` | `%F.%H%M-<sha7>` |
| `deploy-data.yml` | `data` | `%F.%H%M` | `%F.%H%M-<sha7>` |
| `deploy-dbt.yml` | `dbt` | `%F.%H%M` | `%F.%H%M-<sha7>` |
| `deploy-sqlmesh.yml` | `sqlmesh` | `%F.%H%M` | `%F.%H%M-<sha7>` |

Le commentaire d'origine (traçabilité build → commit + note d'absence de surface
d'injection) est repris à l'identique dans chaque workflow. Le `>> "$GITHUB_OUTPUT"`
est désormais entre guillemets.

## Hors-scope

- `deploy-api.yml` (`api`) : schéma différent, tag = nom du tag de release ou SHA
  complet, déjà traçable — non concerné.
- `attestation` / `observatory` / `partner` / `techdoc` : pas d'image Docker (déploiement
  d'un build statique ou OpenAPI vers un bucket).

## Sécurité

Verdict **PASS**. `GITHUB_SHA` est une variable d'environnement intégrée (40 hex), lue par
expansion shell et non par interpolation de contexte `${{ }}` : aucune surface d'injection
de commande. La mise entre guillemets de `$GITHUB_OUTPUT` corrige au passage un
word-splitting potentiel de l'ancienne version.

## CGU

Verdict **PASS**. Diff purement CI : aucun code applicatif, SQL, donnée personnelle ou
financière. Aucune règle CGU concernée.
