### PR TITLE
fix(datalake): comptage stats data.gouv exhaustif (total = exposés + retirés)

### DIFF
--- a/datalake/pipelines/helpers/datagouv_query.py
+++ b/datalake/pipelines/helpers/datagouv_query.py
@@ -112,44 +112,56 @@ def build_stats_sql(start: date, end: date, min_occurrences: int) -> tuple[str, 
     `count_removed = count_removed_start + count_removed_end - count_removed_both`.
     Ajoute la ventilation géographique des exposés (France↔France, France↔Étranger,
     Étranger↔Étranger), dont la somme = `count_exposed`.
+
+    Un geo_code absent de l'agrégat (jointure NULL) est ramené à 0 via `coalesce` :
+    exposé et retiré partitionnent alors exactement le total (pas de trou ternaire).
     """
     sql = f"""
+    WITH joined AS (
+      SELECT
+        c.start_geo_code,
+        c.end_geo_code,
+        -- occurrence INSEE absente de l'agrégat = 0 (trajet non vérifiable -> retiré)
+        coalesce(ts.carpools, 0) AS start_count,
+        coalesce(te.carpools, 0) AS end_count
+      FROM {CARPOOLS_TABLE} AS c
+      LEFT JOIN {TERRITORY_FROM} AS ts
+        ON c.start_geo_code = ts.code
+        AND date_trunc('month', c.start_datetime) = ts.incremental_date
+      LEFT JOIN {TERRITORY_TO} AS te
+        ON c.end_geo_code = te.code
+        AND date_trunc('month', c.start_datetime) = te.incremental_date
+      WHERE c.valid_acquisition_status
+        AND (c.start_datetime AT TIME ZONE 'Europe/Paris')::date >= %(start)s
+        AND (c.start_datetime AT TIME ZONE 'Europe/Paris')::date < %(end)s
+    )
     SELECT
       count(*) AS count_total,
       count(*) FILTER (
-        WHERE ts.carpools >= %(min_occ)s AND te.carpools >= %(min_occ)s
+        WHERE start_count >= %(min_occ)s AND end_count >= %(min_occ)s
       ) AS count_exposed,
       count(*) FILTER (
-        WHERE ts.carpools < %(min_occ)s OR te.carpools < %(min_occ)s
+        WHERE start_count < %(min_occ)s OR end_count < %(min_occ)s
       ) AS count_removed,
-      count(*) FILTER (WHERE ts.carpools < %(min_occ)s) AS count_removed_start,
-      count(*) FILTER (WHERE te.carpools < %(min_occ)s) AS count_removed_end,
+      count(*) FILTER (WHERE start_count < %(min_occ)s) AS count_removed_start,
+      count(*) FILTER (WHERE end_count < %(min_occ)s) AS count_removed_end,
       count(*) FILTER (
-        WHERE ts.carpools < %(min_occ)s AND te.carpools < %(min_occ)s
+        WHERE start_count < %(min_occ)s AND end_count < %(min_occ)s
       ) AS count_removed_both,
       -- Ventilation géographique des trajets exposés : un point hors France a un
       -- code INSEE 99xxx (pays étranger), sinon France (métropole + DROM 97/98).
       count(*) FILTER (
-        WHERE ts.carpools >= %(min_occ)s AND te.carpools >= %(min_occ)s
-          AND c.start_geo_code NOT LIKE '99%%' AND c.end_geo_code NOT LIKE '99%%'
+        WHERE start_count >= %(min_occ)s AND end_count >= %(min_occ)s
+          AND start_geo_code NOT LIKE '99%%' AND end_geo_code NOT LIKE '99%%'
       ) AS count_exposed_france_france,
       count(*) FILTER (
-        WHERE ts.carpools >= %(min_occ)s AND te.carpools >= %(min_occ)s
-          AND (c.start_geo_code LIKE '99%%') <> (c.end_geo_code LIKE '99%%')
+        WHERE start_count >= %(min_occ)s AND end_count >= %(min_occ)s
+          AND (start_geo_code LIKE '99%%') <> (end_geo_code LIKE '99%%')
       ) AS count_exposed_france_etranger,
       count(*) FILTER (
-        WHERE ts.carpools >= %(min_occ)s AND te.carpools >= %(min_occ)s
-          AND c.start_geo_code LIKE '99%%' AND c.end_geo_code LIKE '99%%'
+        WHERE start_count >= %(min_occ)s AND end_count >= %(min_occ)s
+          AND start_geo_code LIKE '99%%' AND end_geo_code LIKE '99%%'
       ) AS count_exposed_etranger_etranger
-    FROM {CARPOOLS_TABLE} AS c
-    LEFT JOIN {TERRITORY_FROM} AS ts
-      ON c.start_geo_code = ts.code
-      AND date_trunc('month', c.start_datetime) = ts.incremental_date
-    LEFT JOIN {TERRITORY_TO} AS te
-      ON c.end_geo_code = te.code
-      AND date_trunc('month', c.start_datetime) = te.incremental_date
-    WHERE c.valid_acquisition_status
-      AND (c.start_datetime AT TIME ZONE 'Europe/Paris')::date >= %(start)s
-      AND (c.start_datetime AT TIME ZONE 'Europe/Paris')::date < %(end)s
+    FROM joined
     """
     return sql, {"start": start, "end": end, "min_occ": min_occurrences}

--- a/datalake/tests/test_datagouv_output.py
+++ b/datalake/tests/test_datagouv_output.py
@@ -178,3 +178,26 @@ def test_stats_geographic_breakdown(pg):
         + stats["count_exposed_etranger_etranger"]
         == stats["count_exposed"]
     )
+
+
+def test_stats_counts_missing_aggregate_as_removed(pg):
+    # Un geo_code absent de l'agrégat territorial (jointure NULL) est non vérifiable
+    # -> retiré, jamais perdu : total = exposés + retirés doit rester vrai.
+    m = "2026-05-15 10:00:00+00"
+    month = "2026-05-01 00:00:00+00"
+    carpools = [
+        ("35238", "35047", m, True),   # exposé (les deux >= 6)
+        ("45308", "35047", m, True),   # départ absent de l'agrégat -> ts NULL
+    ]
+    agg_from = [("35238", month, 10)]  # 45308 volontairement absent
+    agg_to = [("35047", month, 8)]
+    _seed_stats(pg, carpools, agg_from, agg_to)
+
+    stats = fetch_stats(pg, date(2026, 5, 1), date(2026, 6, 1), 6)
+
+    assert stats["count_total"] == 2
+    assert stats["count_exposed"] == 1
+    assert stats["count_removed"] == 1
+    assert stats["count_removed_start"] == 1
+    assert stats["count_removed_end"] == 0
+    assert stats["count_total"] == stats["count_exposed"] + stats["count_removed"]


### PR DESCRIPTION
## Contexte

Sur l'export open-data data.gouv (GEN-634), la description publiée affichait un
`count_total` qui ne se reconciliait pas avec `exposés + retirés` (écart d'un
trajet observé sur un export de juillet).

## Cause

`build_stats_sql` recompte l'occurrence INSEE de chaque trajet via une jointure
`LEFT JOIN` sur les agrégats `territory_month_arr_{from,to}`. Quand un `geo_code`
est **absent** de l'agrégat, la jointure renvoie `NULL`. En logique SQL ternaire,
`NULL >= seuil` **et** `NULL < seuil` valent tous deux « inconnu » : le trajet
échappe alors **à la fois** au filtre des exposés et à celui des retirés. Il est
compté dans `count_total` mais nulle part ailleurs, cassant l'invariant
`total = exposés + retirés`.

## Correction

La requête passe par une CTE `joined` qui ramène l'occurrence manquante à `0`
via `coalesce(..., 0)`. Les deux filtres partitionnent alors exactement le total,
et le trajet non vérifiable (occurrence sous le seuil) est correctement compté
comme **retiré**, jamais perdu.

Le k-anonymat est préservé à l'identique : une occurrence manquante bascule sous
le seuil et devient retirée — la minimisation est renforcée, jamais affaiblie.
`count_exposed` reste inchangé (identique au nombre de lignes du CSV publié).

## Tests

- Nouveau test de non-régression sur fixture Postgres
  (`test_stats_counts_missing_aggregate_as_removed`) : un `geo_code` absent de
  l'agrégat est compté comme retiré et `total = exposés + retirés` tient.
- Suite datalake complète au vert (fixture Postgres CI).

## Périmètre / release

Data-only (`datalake/**`) : ne déclenche pas de release applicative (attendu).

## Sécurité

PASS — aucun finding. Les identifiants de table sont des constantes statiques ;
les valeurs dynamiques (`start`, `end`, `min_occurrences`) restent passées en
paramètres liés psycopg. Aucune donnée sensible dans le diff.

## CGU

PASS — aucun statut `carpool_v2` muté, aucune donnée personnelle touchée, le
mécanisme de k-anonymat est intégralement conservé.