### PR TITLE
fix(nix): retire PYTHONPATH du dev-shell qui masquait les venv uv

### DIFF
--- a/api-datalake/justfile
+++ b/api-datalake/justfile
@@ -12,7 +12,6 @@ dev:
 serve port="8081":
     uv run uvicorn api_datalake.main:app --app-dir src --host 0.0.0.0 --port {{port}}
 
-# Tests. `env -u PYTHONPATH` : le dev-shell Nix injecte un pytest cassé dans
-# PYTHONPATH qui masque celui du venv (sortie muette). On le retire.
+# Tests
 test:
-    env -u PYTHONPATH uv run python -m pytest -q
+    uv run python -m pytest -q

--- a/flake.nix
+++ b/flake.nix
@@ -81,6 +81,11 @@
           ];
 
           shellHook = ''
+            # Les setup-hooks Python de Nix (python313, gdal, pre-commit) agrègent
+            # leurs site-packages dans PYTHONPATH, qui masque alors les venv uv
+            # per-folder et casse dbt/sqlfluff/pytest (ex : pyyaml sans SafeLoader).
+            # Les envs Python sont gérés par dossier via uv : on repart de zéro.
+            unset PYTHONPATH
             export PATH="$PWD/node_modules/.bin/:$PATH"
             export PRE_COMMIT_ALLOW_NO_CONFIG=1
             export GH_REPO=covoiturage-gouv-fr/mono


### PR DESCRIPTION
## Contexte

`dbt`, `sqlfluff` et `pytest` refusaient de démarrer en local dans les
projets Python du monorepo (`datalake/`, `api-datalake/`), dès un simple
`dbt --version`, avec `AttributeError: module 'yaml' has no attribute 'SafeLoader'`.

## Cause racine

Les setup-hooks Python de Nix (`python313`, `gdal`, `pre-commit` en
`buildInputs` du dev-shell) agrègent leurs `site-packages` dans `PYTHONPATH`.
Ce `PYTHONPATH` passe **avant** les venv uv per-folder dans `sys.path` : un
`import yaml` chargeait alors le PyYAML fourni par Nix (incomplet, sans
`SafeLoader`) au lieu de celui, complet, installé dans le venv. dbt/sqlfluff
crashaient à l'import.

## Changement

- `flake.nix` : le `shellHook` fait désormais `unset PYTHONPATH`. Les
  environnements Python restent gérés par dossier via `uv` (intention déjà
  documentée dans le flake), donc rien ne dépend du `PYTHONPATH` Nix (gdal
  n'est utilisé que comme CLI `ogr2ogr`, aucun `import osgeo`).
- `api-datalake/justfile` : le contournement `env -u PYTHONPATH` sur la
  recette `test` devient inutile et est retiré.

## Vérification

Shell flake frais → `PYTHONPATH` vide ; `dbt` (1.11.9), `sqlfluff` (4.2.1) et
`dbt parse` (chargement complet du projet, adapter postgres OK) démarrent sans
aucun contournement.

## Release

Aucun fichier app-stack (`api`/`app-partners`/`app-observatory`/`shared`)
touché : cette PR ne coupe volontairement pas de version et ne déclenche aucun
déploiement — c'est le comportement attendu pour un correctif d'outillage.

## Sécurité

**PASS.** `unset PYTHONPATH` supprime un cas de shadowing de modules (un
pytest/pyyaml Nix masquait celui du venv uv) : la résolution des dépendances
redevient déterministe et isolée par dossier. Commande de test statique, aucune
entrée utilisateur interpolée, aucun secret introduit.

## CGU

**PASS.** Aucun secret ni credential, aucune donnée personnelle ou financière
non publique, aucune info relevant du secret des affaires. Le diff ne touche
que l'outillage de dev (dev-shell Nix, recette de test).
