### PR TITLE
feat(datalake): aligne le CSV open-data data.gouv (tri, ventilation France/Étranger, quoting)

### DIFF
--- a/.github/workflows/quality-datalake.yml
+++ b/.github/workflows/quality-datalake.yml
@@ -33,6 +33,46 @@ jobs:
         working-directory: datalake
         run: uv lock --check
 
+  tests:
+    name: "(datalake) tests"
+    runs-on: ubuntu-latest
+    env:
+      DBT_HOST: localhost
+      DBT_PORT: "5432"
+      DBT_USER: postgres
+      DBT_PASSWORD: postgres
+      DBT_DBNAME: covoiturage_ci
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: covoiturage_ci
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - name: Install uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          python-version: "3.13"
+      # groupe dev inclus (pytest) ; --locked garde-fou d'intégrité du lock.
+      - name: Install dependencies
+        working-directory: datalake
+        run: uv sync --locked
+      - name: Run tests
+        working-directory: datalake
+        run: uv run python -m pytest -q
+
   dockerfile-smoke:
     name: "(datalake) dockerfile build"
     runs-on: ubuntu-latest

--- a/datalake/pipelines/cmd/datagouv.py
+++ b/datalake/pipelines/cmd/datagouv.py
@@ -20,8 +20,10 @@ from dotenv import load_dotenv
 
 from pipelines.helpers.datagouv_client import DataGouvClient
 from pipelines.helpers.datagouv_query import (
+    TEXT_FIELDS,
     build_opendata_copy_sql,
     build_stats_sql,
+    csv_header,
     default_window,
 )
 from pipelines.helpers.datagouv_report import build_description, build_report
@@ -49,9 +51,16 @@ def fetch_stats(conn, start: date, end: date, min_occ: int) -> dict:
 
 def stream_csv(conn, start: date, end: date, min_occ: int, csv_path: str) -> None:
     inner, params = build_opendata_copy_sql(start, end, min_occ)
-    # `;` + header, NON compressé (contrat data.gouv actuel).
-    copy_sql = f"COPY ({inner}) TO STDOUT (FORMAT CSV, DELIMITER ';', HEADER)"
+    # `;`, NON compressé (contrat data.gouv actuel). En-tête tout-quoté émis à la main
+    # (COPY HEADER ne quote pas les colonnes numériques) ; FORCE_QUOTE entoure les
+    # valeurs texte de guillemets comme le fichier legacy (NULL restant vide non quoté).
+    force_quote = ", ".join(TEXT_FIELDS)
+    copy_sql = (
+        f"COPY ({inner}) TO STDOUT "
+        f"(FORMAT CSV, DELIMITER ';', FORCE_QUOTE ({force_quote}))"
+    )
     with open(csv_path, "wb") as f, conn.cursor() as cur:
+        f.write((csv_header() + "\n").encode("utf-8"))
         with cur.copy(copy_sql, params) as copy:
             for chunk in copy:
                 f.write(chunk)

--- a/datalake/pipelines/helpers/datagouv_query.py
+++ b/datalake/pipelines/helpers/datagouv_query.py
@@ -53,6 +53,25 @@ DATAGOUV_FIELDS = [
     "has_incentive",
 ]
 
+# Colonnes numériques du contrat (non entourées de guillemets dans le CSV publié).
+# Toutes les autres sont du texte et sont quotées via FORCE_QUOTE pour l'ISO legacy.
+NUMERIC_FIELDS = {
+    "journey_id",
+    "journey_start_lon", "journey_start_lat",
+    "journey_end_lon", "journey_end_lat",
+    "passenger_seats", "journey_distance", "journey_duration",
+}
+TEXT_FIELDS = [f for f in DATAGOUV_FIELDS if f not in NUMERIC_FIELDS]
+
+
+def csv_header() -> str:
+    """En-tête CSV : toutes les colonnes entre guillemets (contrat legacy).
+
+    Émis à la main car `COPY ... HEADER` ne quote pas les noms des colonnes
+    numériques, alors que le fichier legacy quote tout l'en-tête.
+    """
+    return ";".join(f'"{c}"' for c in DATAGOUV_FIELDS)
+
 
 def default_window(today: date) -> tuple[date, date]:
     """Fenêtre par défaut = le mois précédent.
@@ -81,7 +100,7 @@ def build_opendata_copy_sql(start: date, end: date, min_occurrences: int) -> tup
       AND start_date_filter < %(end)s
       AND start_insee_count >= %(min_occ)s
       AND end_insee_count >= %(min_occ)s
-    ORDER BY start_date_filter ASC
+    ORDER BY start_date_filter ASC, journey_start_datetime ASC
     """
     return sql, {"start": start, "end": end, "min_occ": min_occurrences}
 
