### PR TITLE
fix(datalake): corrige sole_reason de too_many_trips_flagged

### DIFF
--- a/datalake/models/aggregated/terms_violation/too_many_trips_flagged.sql
+++ b/datalake/models/aggregated/terms_violation/too_many_trips_flagged.sql
@@ -10,15 +10,15 @@
 
 WITH refused AS (
   SELECT
-    _id                                                           AS carpool_id,
+    _id                                           AS carpool_id,
     operator_id,
     operator_name,
-    start_datetime_tz::date                                       AS trip_day,
-    created_at                                                    AS refused_at,
+    start_datetime_tz::date                       AS trip_day,
+    created_at                                    AS refused_at,
     driver_key,
     passenger_key,
     acquisition_status,
-    terms_violation_error_labels = ARRAY['too_many_trips_by_day'] AS sole_reason
+    CARDINALITY(terms_violation_error_labels) = 1 AS sole_reason
   FROM {{ ref('carpools') }}
   WHERE
     'too_many_trips_by_day' = ANY(terms_violation_error_labels)


### PR DESCRIPTION
## Résumé

Correctif du modèle `too_many_trips_flagged` mergé en #3328. La colonne `sole_reason` comparait `terms_violation_error_labels` (`character varying[]`) à `ARRAY['too_many_trips_by_day']` (`text[]`) — aucun opérateur `=` entre ces types, donc **échec à l'exécution** (`operator does not exist: character varying[] = text[]`). Non détecté en CI car le job `(datalake) dbt parse` ne matérialise pas les modèles ; l'erreur ne se déclenche qu'au `dbt run`.

Remplacé par `CARDINALITY(terms_violation_error_labels) = 1` : le `WHERE` garantit déjà que `too_many_trips_by_day` est présent, donc « seul motif » ⟺ un seul label. Pas de cast, pas d'ambiguïté de type.

Validé par un `dbt run` complet contre le datalake (79 380 lignes, `Completed successfully`).

## Release

`fix(datalake)` — scope data, aucun déploiement app.