### PR TITLE
feat(datalake): modèle pilote app_metabase.occupation_year (GEN-575)

### DIFF
--- a/datalake/dbt_project.yml
+++ b/datalake/dbt_project.yml
@@ -53,6 +53,10 @@ models:
     exposed:
       +schema: "zone_exposed"
       +dbt-osmosis: "yml/_{model}.yml"
+    app_metabase:
+      +schema: "app_metabase"
+      +materialized: "view"
+      +dbt-osmosis: "yml/_{model}.yml"
 
   ## see docs: https://docs.elementary-data.com/
   elementary:

--- a/datalake/models/app_metabase/mb_occupation_year.sql
+++ b/datalake/models/app_metabase/mb_occupation_year.sql
@@ -1,0 +1,8 @@
+{{ config(
+  materialized='view',
+  tags=['app_metabase', 'occupation']
+) }}
+
+-- Vue app_metabase (GEN-575) sur zone_exposed.occupation_year.
+-- Owner-rights : datalake_mb_ro lit sans acces direct a zone_exposed.
+SELECT * FROM {{ ref('occupation_year') }}

--- a/datalake/models/app_metabase/yml/_mb_occupation_year.yml
+++ b/datalake/models/app_metabase/yml/_mb_occupation_year.yml
@@ -1,0 +1,25 @@
+version: 2
+models:
+  - name: mb_occupation_year
+    description: >
+      Vue app_metabase du taux d'occupation par territoire et par année.
+      Projette zone_exposed.occupation_year pour Metabase (source datalake).
+    columns:
+      - name: year
+        data_type: integer
+      - name: type
+        data_type: text
+      - name: code
+        data_type: character varying
+      - name: libelle
+        data_type: character varying
+      - name: journeys
+        data_type: bigint
+      - name: trips
+        data_type: bigint
+      - name: has_incentive
+        data_type: bigint
+      - name: occupation_rate
+        data_type: numeric
+      - name: geom
+        data_type: json


### PR DESCRIPTION
GEN-575 (carte C) — premier modèle de la migration Metabase → datalake.

`app_metabase.mb_occupation_year` : vue sur `zone_exposed.occupation_year`. En vue
owner-rights, `datalake_mb_ro` lit sans accès direct à `zone_exposed` ; le SELECT est
ouvert par le default privilege de la migration `0004`.

- Préfixe `mb_`, **pas d'`alias`** : la CI aplatit les schémas dans `public`, un alias
  `occupation_year` y collisionnerait avec le modèle exposé homonyme.
- `dbt_project.yml` : mapping schéma `app_metabase` (vue + dbt-osmosis).

Data-only → pas de release. Carte Metabase de comparaison à créer après le `dbt run`
(source Datalake déjà branchée).