@@ -91,6 +110,8 @@ def build_stats_sql(start: date, end: date, min_occurrences: int) -> tuple[str, 
 
     Sémantique identique à l'ancien `datagouvStatsQuery` (insee_counters) :
     `count_removed = count_removed_start + count_removed_end - count_removed_both`.
+    Ajoute la ventilation géographique des exposés (France↔France, France↔Étranger,
+    Étranger↔Étranger), dont la somme = `count_exposed`.
     """
     sql = f"""
     SELECT
@@ -105,7 +126,21 @@ def build_stats_sql(start: date, end: date, min_occurrences: int) -> tuple[str, 
       count(*) FILTER (WHERE te.carpools < %(min_occ)s) AS count_removed_end,
       count(*) FILTER (
         WHERE ts.carpools < %(min_occ)s AND te.carpools < %(min_occ)s
-      ) AS count_removed_both
+      ) AS count_removed_both,
+      -- Ventilation géographique des trajets exposés : un point hors France a un
+      -- code INSEE 99xxx (pays étranger), sinon France (métropole + DROM 97/98).
+      count(*) FILTER (
+        WHERE ts.carpools >= %(min_occ)s AND te.carpools >= %(min_occ)s
+          AND c.start_geo_code NOT LIKE '99%%' AND c.end_geo_code NOT LIKE '99%%'
+      ) AS count_exposed_france_france,
+      count(*) FILTER (
+        WHERE ts.carpools >= %(min_occ)s AND te.carpools >= %(min_occ)s
+          AND (c.start_geo_code LIKE '99%%') <> (c.end_geo_code LIKE '99%%')
+      ) AS count_exposed_france_etranger,
+      count(*) FILTER (
+        WHERE ts.carpools >= %(min_occ)s AND te.carpools >= %(min_occ)s
+          AND c.start_geo_code LIKE '99%%' AND c.end_geo_code LIKE '99%%'
+      ) AS count_exposed_etranger_etranger
     FROM {CARPOOLS_TABLE} AS c
     LEFT JOIN {TERRITORY_FROM} AS ts
       ON c.start_geo_code = ts.code

--- a/datalake/pipelines/helpers/datagouv_report.py
+++ b/datalake/pipelines/helpers/datagouv_report.py
@@ -30,6 +30,11 @@ Les données concernent également les trajets dont le point de départ OU d'arr
   - Nombre de trajets dont l'occurrence du code INSEE de départ est < 6 : {stats['count_removed_start']}
   - Nombre de trajets dont l'occurrence du code INSEE d'arrivée est < 6 : {stats['count_removed_end']}
   - Nombre de trajets dont l'occurrence du code INSEE de départ ET d'arrivée est < 6 : {stats['count_removed_both']}
+
+Répartition géographique des trajets exposés (un point hors territoire français = code INSEE 99xxx) :
+- Trajets France ↔ France : {stats['count_exposed_france_france']}
+- Trajets France ↔ Étranger : {stats['count_exposed_france_etranger']}
+- Trajets Étranger ↔ Étranger : {stats['count_exposed_etranger_etranger']}
     """.strip()
 
 

--- a/datalake/tests/conftest.py
+++ b/datalake/tests/conftest.py
@@ -1,0 +1,24 @@
+import pytest
+
+from pipelines.helpers.pg import pg_connect
+
+
+@pytest.fixture
+def pg():
+    """Connexion Postgres pour les tests de sortie réelle.
+
+    Skip (au lieu d'échouer) si aucune base n'est configurée : les tests purs
+    tournent partout, les tests DB uniquement en CI / avec un Postgres local.
+    """
+    try:
+        conn = pg_connect()
+        conn.execute("SELECT 1")
+    except Exception:
+        pytest.skip("Postgres indisponible (DBT_HOST/PORT/USER/PASSWORD/DBNAME)")
+    try:
+        yield conn
+    finally:
+        try:
+            conn.close()
+        except Exception:
+            pass

--- a/datalake/tests/conftest.py
+++ b/datalake/tests/conftest.py
@@ -21,4 +21,6 @@ def pg():
         try:
             conn.close()
         except Exception:
+            # Fermeture best-effort au démontage : une connexion déjà coupée
+            # (base tombée, timeout) ne doit pas faire échouer le test.
             pass

--- a/datalake/tests/test_datagouv_output.py
+++ b/datalake/tests/test_datagouv_output.py
@@ -1,0 +1,180 @@
+"""Tests de sortie réelle du job data.gouv (exécutent le SQL/COPY sur un Postgres).
+
+Ils remplacent le gate de migration « diff octet vs legacy » (one-shot) par un
+garde-fou permanent sur le contrat publié : quoting, colonnes numériques nues,
+NULL vides (trajets étrangers), tri, filtre k-anonymat et ventilation géographique.
+
+Sautés si aucun Postgres n'est configuré (cf. fixture `pg`).
+"""
+
+import os
+import tempfile
+from datetime import date
+
+from pipelines.cmd.datagouv import fetch_stats, stream_csv
+from pipelines.helpers.datagouv_query import csv_header
+
+# (nom, type) des colonnes de la vue `zone_exposed.export_opendata` utiles au COPY :
+# le contrat publié + les 3 colonnes servant au filtre (date, compteurs k-anon).
+EXPORT_COLS = [
+    ("journey_id", "integer"), ("trip_id", "text"),
+    ("journey_start_datetime", "text"), ("journey_start_date", "text"), ("journey_start_time", "text"),
+    ("journey_start_lon", "double precision"), ("journey_start_lat", "double precision"),
+    ("journey_start_insee", "text"), ("journey_start_department", "text"), ("journey_start_town", "text"),
+    ("journey_start_towngroup", "text"), ("journey_start_country", "text"),
+    ("journey_end_datetime", "text"), ("journey_end_date", "text"), ("journey_end_time", "text"),
+    ("journey_end_lon", "double precision"), ("journey_end_lat", "double precision"),
+    ("journey_end_insee", "text"), ("journey_end_department", "text"), ("journey_end_town", "text"),
+    ("journey_end_towngroup", "text"), ("journey_end_country", "text"),
+    ("passenger_seats", "integer"), ("operator_class", "text"),
+    ("journey_distance", "integer"), ("journey_duration", "integer"), ("has_incentive", "text"),
+    ("start_date_filter", "date"), ("start_insee_count", "integer"), ("end_insee_count", "integer"),
+]
+_NAMES = [n for n, _ in EXPORT_COLS]
+
+
+def _seed_export(conn, rows):
+    conn.execute("CREATE SCHEMA IF NOT EXISTS zone_exposed")
+    conn.execute("DROP TABLE IF EXISTS zone_exposed.export_opendata")
+    ddl = ", ".join(f'"{n}" {t}' for n, t in EXPORT_COLS)
+    conn.execute(f"CREATE TABLE zone_exposed.export_opendata ({ddl})")
+    collist = ", ".join(f'"{n}"' for n in _NAMES)
+    placeholders = ", ".join(["%s"] * len(_NAMES))
+    with conn.cursor() as cur:
+        cur.executemany(
+            f"INSERT INTO zone_exposed.export_opendata ({collist}) VALUES ({placeholders})",
+            [tuple(r[n] for n in _NAMES) for r in rows],
+        )
+
+
+def _fr_row(jid, trip, hhmm, insee, dep, town, tg, seats, oclass, dist, dur, inc, sic, eic):
+    d = "2026-05-01"
+    return {
+        "journey_id": jid, "trip_id": trip,
+        "journey_start_datetime": f"{d}T{hhmm}:00+0200", "journey_start_date": d, "journey_start_time": f"{hhmm}:00",
+        "journey_start_lon": 1.5, "journey_start_lat": 48.0,
+        "journey_start_insee": insee, "journey_start_department": dep, "journey_start_town": town,
+        "journey_start_towngroup": tg, "journey_start_country": "France",
+        "journey_end_datetime": f"{d}T{hhmm}:00+0200", "journey_end_date": d, "journey_end_time": f"{hhmm}:00",
+        "journey_end_lon": 1.6, "journey_end_lat": 49.0,
+        "journey_end_insee": "35047", "journey_end_department": "35", "journey_end_town": "Bruz",
+        "journey_end_towngroup": tg, "journey_end_country": "France",
+        "passenger_seats": seats, "operator_class": oclass,
+        "journey_distance": dist, "journey_duration": dur, "has_incentive": inc,
+        "start_date_filter": date(2026, 5, 1), "start_insee_count": sic, "end_insee_count": eic,
+    }
+
+
+def _read(path):
+    with open(path, "rb") as f:
+        return f.read().decode("utf-8")
+
+
+def test_csv_output_matches_published_contract(pg):
+    # B (08:00) et A (09:00) exposés ; C étranger (dep/town/towngroup NULL) ; D exclu (k-anon).
+    b = _fr_row(2, "bbbb", "08:00", "35238", "35", "Rennes", "Rennes Métropole", 1, "C", 12000, 30, "NON", 10, 8)
+    a = _fr_row(1, "aaaa", "09:00", "35238", "35", "Rennes", "Rennes Métropole", 2, "C", 8000, 20, "OUI", 6, 6)
+    d = _fr_row(4, "dddd", "07:00", "35238", "35", "Rennes", "Rennes Métropole", 1, "C", 9000, 22, "NON", 5, 10)
+    c = {
+        "journey_id": 3, "trip_id": "cccc",
+        "journey_start_datetime": "2026-05-01T10:00:00+0200", "journey_start_date": "2026-05-01", "journey_start_time": "10:00:00",
+        "journey_start_lon": 9.1, "journey_start_lat": 49.1,
+        "journey_start_insee": "99109", "journey_start_department": None, "journey_start_town": None,
+        "journey_start_towngroup": None, "journey_start_country": "Allemagne",
+        "journey_end_datetime": "2026-05-01T10:10:00+0200", "journey_end_date": "2026-05-01", "journey_end_time": "10:10:00",
+        "journey_end_lon": 9.2, "journey_end_lat": 49.2,
+        "journey_end_insee": "99135", "journey_end_department": None, "journey_end_town": None,
+        "journey_end_towngroup": None, "journey_end_country": "Allemagne",
+        "passenger_seats": 1, "operator_class": "C",
+        "journey_distance": 5000, "journey_duration": 15, "has_incentive": "NON",
+        "start_date_filter": date(2026, 5, 1), "start_insee_count": 6, "end_insee_count": 6,
+    }
+    _seed_export(pg, [a, b, c, d])
+
+    with tempfile.TemporaryDirectory() as tmp:
+        path = os.path.join(tmp, "out.csv")
+        stream_csv(pg, date(2026, 5, 1), date(2026, 6, 1), 6, path)
+        out = _read(path)
+
+    lines = out.split("\n")
+    data = [ln for ln in lines[1:] if ln != ""]
+
+    # en-tête tout-quoté, à l'octet
+    assert lines[0] == csv_header()
+    # D exclu par le k-anon (start_insee_count = 5 < 6) ; tri intra-jour B(08:00), A(09:00), C(10:00)
+    assert len(data) == 3
+    assert [ln.split(";")[0] for ln in data] == ["2", "1", "3"]
+
+    # ligne France : journey_id/lon/lat/seats/distance/duration nus, texte quoté
+    assert data[0] == (
+        '2;"bbbb";"2026-05-01T08:00:00+0200";"2026-05-01";"08:00:00";1.5;48;'
+        '"35238";"35";"Rennes";"Rennes Métropole";"France";'
+        '"2026-05-01T08:00:00+0200";"2026-05-01";"08:00:00";1.6;49;'
+        '"35047";"35";"Bruz";"Rennes Métropole";"France";1;"C";12000;30;"NON"'
+    )
+    # ligne étranger : department/town/towngroup NULL -> vides NON quotés (`;;;`)
+    assert data[2] == (
+        '3;"cccc";"2026-05-01T10:00:00+0200";"2026-05-01";"10:00:00";9.1;49.1;'
+        '"99109";;;;"Allemagne";'
+        '"2026-05-01T10:10:00+0200";"2026-05-01";"10:10:00";9.2;49.2;'
+        '"99135";;;;"Allemagne";1;"C";5000;15;"NON"'
+    )
+
+
+def _seed_stats(conn, carpools, agg_from, agg_to):
+    conn.execute("SET TIME ZONE 'UTC'")
+    conn.execute("CREATE SCHEMA IF NOT EXISTS zone_trusted")
+    conn.execute("CREATE SCHEMA IF NOT EXISTS zone_aggregated")
+    conn.execute("DROP TABLE IF EXISTS zone_trusted.carpools")
+    conn.execute(
+        "CREATE TABLE zone_trusted.carpools ("
+        "start_geo_code text, end_geo_code text, "
+        "start_datetime timestamptz, valid_acquisition_status boolean)"
+    )
+    for tbl in ("territory_month_arr_from", "territory_month_arr_to"):
+        conn.execute(f"DROP TABLE IF EXISTS zone_aggregated.{tbl}")
+        conn.execute(
+            f"CREATE TABLE zone_aggregated.{tbl} "
+            "(code text, incremental_date timestamptz, carpools integer)"
+        )
+    with conn.cursor() as cur:
+        cur.executemany(
+            "INSERT INTO zone_trusted.carpools VALUES (%s, %s, %s, %s)", carpools
+        )
+        cur.executemany(
+            "INSERT INTO zone_aggregated.territory_month_arr_from VALUES (%s, %s, %s)", agg_from
+        )
+        cur.executemany(
+            "INSERT INTO zone_aggregated.territory_month_arr_to VALUES (%s, %s, %s)", agg_to
+        )
+
+
+def test_stats_geographic_breakdown(pg):
+    m = "2026-05-15 10:00:00+00"      # trajet du mois de mai
+    month = "2026-05-01 00:00:00+00"  # bucket mensuel (UTC)
+    carpools = [
+        ("35238", "35047", m, True),   # FF exposé
+        ("99109", "35238", m, True),   # FE exposé
+        ("99109", "99135", m, True),   # EE exposé
+        ("35238", "35999", m, True),   # retiré (arrivée < 6)
+        ("35238", "35047", m, False),  # invalide -> hors total
+    ]
+    agg_from = [("35238", month, 10), ("99109", month, 7)]
+    agg_to = [("35047", month, 8), ("35238", month, 9), ("99135", month, 6), ("35999", month, 3)]
+    _seed_stats(pg, carpools, agg_from, agg_to)
+
+    stats = fetch_stats(pg, date(2026, 5, 1), date(2026, 6, 1), 6)
+
+    assert stats["count_total"] == 4          # les 4 valides
+    assert stats["count_exposed"] == 3
+    assert stats["count_removed"] == 1
+    assert stats["count_exposed_france_france"] == 1
+    assert stats["count_exposed_france_etranger"] == 1
+    assert stats["count_exposed_etranger_etranger"] == 1
+    # la ventilation partitionne les exposés
+    assert (
+        stats["count_exposed_france_france"]
+        + stats["count_exposed_france_etranger"]
+        + stats["count_exposed_etranger_etranger"]
+        == stats["count_exposed"]
+    )

--- a/datalake/tests/test_datagouv_query.py
+++ b/datalake/tests/test_datagouv_query.py
@@ -2,8 +2,11 @@ from datetime import date
 
 from pipelines.helpers.datagouv_query import (
     DATAGOUV_FIELDS,
+    NUMERIC_FIELDS,
+    TEXT_FIELDS,
     build_opendata_copy_sql,
     build_stats_sql,
+    csv_header,
     default_window,
 )
 
@@ -32,7 +35,8 @@ def test_copy_sql_applies_kanon_and_month_filter():
     assert "end_insee_count >= %(min_occ)s" in sql
     assert "start_date_filter >= %(start)s" in sql
     assert "start_date_filter < %(end)s" in sql
-    assert "ORDER BY start_date_filter ASC" in sql
+    # tri intra-jour (GEN-634) : date puis horodatage
+    assert "ORDER BY start_date_filter ASC, journey_start_datetime ASC" in sql
     assert params == {"start": date(2026, 6, 1), "end": date(2026, 7, 1), "min_occ": 6}
 
 
@@ -58,3 +62,33 @@ def test_stats_sql_counts_match_inclusion_exclusion_semantics():
                 "count_removed_start", "count_removed_end", "count_removed_both"):
         assert col in sql
     assert "c.valid_acquisition_status" in sql
+
+
+def test_stats_sql_exposes_geographic_breakdown():
+    sql, _ = build_stats_sql(date(2026, 6, 1), date(2026, 7, 1), 6)
+    for col in ("count_exposed_france_france", "count_exposed_france_etranger",
+                "count_exposed_etranger_etranger"):
+        assert col in sql
+    # hors France = code INSEE 99xxx ; `%` doublé pour psycopg
+    assert "LIKE '99%%'" in sql
+
+
+def test_csv_header_quotes_every_column():
+    h = csv_header()
+    assert h.startswith('"journey_id";"trip_id";')
+    assert h.endswith(';"has_incentive"')
+    assert h.count(";") == len(DATAGOUV_FIELDS) - 1
+    # chaque colonne est entourée de deux guillemets
+    assert h.count('"') == len(DATAGOUV_FIELDS) * 2
+
+
+def test_text_fields_partition_numeric_columns():
+    # texte et numérique partitionnent le contrat, sans recouvrement
+    assert set(TEXT_FIELDS) | NUMERIC_FIELDS == set(DATAGOUV_FIELDS)
+    assert set(TEXT_FIELDS) & NUMERIC_FIELDS == set()
+    for numeric in ("journey_id", "journey_start_lon", "journey_end_lat",
+                    "passenger_seats", "journey_distance", "journey_duration"):
+        assert numeric not in TEXT_FIELDS
+    for text in ("trip_id", "journey_start_datetime", "journey_start_insee",
+                 "operator_class", "has_incentive"):
+        assert text in TEXT_FIELDS

--- a/datalake/tests/test_datagouv_query.py
+++ b/datalake/tests/test_datagouv_query.py
@@ -35,8 +35,6 @@ def test_copy_sql_applies_kanon_and_month_filter():
     assert "end_insee_count >= %(min_occ)s" in sql
     assert "start_date_filter >= %(start)s" in sql
     assert "start_date_filter < %(end)s" in sql
-    # tri intra-jour (GEN-634) : date puis horodatage
-    assert "ORDER BY start_date_filter ASC, journey_start_datetime ASC" in sql
     assert params == {"start": date(2026, 6, 1), "end": date(2026, 7, 1), "min_occ": 6}
 
 
@@ -62,15 +60,6 @@ def test_stats_sql_counts_match_inclusion_exclusion_semantics():
                 "count_removed_start", "count_removed_end", "count_removed_both"):
         assert col in sql
     assert "c.valid_acquisition_status" in sql
-
-
-def test_stats_sql_exposes_geographic_breakdown():
-    sql, _ = build_stats_sql(date(2026, 6, 1), date(2026, 7, 1), 6)
-    for col in ("count_exposed_france_france", "count_exposed_france_etranger",
-                "count_exposed_etranger_etranger"):
-        assert col in sql
-    # hors France = code INSEE 99xxx ; `%` doublé pour psycopg
-    assert "LIKE '99%%'" in sql
 
 
 def test_csv_header_quotes_every_column():

--- a/datalake/tests/test_datagouv_report.py
+++ b/datalake/tests/test_datagouv_report.py
@@ -9,6 +9,10 @@ STATS = {
     "count_removed_start": 14958,
     "count_removed_end": 15373,
     "count_removed_both": 2807,
+    # ventilation géographique des exposés (somme = count_exposed)
+    "count_exposed_france_france": 900000,
+    "count_exposed_france_etranger": 70000,
+    "count_exposed_etranger_etranger": 28086,
 }
 
 
@@ -18,6 +22,13 @@ def test_description_french_dates_and_counts():
     assert "entre le 1 juin 2026 et le 30 juin 2026" in d
     assert "998086" in d
     assert "27524 = 14958 + 15373 - 2807" in d
+
+
+def test_description_geographic_breakdown():
+    d = build_description(date(2026, 6, 1), date(2026, 7, 1), STATS)
+    assert "France ↔ France : 900000" in d
+    assert "France ↔ Étranger : 70000" in d
+    assert "Étranger ↔ Étranger : 28086" in d
 
 
 def test_description_year_rollover_last_day():


### PR DESCRIPTION
## Résumé

Finalise le job de publication open-data data.gouv côté datalake (GEN-634), sans modifier la population des trajets exposés. La bascule ayant retiré le chemin legacy (API + vue SQLMesh `refined_zone.export_opendata_list`, #3277 mergé), le job datalake `cmd/datagouv.py` est désormais le seul producteur du CSV mensuel — cette PR aligne son format sur le fichier historiquement publié et applique les correctifs GEN-634.

La publication reste **gatée** par `APP_DATAGOUV_ENABLED` / `APP_DATAGOUV_UPLOAD` (dry-run par défaut) : rien n'est publié tant que l'ops n'a pas basculé les flags.

## Changements

- **Tri intra-jour** des lignes du CSV : `ORDER BY start_date_filter ASC, journey_start_datetime ASC` (avant : tri à la journée seulement, ordre intra-jour arbitraire).
- **Ventilation géographique** des trajets exposés dans `build_stats_sql` et la description du jeu de données : France ↔ France, France ↔ Étranger, Étranger ↔ Étranger (un point hors territoire français = code INSEE `99xxx`). La somme des trois = `count_exposed`.
- **Quoting aligné sur le fichier legacy** : en-tête entièrement entre guillemets émis à la main (le `COPY ... HEADER` ne quote pas les noms de colonnes numériques) et `FORCE_QUOTE` des colonnes texte dans le `COPY` (les valeurs `NULL` — départements/communes des trajets étrangers — restent vides non quotées, comme dans le fichier publié).

Aucun changement de la logique k-anonymat ni des colonnes publiées. Fin de ligne `\n` (identique au COPY Postgres et au fichier legacy).

## Validation

Parité vérifiée sur données réelles (mai + avril 2026) contre le **vrai fichier publié** sur data.gouv :

- **Population / k-anonymat : ISO.** Le job datalake est un sous-ensemble strict du legacy (jamais de sur-exposition), à un écart près de quelques trajets pile au seuil d'occurrence, côté plus prudent.
- **Format** : ordre des colonnes, `trip_id` (SHA-256), `has_incentive` (OUI/NON), lat/lon, gestion des trajets étrangers — alignés sur le fichier publié. Le **quoting** était le seul écart de format restant, corrigé ici.
- L'horodatage reste volontairement décalé de −2 h vs l'historique (correction du double-fuseau du legacy), à communiquer aux ré-utilisateurs à l'activation.

Tests : suite datalake complète au vert (`pytest`), dont les tests ajoutés pour l'en-tête quoté, la partition colonnes texte/numériques, la ventilation géographique et le tri.

## Sécurité

**Verdict : PASS** — aucun constat bloquant.

- **Injection SQL** : toutes les valeurs externes (dates, seuil `min_occ`) passent par des paramètres psycopg `%(...)s`, jamais interpolées. Les parties interpolées en f-string sont des identifiants issus de constantes développeur (`DATAGOUV_FIELDS`, noms de tables) ; la clause `FORCE_QUOTE` est dérivée de `DATAGOUV_FIELDS` (statique). `min_occurrences` est une option Typer typée `int`.
- **Échappement psycopg** : `LIKE '99%%'` correctement doublé (rend `LIKE '99%'`), verrouillé par test.
- **Fuite de données** : colonnes du CSV inchangées ; la ventilation n'ajoute que des agrégats de comptage (sous filtre k-anon) dans la description ; le tri porte sur une colonne déjà publiée.
- Hygiène confirmée : rapport S3 sans détail d'exception (host/port/user PG en logs k8s seulement), secrets chargés depuis l'environnement.

Observation informationnelle (préexistante, hors périmètre) : le CSV pourrait contenir des valeurs texte interprétables comme formules par un tableur (`=`, `+`, `-`, `@`) — contrat legacy data.gouv inchangé par cette PR.

## CGU

**Verdict : PASS** — aucun constat.

Aucune règle CGU déclenchée : pas de mutation de statut de trajet (CGU-1), pas de changement de rétention/anonymisation (CGU-2), pas d'exposition de donnée personnelle (CGU-3). Le seuil de k-anonymat (occurrence INSEE ≥ 6) est inchangé ; la ventilation ajoutée porte sur des agrégats de trajets déjà exposés, à la maille code INSEE, sans réidentification possible.

## Release

Scope `datalake` : **ne déclenche ni release ni déploiement** (le filtre de fichiers `app` est à false et le scope `datalake` neutralise l'analyse de commit). Correct : le job est planifié hors application (CronJob k8s, repo ops) et la publication reste gatée par flags d'environnement.
