### PR TITLE
feat(datalake): suivi des refus too_many_trips_by_day (modèles + vue Metabase)

### DIFF
--- a/datalake/models/aggregated/terms_violation/too_many_trips_flagged.sql
+++ b/datalake/models/aggregated/terms_violation/too_many_trips_flagged.sql
@@ -1,0 +1,100 @@
+{{ config(
+    materialized='incremental',
+    incremental_strategy='delete+insert',
+    unique_key='carpool_id',
+    tags=['aggregated', 'terms_violation', 'daily']
+) }}
+
+-- GEN-647 — refus too_many_trips_by_day : à tort (aucun > 4) vs légitime.
+-- Incrémental 7 j ; --full-refresh pour les statuts historiques.
+
+WITH refused AS (
+  SELECT
+    _id                                                           AS carpool_id,
+    operator_id,
+    operator_name,
+    start_datetime_tz::date                                       AS trip_day,
+    created_at                                                    AS refused_at,
+    driver_key,
+    passenger_key,
+    acquisition_status,
+    terms_violation_error_labels = ARRAY['too_many_trips_by_day'] AS sole_reason
+  FROM {{ ref('carpools') }}
+  WHERE
+    'too_many_trips_by_day' = ANY(terms_violation_error_labels)
+  {% if is_incremental() %}
+      AND start_datetime_tz >= (CURRENT_DATE - interval '7 days')
+    {% endif %}
+),
+
+scope AS (
+  SELECT DISTINCT
+    operator_id,
+    trip_day
+  FROM refused
+),
+
+-- Trajets d'un usager (conducteur ou passager) par opérateur / jour.
+participations AS (
+  SELECT
+    c.operator_id,
+    c.start_datetime_tz::date AS trip_day,
+    c.driver_key              AS user_key,
+    c.operator_trip_id
+  FROM {{ ref('carpools') }} AS c
+  INNER JOIN scope AS s
+    ON
+      c.operator_id = s.operator_id
+      AND c.start_datetime_tz::date = s.trip_day
+  WHERE c.acquisition_status IS DISTINCT FROM 'canceled'
+
+  UNION
+
+  SELECT
+    c.operator_id,
+    c.start_datetime_tz::date AS trip_day,
+    c.passenger_key           AS user_key,
+    c.operator_trip_id
+  FROM {{ ref('carpools') }} AS c
+  INNER JOIN scope AS s
+    ON
+      c.operator_id = s.operator_id
+      AND c.start_datetime_tz::date = s.trip_day
+  WHERE c.acquisition_status IS DISTINCT FROM 'canceled'
+),
+
+user_trip_counts AS (
+  SELECT
+    operator_id,
+    trip_day,
+    user_key,
+    COUNT(DISTINCT operator_trip_id) AS trips
+  FROM participations
+  GROUP BY operator_id, trip_day, user_key
+)
+
+SELECT
+  r.carpool_id,
+  r.operator_id,
+  r.operator_name,
+  r.trip_day,
+  r.refused_at,
+  r.acquisition_status,
+  r.sole_reason,
+  COALESCE(cd.trips, 0)                                       AS driver_trips,
+  COALESCE(cp.trips, 0)
+    AS passenger_trips,
+  GREATEST(COALESCE(cd.trips, 0), COALESCE(cp.trips, 0))      AS max_trips,
+  -- limite « 4 max par usager »
+  GREATEST(COALESCE(cd.trips, 0), COALESCE(cp.trips, 0)) <= 4 AS wrongly_flagged
+FROM refused AS r
+LEFT JOIN user_trip_counts AS cd
+  ON
+    r.operator_id = cd.operator_id
+    AND r.trip_day = cd.trip_day
+    AND r.driver_key = cd.user_key
+LEFT JOIN user_trip_counts AS cp
+  ON
+    r.operator_id = cp.operator_id
+    AND r.trip_day = cp.trip_day
+    AND r.passenger_key = cp.user_key

