### PR TITLE
fix(observatory): corrige le crash de la carte des aires de covoiturage

### DIFF
--- a/app-observatory/src/app/observatoire/territoire/Dashboard.tsx
+++ b/app-observatory/src/app/observatoire/territoire/Dashboard.tsx
@@ -137,10 +137,10 @@ export default function Dashboard() {
           </div>
           <div className={fr.cx('fr-grid-row', 'fr-grid-row--gutters')}>
             <div className={fr.cx('fr-col-12')}>
-              {dashboard.params.map == 1 && <FluxMap title={mapList[0].name} />}
-              {dashboard.params.map == 2 && <DensiteMap title={mapList[1].name} />}
-              {dashboard.params.map == 3 && <OccupationMap title={mapList[2].name} />}
-              {dashboard.params.map == 4 && <AiresCovoiturageMap title={mapList[3].name} />}
+              {dashboard.params.map == 1 && <FluxMap title={mapList.find((m) => m.id === 1)?.name ?? ''} />}
+              {dashboard.params.map == 2 && <DensiteMap title={mapList.find((m) => m.id === 2)?.name ?? ''} />}
+              {dashboard.params.map == 3 && <OccupationMap title={mapList.find((m) => m.id === 3)?.name ?? ''} />}
+              {dashboard.params.map == 4 && <AiresCovoiturageMap title={mapList.find((m) => m.id === 4)?.name ?? ''} />}
             </div>
           </div>
         </>


### PR DESCRIPTION
## Contexte

Sur l'observatoire (`app-observatory`), sélectionner la carte **« Aires de covoiturage »** faisait planter toute la page (écran blanc), erreur `TypeError: Cannot read properties of undefined (reading 'name')`.

Réf. tâche : GEN-696 (priorité 🔥🔥 Run).

## Cause racine

`Dashboard.tsx` indexait `mapList` **par position** (`mapList[3].name`, `mapList[2].name`, …). Or les entrées « Densité de départs/arrivées » (`id: 2`) et « Voies réservées » (`id: 5`) sont commentées dans `helpers/lists.ts`, ce qui réduit le tableau à trois éléments (indices 0–2). Pour la carte 4, `mapList[3]` valait donc `undefined` → l'accès à `.name` levait l'exception, au **montage du composant, avant même tout appel réseau**.

Bug latent corrigé au passage : la carte 3 (taux d'occupation) affichait un titre erroné (`mapList[2]` = « Aires de covoiturage »).

## Changement

Recherche par `id` au lieu de la position :

```diff
-{dashboard.params.map == 4 && <AiresCovoiturageMap title={mapList[3].name} />}
+{dashboard.params.map == 4 && <AiresCovoiturageMap title={mapList.find((m) => m.id === 4)?.name ?? ''} />}
```

Les quatre lignes de sélection de carte sont alignées sur ce motif, robuste vis-à-vis de l'ordre et des entrées commentées.

## Vérification

- **Reproduction** (Playwright, site public) : la sélection de « Aires de covoiturage » lève bien `reading 'name'`.
- **Après correctif** (build local + Playwright, données mockées) : la carte se sélectionne sans crash.
- **Contre-épreuve** : correctif retiré → la stack exacte de prod se reproduit ; correctif remis → plus de crash.
- **Données sous-jacentes** (API prod `dlk.covoiturage.beta.gouv.fr/observatory/aires-covoiturage`) : tableau JSON de 2399 points pour la France, 100 % géométries `Point` valides, 0 nulle, `type` conformes aux libellés de filtre. Un territoire sans aire renvoie `[]` (callout « Pas de données », pas de crash).

## Sécurité

Verdict : **PASS** (risque LOW). Composant client, pas de nouvel appel réseau, pas d'entrée utilisateur, pas de secret. Le `title` provient de constantes internes (`mapList`) et transite par une prop React (échappement automatique). Aucun finding.

## CGU

Verdict : **PASS**. Correctif frontend pur ; aucune mutation de statut de trajet, aucun changement de rétention/PII, aucun élargissement d'export ou de statistique publique. Aucun finding.