### PR TITLE
feat(acquisition): compteurs par usager dans le refus too_many_trips_by_day

### DIFF
--- a/api/specs/api-v3.4.yaml
+++ b/api/specs/api-v3.4.yaml
@@ -301,8 +301,11 @@ paths:
                         properties:
                           terms_violation_labels:
                             $ref: "#/components/schemas/terms_violation_label"
+                          terms_violation_error_details:
+                            $ref: "#/components/schemas/terms_violation_error_details"
                         required:
                           - terms_violation_labels
+                          - terms_violation_error_details
                       code:
                         type: integer
                         enum:
@@ -1322,6 +1325,31 @@ components:
       type: array
       items:
         $ref: "#/components/schemas/terms_violation_label"
+    terms_violation_error_details:
+      description: |
+        Détail par règle CGU ayant abouti au rejet du trajet : une entrée par étiquette.
+        `metas` n'est présent que pour `too_many_trips_by_day` (compteurs de trajets de la journée).
+      type: array
+      items:
+        type: object
+        properties:
+          label:
+            $ref: "#/components/schemas/terms_violation_label"
+          metas:
+            description: Présent uniquement pour `too_many_trips_by_day`.
+            type: object
+            properties:
+              driver:
+                description: Nombre de trajets du conducteur sur la journée retenus par la règle.
+                type: integer
+              passenger:
+                description: Nombre de trajets du passager sur la journée retenus par la règle.
+                type: integer
+              limit:
+                description: Limite de trajets par usager et par jour.
+                type: integer
+        required:
+          - label
     terms_violation_label:
       description: |
         Etiquette possible pour un cas de non respect des CGU au sein du même opérateur:

