### PR TITLE
feat(datalake): schéma app_metabase + droits datalake_mb_ro (GEN-575)

### DIFF
--- a/datalake/migrations/0004_app_metabase.sql
+++ b/datalake/migrations/0004_app_metabase.sql
@@ -1,0 +1,54 @@
+-- =============================================================================
+-- 0004_app_metabase — schéma cible Metabase + droits datalake_mb_ro (GEN-575)
+-- =============================================================================
+--
+-- Metabase est découplé de covoiturage_production : ses dashboards ne liront plus
+-- que des modèles dbt matérialisés dans le schéma `app_metabase`, via le rôle en
+-- lecture seule `datalake_mb_ro` (créé par l'infra, carte A — CONNECT + preset
+-- « readonly » Scaleway, mot de passe dans Secret Manager).
+--
+-- Cette migration est jouée par le rôle `datalake` (propriétaire des schémas dbt) :
+--   1. crée le schéma app_metabase (owner datalake) ;
+--   2. ouvre USAGE + un DEFAULT PRIVILEGE SELECT à datalake_mb_ro, posé AVANT que
+--      dbt matérialise quoi que ce soit → chaque table/vue créée ensuite par
+--      datalake hérite du SELECT, sans GRANT rétroactif ;
+--   3. retire l'accès large que le preset readonly a ouvert sur les zones dbt
+--      (datalake_mb_ro ne doit voir QUE app_metabase).
+--
+-- Idempotent : IF NOT EXISTS + GRANT/REVOKE rejouables. Le preset Scaleway est
+-- posé en `ignore_changes` côté OpenTofu : ces REVOKE ne seront pas réconciliés.
+--
+-- Périmètre : on ne touche QUE ce que le rôle datalake a granté lui-même (USAGE +
+-- SELECT table sur les zones). L'USAGE sur `public` a été granté par
+-- _rdb_superadmin sur un schéma qu'il possède : datalake ne peut pas le révoquer.
+-- Si l'on veut fermer `public` à Metabase, c'est à faire côté infra (OpenTofu).
+--
+-- Les grants sont gardés par un test d'existence du rôle : sur un environnement
+-- neuf/staging où l'infra n'a pas encore créé datalake_mb_ro, la migration crée le
+-- schéma et n'échoue pas (comme 0003 pour un serveur FDW absent).
+-- -----------------------------------------------------------------------------
+
+-- 1. Schéma cible (owner = datalake, le rôle qui joue cette migration et dbt)
+CREATE SCHEMA IF NOT EXISTS app_metabase AUTHORIZATION datalake;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'datalake_mb_ro') THEN
+    RAISE NOTICE 'role datalake_mb_ro absent — schéma créé, droits différés (infra carte A)';
+    RETURN;
+  END IF;
+
+  -- 2. Droits sur app_metabase — posés AVANT tout modèle dbt.
+  GRANT USAGE ON SCHEMA app_metabase TO datalake_mb_ro;
+  -- objets déjà présents (no-op sur un schéma vide, utile aux rejeux ultérieurs)
+  GRANT SELECT ON ALL TABLES IN SCHEMA app_metabase TO datalake_mb_ro;
+  -- objets FUTURS créés par datalake dans ce schéma → SELECT automatique
+  ALTER DEFAULT PRIVILEGES FOR ROLE datalake IN SCHEMA app_metabase
+    GRANT SELECT ON TABLES TO datalake_mb_ro;
+
+  -- 3. Fermeture des zones dbt (le preset readonly Scaleway est trop large).
+  REVOKE USAGE ON SCHEMA zone_raw, zone_trusted, zone_aggregated, zone_exposed, dlk_import
+    FROM datalake_mb_ro;
+  REVOKE ALL ON ALL TABLES IN SCHEMA zone_raw, zone_trusted, zone_aggregated, zone_exposed, dlk_import
+    FROM datalake_mb_ro;
+END $$;


### PR DESCRIPTION
## Contexte

GEN-575 (carte C) — Découpler Metabase de `covoiturage_production`. Les tableaux de
bord ne doivent plus lire que des modèles **dbt** exposés dans `datalake_production`,
via un rôle en lecture seule dédié et restreint (`datalake_mb_ro`, créé côté infra —
carte A).

