### PR TITLE
fix(ci): borne l'attente du stack e2e (échec rapide au lieu de hang)

### DIFF
--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -53,6 +53,9 @@ services:
       DOMAIN: ${WAIT_DOMAIN:-api}
       PORT: ${WAIT_PORT:-8080}
     working_dir: /app/api
-    command: ['/bin/sh', '-c', 'until nc -zv $$DOMAIN $$PORT -w1; do echo " Waiting for $$DOMAIN..."; sleep 1; done']
+    # Attente bornée (~60 essais ≈ 2 min) : sur panne (service qui ne monte pas,
+    # DNS cassé...) on échoue vite avec un message clair au lieu de boucler à
+    # l'infini et bloquer « Build stack » jusqu'à annulation du job.
+    command: ['/bin/sh', '-c', 'i=0; until nc -zv $$DOMAIN $$PORT -w1; do i=$$((i+1)); [ "$$i" -ge 60 ] && { echo "timeout: $$DOMAIN:$$PORT injoignable après $$i essais"; exit 1; }; echo " Waiting for $$DOMAIN..."; sleep 1; done']
     networks:
       - back


### PR DESCRIPTION
## Problème

Le service `wait` du stack e2e (`docker-compose.e2e.yml`) boucle
`until nc -zv $DOMAIN $PORT; sleep 1; done` **sans limite ni timeout**. Sur
n'importe quelle panne (un service qui ne démarre pas, un DNS cassé, l'API qui
crashe au boot), l'étape « Build stack » reste coincée **jusqu'à l'annulation
manuelle du job** (~1 h observé), au lieu d'échouer vite. Le job GHA n'a pas non
plus de `timeout-minutes` (défaut 6 h).

## Correctif

Attente **bornée** : plafond ~60 essais (~2 min), puis `exit 1` avec un message
clair (`timeout: <host>:<port> injoignable après N essais`). Un problème de stack
échoue désormais en ~2 min de façon diagnostiquable, au lieu de hang.

Testé en busybox `sh` : sur port fermé, la boucle sort bien en `exit 1` après N
essais (pas de hang) ; la config compose parse.

## Portée

Ne touche que `docker-compose.e2e.yml` → pas de code app, pas de release/déploiement.
Complète le fix busybox (#3310) : celui-ci corrigeait la cause d'un hang connu,
celui-ci empêche *tout* hang futur du même type de rester invisible pendant 1 h.