--- a/api/src/pdc/providers/carpool/interfaces/acquisition.ts
+++ b/api/src/pdc/providers/carpool/interfaces/acquisition.ts
@@ -1,4 +1,12 @@
-import { ApiVersion, CancelCode, CancelMessage, Id, TermsViolationErrorLabels, Uuid } from "./common.ts";
+import {
+  ApiVersion,
+  CancelCode,
+  CancelMessage,
+  Id,
+  TermsViolationErrorDetails,
+  TermsViolationErrorLabels,
+  Uuid,
+} from "./common.ts";
 import { InsertableCarpool, UpdatableCarpool } from "./database/carpool.ts";
 
 interface ApiVersionObject {
@@ -9,6 +17,7 @@ export type RegisterRequest = InsertableCarpool & ApiVersionObject;
 export type RegisterResponse = {
   created_at: Date;
   terms_violation_error_labels: TermsViolationErrorLabels;
+  terms_violation_error_details: TermsViolationErrorDetails;
 };
 
 export interface PatchRequest extends UpdatableCarpool, ApiVersionObject {

--- a/api/src/pdc/providers/carpool/interfaces/common.ts
+++ b/api/src/pdc/providers/carpool/interfaces/common.ts
@@ -79,6 +79,20 @@ export enum CarpoolAcquisitionStatusEnum {
 
 export type TermsViolationErrorLabels = Array<string>;
 
+export const MAX_TRIPS_PER_DAY = 4;
+
+export type TermsViolationLabel =
+  | "distance_too_short"
+  | "too_many_trips_by_day"
+  | "too_close_trips"
+  | "expired";
+
+export type TermsViolationErrorDetail =
+  | { label: "too_many_trips_by_day"; metas: { driver: number; passenger: number; limit: number } }
+  | { label: "distance_too_short" | "too_close_trips" | "expired" };
+
+export type TermsViolationErrorDetails = Array<TermsViolationErrorDetail>;
+
 export enum CarpoolFraudStatusEnum {
   Pending = "pending",
   Passed = "passed",

--- a/api/src/pdc/providers/carpool/providers/CarpoolAcquisitionService.integration.spec.ts
+++ b/api/src/pdc/providers/carpool/providers/CarpoolAcquisitionService.integration.spec.ts
@@ -258,13 +258,25 @@ describe("CarpoolAcquisitionService", () => {
     };
 
     const errors = await service.verifyTermsViolation({ ...data, distance: 100 });
-    assertEquals(errors, ["distance_too_short"]);
+    assertEquals(errors, [{ label: "distance_too_short" }]);
     assertEquals(
       carpoolL.countJourneyBy.getCalls().map((c: any) => c.args),
       [
         [
           {
-            identity_key: ["key_driver", "key_passenger"],
+            identity_key: ["key_driver"],
+            identity_key_or: true,
+            start_date: {
+              max: new Date("2024-01-01T22:59:59.999Z"),
+              min: new Date("2023-12-31T23:00:00.000Z"),
+            },
+            operator_id: 1,
+          },
+          undefined,
+        ],
+        [
+          {
+            identity_key: ["key_passenger"],
             identity_key_or: true,
             start_date: {
               max: new Date("2024-01-01T22:59:59.999Z"),
@@ -314,16 +326,25 @@ describe("CarpoolAcquisitionService", () => {
     };
 
     const errors = await service.verifyTermsViolation(data);
-    assertEquals(errors, ["expired"]);
+    assertEquals(errors, [{ label: "expired" }]);
     assertEquals(
       carpoolL.countJourneyBy.getCalls().map((c: any) => c.args),
       [
         [
           {
-            identity_key: [
-              "key_driver",
-              "key_passenger",
-            ],
+            identity_key: ["key_driver"],
+            identity_key_or: true,
+            operator_id: 1,
+            start_date: {
+              max: new Date("2024-10-23T21:59:59.999Z"),
+              min: new Date("2024-10-22T22:00:00.000Z"),
+            },
+          },
+          undefined,
+        ],
+        [
+          {
+            identity_key: ["key_passenger"],
             identity_key_or: true,
             operator_id: 1,
             start_date: {
@@ -355,6 +376,106 @@ describe("CarpoolAcquisitionService", () => {
         ],
       ],
     );
+  });
+
+  describe("too_many_trips_by_day", () => {
+    const operator_id = insertableCarpool.operator_id;
+    // created_at is set by the DB to "now" on insert, so start_datetime must stay
+    // recent (< 24h) to avoid tripping the unrelated "expired" rule.
+    const day = new Date(Date.now() - 4 * 3_600_000);
+
+    function tripAt(minuteOffset: number, overrides: Partial<typeof insertableCarpool>) {
+      const start_datetime = new Date(day.valueOf() + minuteOffset * 60_000);
+      return {
+        ...insertableCarpool,
+        operator_id,
+        start_datetime,
+        end_datetime: new Date(start_datetime.valueOf() + 1_800_000),
+        ...overrides,
+      };
+    }
+
+    async function register(service: CarpoolAcquisitionService, data: ReturnType<typeof tripAt>) {
+      return service.registerRequest({ ...data, api_version: "3" });
+    }
+
+    it("Should not flag two regular users each having 4 trips a day meeting for a 5th trip together", async () => {
+      const service = getService({});
+      const driver_identity_key = "a".repeat(64);
+      const passenger_identity_key = "b".repeat(64);
+
+      // driver already did 4 trips today, each with a different passenger
+      for (let i = 0; i < 4; i++) {
+        await register(
+          service,
+          tripAt(i * 15, {
+            operator_journey_id: `too_many_driver_${i}`,
+            operator_trip_id: `too_many_driver_${i}`,
+            driver_identity_key,
+            passenger_identity_key: `driver_partner_${i}`.padEnd(64, "0"),
+          }),
+        );
+      }
+
+      // passenger already did 4 trips today, each with a different driver
+      for (let i = 0; i < 4; i++) {
+        await register(
+          service,
+          tripAt(60 + i * 15, {
+            operator_journey_id: `too_many_passenger_${i}`,
+            operator_trip_id: `too_many_passenger_${i}`,
+            driver_identity_key: `passenger_partner_${i}`.padEnd(64, "0"),
+            passenger_identity_key,
+          }),
+        );
+      }
+
+      // driver and passenger meet for a 5th trip each, together
+      const res = await register(
+        service,
+        tripAt(150, {
+          operator_journey_id: "too_many_together",
+          operator_trip_id: "too_many_together",
+          driver_identity_key,
+          passenger_identity_key,
+        }),
+      );
+
+      assert(!res.terms_violation_error_labels.includes("too_many_trips_by_day"));
+    });
+
+    it("Should flag a user having 5 trips a day", async () => {
+      const service = getService({});
+      const driver_identity_key = "c".repeat(64);
+
+      for (let i = 0; i < 5; i++) {
+        await register(
+          service,
+          tripAt(i * 15, {
+            operator_journey_id: `five_trips_${i}`,
+            operator_trip_id: `five_trips_${i}`,
+            driver_identity_key,
+            passenger_identity_key: `five_trips_partner_${i}`.padEnd(64, "0"),
+          }),
+        );
+      }
+
+      const res = await register(
+        service,
+        tripAt(150, {
+          operator_journey_id: "five_trips_new",
+          operator_trip_id: "five_trips_new",
+          driver_identity_key,
+          passenger_identity_key: "new_partner".padEnd(64, "0"),
+        }),
+      );
+
+      assert(res.terms_violation_error_labels.includes("too_many_trips_by_day"));
+
+      const detail = res.terms_violation_error_details.find((d) => d.label === "too_many_trips_by_day");
+      assert(detail && "metas" in detail);
+      assertEquals(detail.metas, { driver: 5, passenger: 0, limit: 4 });
+    });
   });
 
   it("Should keep terms_violation_error status when geo batch processes the carpool", async () => {

--- a/api/src/pdc/providers/carpool/providers/CarpoolAcquisitionService.ts
+++ b/api/src/pdc/providers/carpool/providers/CarpoolAcquisitionService.ts
@@ -13,12 +13,13 @@ import { GeoProvider } from "@/pdc/providers/geo/index.ts";
 import {
   CancelRequest,
   CarpoolAcquisitionStatusEnum,
+  MAX_TRIPS_PER_DAY,
   PatchRequest,
   ProcessGeoParams,
   ProcessGeoResults,
   RegisterRequest,
   RegisterResponse,
-  TermsViolationErrorLabels,
+  TermsViolationErrorDetails,
 } from "../interfaces/index.ts";
 import { CarpoolGeoRepository } from "../repositories/CarpoolGeoRepository.ts";
 import { CarpoolLookupRepository } from "../repositories/CarpoolLookupRepository.ts";
@@ -49,31 +50,41 @@ export class CarpoolAcquisitionService {
     end_datetime: Date;
     operator_trip_id: string;
     start_position: Position;
-  }, client?: PoolClient): Promise<Array<string>> {
-    const result = [];
+  }, client?: PoolClient): Promise<TermsViolationErrorDetails> {
+    const result: TermsViolationErrorDetails = [];
     // The journey has been sent too late
     if (differenceInHours(data.created_at, data.start_datetime) > 24) {
-      result.push("expired");
+      result.push({ label: "expired" });
     }
 
     if (data.distance < 1_000) {
-      result.push("distance_too_short");
+      result.push({ label: "distance_too_short" });
     }
 
-    // This select all distinct operator_trip_id that started in the same day
-    // with the same identity key as any role
+    // Count each user's trips separately (not the union of both), otherwise two
+    // regular users each under the limit get flagged for their combined total.
     const tz = getTzFromLon(data.start_position.lon);
-    const journeyCount = await this.lookupRepository.countJourneyBy({
+    const start_date = {
+      min: startOfDay(data.start_datetime, tz),
+      max: endOfDay(data.start_datetime, tz),
+    };
+    const driverJourneyCount = await this.lookupRepository.countJourneyBy({
       operator_id: data.operator_id,
-      identity_key: [data.driver_identity_key, data.passenger_identity_key],
+      identity_key: [data.driver_identity_key],
       identity_key_or: true,
-      start_date: {
-        min: startOfDay(data.start_datetime, tz),
-        max: endOfDay(data.start_datetime, tz),
-      },
+      start_date,
     }, client);
-    if (journeyCount > 4) {
-      result.push("too_many_trips_by_day");
+    const passengerJourneyCount = await this.lookupRepository.countJourneyBy({
+      operator_id: data.operator_id,
+      identity_key: [data.passenger_identity_key],
+      identity_key_or: true,
+      start_date,
+    }, client);
+    if (Math.max(driverJourneyCount, passengerJourneyCount) > MAX_TRIPS_PER_DAY) {
+      result.push({
+        label: "too_many_trips_by_day",
+        metas: { driver: driverJourneyCount, passenger: passengerJourneyCount, limit: MAX_TRIPS_PER_DAY },
+      });
     }
 
     // This select all distinct operator_trip_id that started before
@@ -88,7 +99,7 @@ export class CarpoolAcquisitionService {
       operator_trip_id: data.operator_trip_id,
     }, client);
     if (journeyCloseCount >= 1) {
-      result.push("too_close_trips");
+      result.push({ label: "too_close_trips" });
     }
 
     return result;
@@ -113,7 +124,7 @@ export class CarpoolAcquisitionService {
       if (carpool.conflict) {
         throw new ConflictException(`Carpool already registered at ${carpool.created_at}`);
       }
-      let terms_violation_error_labels: TermsViolationErrorLabels = [];
+      let terms_violation_error_details: TermsViolationErrorDetails = [];
       if (env_or_false("APP_DISABLE_TERMS_VALIDATION")) {
         await this.statusRepository.saveAcquisitionStatus(
           new CarpoolAcquisitionStatus(
@@ -124,7 +135,7 @@ export class CarpoolAcquisitionService {
           conn,
         );
       } else {
-        terms_violation_error_labels = await this.verifyTermsViolation({
+        terms_violation_error_details = await this.verifyTermsViolation({
           operator_id: data.operator_id,
           created_at: carpool.created_at,
           distance: data.distance,
@@ -140,17 +151,17 @@ export class CarpoolAcquisitionService {
           new CarpoolAcquisitionStatus(
             carpool._id,
             request._id,
-            terms_violation_error_labels.length
+            terms_violation_error_details.length
               ? CarpoolAcquisitionStatusEnum.TermsViolationError
               : CarpoolAcquisitionStatusEnum.Received,
           ),
           conn,
         );
 
-        if (terms_violation_error_labels.length) {
+        if (terms_violation_error_details.length) {
           await this.statusRepository.setTermsViolationErrorLabels(
             carpool._id,
-            terms_violation_error_labels,
+            terms_violation_error_details.map((d) => d.label),
             conn,
           );
         }
@@ -158,7 +169,8 @@ export class CarpoolAcquisitionService {
 
       await conn.query("COMMIT");
       return {
-        terms_violation_error_labels,
+        terms_violation_error_labels: terms_violation_error_details.map((d) => d.label),
+        terms_violation_error_details,
         created_at: carpool.created_at,
       };
     } catch (e) {

--- a/api/src/pdc/services/acquisition/actions/CreateJourneyAction.ts
+++ b/api/src/pdc/services/acquisition/actions/CreateJourneyAction.ts
@@ -93,6 +93,7 @@ export class CreateJourneyAction extends AbstractAction {
     if (result.terms_violation_error_labels.length) {
       throw new UnprocessableRequestException({
         terms_violation_labels: result.terms_violation_error_labels,
+        terms_violation_error_details: result.terms_violation_error_details,
       });
     }
   }

--- a/docs/superpowers/specs/2026-07-29-payload-refus-enrichi-design.md
+++ b/docs/superpowers/specs/2026-07-29-payload-refus-enrichi-design.md
@@ -1,0 +1,122 @@
+# Design — Enrichissement du payload de refus de trajet (compteurs de règle)
+
+**Date** : 2026-07-29
+**Ticket** : GEN-647 (suite)
+**Statut** : design validé, à implémenter
+
+## Contexte & objectif
+
+Quand un trajet est refusé pour non-respect des CGU, l'opérateur reçoit une erreur JSON-RPC
+(`code -32422`, HTTP 422) dont le corps `data` vaut aujourd'hui :
+
+```jsonc
+data: { terms_violation_labels: ["too_many_trips_by_day"] }
+```
+
+L'opérateur ne connaît que **le motif**, jamais **les chiffres** qui l'ont déclenché. Objectif :
+préciser la cause en exposant, pour `too_many_trips_by_day`, le nombre de trajets du conducteur
+et du passager sur la journée, plus la limite.
+
+Chaîne actuelle : `CarpoolAcquisitionService.verifyTermsViolation` (retourne `string[]`)
+→ `registerRequest` → `CreateJourneyAction.validateResults` → `UnprocessableRequestException(data)`.
+
+Synergie : le fix GEN-647 (même branche `gen647-too-many-trips-fix`) calcule **déjà** `driverCount`
+et `passengerCount` pour la règle `too_many_trips_by_day`. Cet enrichissement les expose — coût nul.
+
+## Décisions
+
+| Point | Choix |
+|---|---|
+| Périmètre | Générique extensible : garder `terms_violation_labels` (compat), AJOUTER un tableau d'objets |
+| Nom du champ | **`terms_violation_error_details`** (convention maison `*_error_details`, cf. `anomaly_error_details` / `fraud_error_details`) — évite la collision avec le `terms_violation_details` existant de la réponse GET statut |
+| Forme d'un item | `{ label, metas? }`, calqué sur `AnomalyErrorDetails` (`{ label, metas }`) |
+| Entrées | **Une entrée par règle déclenchée** ; `metas` présent seulement pour `too_many_trips_by_day` pour l'instant |
+| Compteurs | `metas: { driver, passenger, limit }` — `driver`/`passenger` = **valeur brute que la règle compare à `limit`** (exclut le trajet courant + canceled/expired/refusés, comme `countJourneyBy`), donc `driver > limit` ou `passenger > limit` explique le refus exactement |
+| Persistance | **Aucune** en base transactionnelle. Suivi de l'indicateur = modèle datalake a posteriori (chantier distinct, hors de ce spec) |
+| Séquencement | **Même PR que le fix GEN-647** |
+| OpenAPI | Cible la spec **v3.4** (`api/specs/api-v3.4.yaml`), non encore publiée auprès des opérateurs |
+
+## Forme du payload
+
+Réponse 422 enrichie (exemple avec deux motifs) :
+
+```jsonc
+data: {
+  terms_violation_labels: ["too_many_trips_by_day", "distance_too_short"],   // inchangé (compat)
+  terms_violation_error_details: [
+    { label: "too_many_trips_by_day",
+      metas: { driver: 5, passenger: 2, limit: 4 } },
+    { label: "distance_too_short" }                                          // pas de metas (pour l'instant)
+  ]
+}
+```
+
+## Plumbing
+
+Source de vérité unique : `verifyTermsViolation` ne renvoie plus `string[]` mais
+`TermsViolationErrorDetail[]` ; les labels s'en déduisent par `.map(d => d.label)`.
+**Zéro changement de schéma DB** : on continue à stocker les labels `string[]` comme aujourd'hui.
+
+### Types — `api/src/pdc/providers/carpool/interfaces/common.ts`
+
+```ts
+export const MAX_TRIPS_PER_DAY = 4;
+
+export type TermsViolationLabel =
+  | "distance_too_short"
+  | "too_many_trips_by_day"
+  | "too_close_trips"
+  | "expired";
+
+export type TermsViolationErrorDetail =
+  | { label: "too_many_trips_by_day"; metas: { driver: number; passenger: number; limit: number } }
+  | { label: "distance_too_short" | "too_close_trips" | "expired" };
+
+export type TermsViolationErrorDetails = Array<TermsViolationErrorDetail>;
+```
+
+`TermsViolationErrorLabels = Array<string>` (existant) reste, dérivé des labels.
+
+### Changements
+
+| Fichier | Changement |
+|---|---|
+| `interfaces/common.ts` | + `MAX_TRIPS_PER_DAY`, `TermsViolationLabel`, `TermsViolationErrorDetail(s)` |
+| `providers/CarpoolAcquisitionService.ts` (`verifyTermsViolation`) | retourne `TermsViolationErrorDetail[]` ; pousse des objets structurés au lieu de strings ; `too_many_trips_by_day` réutilise `driverCount`/`passengerCount` du fix et pose `metas: { driver, passenger, limit: MAX_TRIPS_PER_DAY }` |
+| `providers/CarpoolAcquisitionService.ts` (`registerRequest`) | `const details = await verifyTermsViolation(...)` ; `const labels = details.map(d => d.label)` → statut + `setTermsViolationErrorLabels(labels)` **inchangés** ; renvoie aussi `details` |
+| `interfaces/acquisition.ts` (`RegisterResponse`) | + `terms_violation_error_details: TermsViolationErrorDetails` |
+| `actions/CreateJourneyAction.ts` (`validateResults`) | `throw new UnprocessableRequestException({ terms_violation_labels: labels, terms_violation_error_details: details })` |
+| `api/specs/api-v3.4.yaml` | nouveau schéma `terms_violation_error_details` (items `{ label: terms_violation_label, metas }`, calqué sur `anomaly_error_details`) ; l'ajouter dans la réponse `"422"` du `POST /journeys` à côté de `terms_violation_labels` |
+
+Le `too_close_trips` (règle voisine, `identity_key_or: false`) n'est pas modifié.
+
+## Compatibilité
+
+- Ajout **additif** dans `data` (free-form, `data?: any`) → non-breaking pour l'API live ; les opérateurs
+  qui ignorent le nouveau champ ne cassent pas. `terms_violation_labels` est conservé tel quel.
+- OpenAPI : la modification vise la v3.4 non publiée → aucune rupture de contrat déjà annoncé.
+
+## Hors-scope (chantiers distincts)
+
+- **Persistance des compteurs** en base : écartée (YAGNI ; recalculables).
+- **Modèle datalake** de suivi de l'indicateur « % de refus `too_many` où `max(driver, passenger) ≤ 4` » :
+  agrégation dbt a posteriori + carte Metabase. À concevoir séparément.
+- **Réponse GET statut** (`CarpoolStatusService` → `terms_violation_details: string[]`) : laissée
+  telle quelle (label-only). L'aligner sur `{ label, metas }` supposerait de persister les compteurs
+  → hors-scope. Asymétrie assumée : le 422 (temps réel) porte les `metas`, le GET statut non.
+- **Rétro-action** des trajets déjà refusés : script séparé (sous-page Notion GEN-647).
+
+## Tests
+
+- Unit/intégration `CarpoolAcquisitionService` : `too_many_trips_by_day` déclenché → un item
+  `terms_violation_error_details` avec `metas.driver` / `metas.passenger` corrects et `metas.limit = 4`.
+- Une règle sans metas (ex. `distance_too_short`) → item `{ label }` sans `metas`.
+- Cumul de deux motifs → `terms_violation_labels` et `terms_violation_error_details` cohérents
+  (même ensemble de labels, même ordre).
+- Non-régression : `terms_violation_labels` conserve exactement la forme actuelle.
+
+## Points à valider (revue)
+
+1. Nom **`terms_violation_error_details`** + wrapper **`metas`** (alignement convention `anomaly_error_details`) —
+   diffère du `terms_violation_details` / forme plate évoqués plus tôt.
+2. `driver`/`passenger` = valeur brute de la règle (exclut le trajet courant), pas « total incluant ce trajet ».


### PR DESCRIPTION
## Résumé

La règle `too_many_trips_by_day` comptait l'**union** des trajets du conducteur et du passager au lieu de considérer chaque usager séparément : deux usagers réguliers restés chacun sous la limite quotidienne pouvaient être refusés à tort dès qu'ils covoituraient ensemble. Le comptage se fait désormais par usager, en comparant le **maximum des deux** à la limite.

En complément, la réponse 422 de refus expose `terms_violation_error_details` : pour `too_many_trips_by_day`, les compteurs `driver` / `passenger` et la `limit`. Champ **additif** (l'existant `terms_violation_labels` est conservé), documenté dans la spec OpenAPI v3.4 (non encore publiée).

## Release

`feat` — déploiement API attendu (correction + nouveau champ 422 additif, rétro-compatible). Aucune migration.