### PR TITLE
fix(datalake): carto taux d'occupation — cercle au centroïde, pas le contour

### DIFF
--- a/datalake/models/exposed/observatory/occupation_month.sql
+++ b/datalake/models/exposed/observatory/occupation_month.sql
@@ -60,8 +60,9 @@ SELECT
   t.has_incentive,
   round(
     (t.carpools + t.passenger_seats)::numeric / nullif(t.carpools, 0), 2
-  )                             AS occupation_rate,
-  st_asgeojson(p.geom, 6)::json AS geom
+  )                                 AS occupation_rate,
+  -- centroïde (point) : la carte trace un cercle par zone, pas le contour
+  st_asgeojson(p.centroid, 6)::json AS geom
 FROM territory AS t
 LEFT JOIN {{ ref('perimeters_agg') }} AS p
   ON

--- a/datalake/models/exposed/observatory/occupation_quarter.sql
+++ b/datalake/models/exposed/observatory/occupation_quarter.sql
@@ -60,8 +60,9 @@ SELECT
   t.has_incentive,
   round(
     (t.carpools + t.passenger_seats)::numeric / nullif(t.carpools, 0), 2
-  )                             AS occupation_rate,
-  st_asgeojson(p.geom, 6)::json AS geom
+  )                                 AS occupation_rate,
+  -- centroïde (point) : la carte trace un cercle par zone, pas le contour
+  st_asgeojson(p.centroid, 6)::json AS geom
 FROM territory AS t
 LEFT JOIN {{ ref('perimeters_agg') }} AS p
   ON

--- a/datalake/models/exposed/observatory/occupation_semester.sql
+++ b/datalake/models/exposed/observatory/occupation_semester.sql
@@ -60,8 +60,9 @@ SELECT
   t.has_incentive,
   round(
     (t.carpools + t.passenger_seats)::numeric / nullif(t.carpools, 0), 2
-  )                             AS occupation_rate,
-  st_asgeojson(p.geom, 6)::json AS geom
+  )                                 AS occupation_rate,
+  -- centroïde (point) : la carte trace un cercle par zone, pas le contour
+  st_asgeojson(p.centroid, 6)::json AS geom
 FROM territory AS t
 LEFT JOIN {{ ref('perimeters_agg') }} AS p
   ON

--- a/datalake/models/exposed/observatory/occupation_year.sql
+++ b/datalake/models/exposed/observatory/occupation_year.sql
@@ -58,8 +58,9 @@ SELECT
   t.has_incentive,
   round(
     (t.carpools + t.passenger_seats)::numeric / nullif(t.carpools, 0), 2
-  )                             AS occupation_rate,
-  st_asgeojson(p.geom, 6)::json AS geom
+  )                                 AS occupation_rate,
+  -- centroïde (point) : la carte trace un cercle par zone, pas le contour
+  st_asgeojson(p.centroid, 6)::json AS geom
 FROM territory AS t
 LEFT JOIN {{ ref('perimeters_agg') }} AS p
   ON


### PR DESCRIPTION
## Contexte

[GEN-697] Les cartes des taux d'occupation de l'observatoire ont un rendu
anormal : au lieu d'un cercle unique par territoire, on voit une multitude de
cercles alignés le long du **contour** de chaque zone (EPCI, AOM, département,
région, communes).

## Cause racine

La carte est une carte à **cercles proportionnels** (rayon = nombre de
véhicules partagés, couleur = taux d'occupation), rendue par un `circle` layer
MapLibre. Or les modèles exposés `occupation_{month,quarter,semester,year}`
renvoyaient `p.geom`, c'est-à-dire le **MultiPolygon** (le contour) de la zone.
Un `circle` layer MapLibre dessine **un cercle par sommet** de la géométrie :
d'où l'anneau de cercles le long du contour.

## Correctif

On expose désormais `p.centroid` — le **point** déjà calculé dans
`perimeters_agg` via `ST_POINTONSURFACE` (garanti à l'intérieur du polygone) —
au lieu de `p.geom`. Un seul cercle par zone, positionné à son centroïde.

Aucun changement côté front nécessaire : `geom` est typé `Geometry` (un `Point`
est accepté), et le calcul des bornes (`bbox`) comme le téléchargement GeoJSON
fonctionnent sur des points.

## Validé sur données de production (MCP datalake)

| | avant | après |
| --- | --- | --- |
| type de géométrie | `MultiPolygon` | `Point` |
| taille par zone | 1 à 5,5 Ko | ~50 o |

Coordonnées cohérentes (points à l'intérieur des territoires). Bonus : charge
utile de la carte fortement réduite (on n'envoyait des polygones que pour
dessiner des pastilles).

## Fichiers modifiés

- `datalake/models/exposed/observatory/occupation_month.sql`
- `datalake/models/exposed/observatory/occupation_quarter.sql`
- `datalake/models/exposed/observatory/occupation_semester.sql`
- `datalake/models/exposed/observatory/occupation_year.sql`

## ⚠️ À prévoir au déploiement

Ces modèles sont incrémentaux (`delete+insert` sur fenêtre glissante). Les
lignes historiques conservent l'ancien `geom` polygonal. Un
**`dbt run --full-refresh`** sur ces 4 modèles est nécessaire pour corriger
toutes les périodes affichées (sélecteurs année / mois), pas seulement les plus
récentes.

## Hors-scope

- `AiresMap` utilise aussi un `circle` layer mais sur de vrais points (aires de
  covoiturage) — pas de bug.
- `IncentiveMap` rend des polygones via un `fill` layer — comportement correct.