--- a/datalake/models/aggregated/terms_violation/yml/_too_many_trips_flagged.yml
+++ b/datalake/models/aggregated/terms_violation/yml/_too_many_trips_flagged.yml
@@ -1,0 +1,39 @@
+version: 2
+models:
+  - name: too_many_trips_flagged
+    description: >
+      GEN-647 — un trajet par refus `too_many_trips_by_day`, avec le nombre de
+      trajets réels du jour de chaque usager (conducteur / passager) et le drapeau
+      `wrongly_flagged` (aucun des deux n'a dépassé la limite). Sert le suivi du fix.
+    columns:
+      - name: carpool_id
+        description: identifiant du trajet refusé (carpool_v2)
+        data_type: integer
+      - name: operator_id
+        data_type: integer
+      - name: operator_name
+        data_type: character varying
+      - name: trip_day
+        description: jour de départ (fuseau local du point de départ)
+        data_type: date
+      - name: refused_at
+        description: date de décision du refus (created_at du trajet)
+        data_type: timestamp with time zone
+      - name: acquisition_status
+        description: statut d'acquisition courant du trajet
+        data_type: character varying
+      - name: sole_reason
+        description: vrai si too_many_trips_by_day est le seul motif de refus
+        data_type: boolean
+      - name: driver_trips
+        description: trajets distincts du conducteur ce jour-là (tous rôles)
+        data_type: bigint
+      - name: passenger_trips
+        description: trajets distincts du passager ce jour-là (tous rôles)
+        data_type: bigint
+      - name: max_trips
+        description: max(driver_trips, passenger_trips)
+        data_type: bigint
+      - name: wrongly_flagged
+        description: vrai si max_trips <= 4 (refus à tort)
+        data_type: boolean

--- a/datalake/models/app_metabase/mb_too_many_trips_flagged.sql
+++ b/datalake/models/app_metabase/mb_too_many_trips_flagged.sql
@@ -1,0 +1,8 @@
+{{ config(
+  materialized='view',
+  tags=['app_metabase', 'terms_violation']
+) }}
+
+-- Vue app_metabase (GEN-647) sur zone_aggregated.too_many_trips_flagged.
+-- Owner-rights : datalake_mb_ro lit sans acces direct a zone_aggregated.
+SELECT * FROM {{ ref('too_many_trips_flagged') }}

--- a/datalake/models/app_metabase/yml/_mb_too_many_trips_flagged.yml
+++ b/datalake/models/app_metabase/yml/_mb_too_many_trips_flagged.yml
@@ -1,0 +1,29 @@
+version: 2
+models:
+  - name: mb_too_many_trips_flagged
+    description: >
+      Vue app_metabase (GEN-647) sur zone_aggregated.too_many_trips_flagged.
+      Suivi des refus too_many_trips_by_day (à tort vs légitimes) pour Metabase.
+    columns:
+      - name: carpool_id
+        data_type: integer
+      - name: operator_id
+        data_type: integer
+      - name: operator_name
+        data_type: character varying
+      - name: trip_day
+        data_type: date
+      - name: refused_at
+        data_type: timestamp with time zone
+      - name: acquisition_status
+        data_type: character varying
+      - name: sole_reason
+        data_type: boolean
+      - name: driver_trips
+        data_type: bigint
+      - name: passenger_trips
+        data_type: bigint
+      - name: max_trips
+        data_type: bigint
+      - name: wrongly_flagged
+        data_type: boolean

--- a/docs/superpowers/specs/2026-07-30-datalake-suivi-too-many-trips-design.md
+++ b/docs/superpowers/specs/2026-07-30-datalake-suivi-too-many-trips-design.md
@@ -1,0 +1,44 @@
+# Design — Suivi datalake + Metabase des refus `too_many_trips_by_day` (GEN-647)
+
+**Date** : 2026-07-30
+**Ticket** : GEN-647 (suite)
+**Objectif** : suivre l'évolution des trajets refusés `too_many_trips_by_day` et le rapport à leurs statuts, pour valider que le fix (comptage par usager) fonctionne.
+
+## Décisions
+
+| Point | Choix |
+|---|---|
+| Grain | Détail : une ligne par trajet refusé |
+| Axe temps | `trip_day` (jour de départ) ; `refused_at` conservé en colonne |
+| Périmètre | Tous opérateurs, opérateur en dimension |
+| Lecture | Uniquement `trusted` (`ref('carpools')`), jamais `dlk_import`/`raw` |
+| Persistance compteurs | Recalculés dans le modèle (pas de stockage côté OLTP) |
+
+## Modèles
+
+**`aggregated/terms_violation/too_many_trips_flagged`** (table incrémentale, `delete+insert` sur `carpool_id`, lookback 7 j, tag `daily`) — sur `ref('carpools')` :
+- `carpool_id`, `operator_id`, `operator_name`, `trip_day`, `refused_at`, `acquisition_status`, `sole_reason`
+- `driver_trips`, `passenger_trips` = `count(distinct operator_trip_id)` par usager / opérateur / jour, rôle conducteur ∪ passager, hors `canceled`
+- `max_trips`, `wrongly_flagged` = `max_trips <= 4`
+
+Clé usager = `md5(identity_key)` (colonnes `driver_key`/`passenger_key` de `carpools`), indépendante du rôle → comptage cross-rôle correct.
+
+Incrémental 7 j : les refus récents restent à jour (les refus arrivent < 24 h après le trajet). Les statuts historiques ne se rafraîchissent qu'au `dbt run --full-refresh` — à lancer après la rétro-action.
+
+**`app_metabase/mb_too_many_trips_flagged`** (vue, owner-rights) — `SELECT * FROM ref('too_many_trips_flagged')`, exposée à `datalake_mb_ro`.
+
+## Validation
+
+Logique validée sur le datalake (op 9 = BlaBlaCar Daily) : total ≈ 19 179 / à tort ≈ 17 670, cohérent avec le chiffrage prod_ro (19 151 / 17 653). Écart marginal = fuseau (geo-code local vs Europe/Paris).
+
+## Dashboard Metabase (source Datalake, `app_metabase.mb_too_many_trips_flagged`)
+
+1. **Validation du fix** — refus par semaine (`trip_day`), série `wrongly_flagged` vs légitime. La série à tort doit tomber à ~0 après déploiement du fix.
+2. **Suivi des statuts** — trajets `wrongly_flagged` par `acquisition_status` (suit la rétro-action).
+3. **KPI** — refus `wrongly_flagged` sur les 30 derniers jours (→ 0 post-fix).
+
+Filtre opérateur transverse. Cartes fonctionnelles une fois les modèles déployés (dbt run en prod).
+
+## Hors-scope
+
+Rétro-action des trajets déjà refusés (script séparé, sous-page Notion) ; la mise à jour de leurs statuts dans ce modèle se fait via `--full-refresh`.


### PR DESCRIPTION
## Résumé

Modèles de suivi (GEN-647) pour valider le correctif du comptage `too_many_trips_by_day` (PR #3327).

- `aggregated/terms_violation/too_many_trips_flagged` — un trajet par refus, avec le nombre de trajets réels du jour de chaque usager (conducteur / passager) et le drapeau `wrongly_flagged` (aucun des deux n'a dépassé la limite). Lecture **`trusted` uniquement** (`ref('carpools')`). Incrémental 7 j ; `--full-refresh` pour rafraîchir les statuts historiques.
- `app_metabase/mb_too_many_trips_flagged` — vue owner-rights exposée à `datalake_mb_ro` (Metabase).

Alimente un dashboard Metabase (cartes à brancher une fois les modèles déployés) : refus à tort vs légitimes dans le temps + répartition par statut d'acquisition.

## Release

`feat(datalake)` — scope data, **aucun déploiement app**.