Cette PR livre la première brique côté monorepo/dbt : la **migration** qui crée le
schéma cible et pose les droits. Le portage des modèles dans `app_metabase` (config
dbt `+schema`) et la cartographie des cartes suivront dans des PR séparées.

## Ce que fait la migration

`datalake/migrations/0004_app_metabase.sql`, jouée par le rôle `datalake` (propriétaire
des schémas dbt) au prochain `just migrate` :

1. **Crée le schéma** `app_metabase` (`CREATE SCHEMA IF NOT EXISTS ... AUTHORIZATION datalake`).
2. **Ouvre les droits** à `datalake_mb_ro` — `USAGE` + `SELECT` sur l'existant, et surtout
   `ALTER DEFAULT PRIVILEGES FOR ROLE datalake ... GRANT SELECT ON TABLES`. Posé **avant**
   que dbt matérialise quoi que ce soit → chaque table/vue future créée par `datalake`
   dans ce schéma hérite du `SELECT`, sans GRANT rétroactif.
3. **Referme les zones dbt** — `REVOKE USAGE` + `REVOKE ALL ON ALL TABLES` sur
   `zone_raw`, `zone_trusted`, `zone_aggregated`, `zone_exposed`, `dlk_import` (le preset
   readonly Scaleway ouvrait un accès trop large).

Le retrait de l'`USAGE` de schéma est le verrou effectif : sans lui, aucune table de ces
zones n'est atteignable, même en cas de `SELECT` résiduel.

## Choix de conception

- **Idempotente** (`IF NOT EXISTS`, GRANT/REVOKE rejouables), conforme au runner à ledger
  (`public.schema_migrations`), rejouée à chaque déploiement.
- **Gardée par existence du rôle** : sur un environnement neuf/staging où l'infra n'a pas
  encore créé `datalake_mb_ro`, le schéma est créé et les droits sont différés — la
  migration n'échoue pas (même pattern que `0003` pour un serveur FDW absent).
- Le preset Scaleway est posé en `ignore_changes` côté OpenTofu : les `REVOKE` ne seront
  pas réconciliés/re-grantés.

## Limite connue (à traiter côté infra)

`datalake_mb_ro` conserve l'`USAGE` + `SELECT` sur le schéma `public` : ce droit a été
granté par `_rdb_superadmin` sur un schéma qu'il possède, `datalake` ne peut donc pas le
révoquer. Si l'on veut fermer `public` à Metabase, c'est un ticket infra (OpenTofu). Sans
objet pour cette PR, qui n'introduit aucune donnée dans `public`.

## Déploiement

Non déclenché par cette PR (scope `datalake` → pas de release applicative). La migration
part au prochain déploiement via le Job k8s `just migrate`, exécuté en tant que `datalake`.

## Vérification post-déploiement

```sql
-- après migrate : datalake_mb_ro ne doit plus voir que app_metabase (+ public, cf. limite)
SELECT nspname
FROM pg_namespace n
WHERE has_schema_privilege('datalake_mb_ro', n.oid, 'USAGE')
  AND nspname NOT IN ('pg_catalog', 'information_schema');
```

## Sécurité

Revue moindre privilège — verdict **PASS** (risque LOW).

- Rôle RO : `SELECT` seul (aucun `INSERT/UPDATE/DELETE/CREATE`) ; propriété du schéma
  gardée par `datalake` via `AUTHORIZATION`.
- `ALTER DEFAULT PRIVILEGES` correctement scopé sur le créateur réel des objets (dbt tourne
  en `datalake`) ; `TABLES` couvre tables + vues + vues matérialisées.
- Fermeture des zones effective via retrait d'`USAGE`.
- Migration 100 % statique : aucune interpolation, aucun vecteur d'injection.
- Idempotente et sûre au rejeu ; garde par existence de rôle valide.

Deux findings **LOW non bloquants**, déjà tracés dans l'en-tête de la migration :
default privileges des zones non révoqués (protégé par `ignore_changes` OpenTofu) et
schéma `public` résiduel (fermeture = ressort infra).

## CGU

Verdict **PASS**. Migration purement technique de droits DB : aucune mutation de statut de
trajet (CGU-1), aucun impact sur les durées de conservation (CGU-2), aucune exposition de
données personnelles (CGU-3) — le changement *restreint* au contraire la surface d'accès.